### PR TITLE
Add translations for Newsletter #17

### DIFF
--- a/content/de/newsletters/2026-04-08-newsletter.md
+++ b/content/de/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Willkommen zurück bei Nostr Compass, deinem wöchentlichen Wegweiser durch Nostr.
+
+**Diese Woche:** [Amethyst](https://github.com/vitorpamplona/amethyst) liefert [v1.08.0](#amethyst-liefert-arti-tor-und-integriert-reines-kotlin-mls-und-marmot) mit Arti-Tor-Integration und einer neu gestalteten Shorts-UI aus und integriert zugleich reine Kotlin-Implementierungen von [MLS](/de/topics/mls/) und [Marmot](/de/topics/marmot/) in seine [Quartz](/de/topics/quartz/)-Bibliothek. [Nostur](https://github.com/nostur-com/nostur-ios-public) liefert [v1.27.0](#nostur-v1270-fügt-videoaufnahme-und-private-antworten-hinzu) mit Videoaufnahme, animierten GIF-Profilen und privaten Antworten. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) startet [v0.15.0](#shosho-v0150-startet-shows-und-ein-vertikales-video-karussell) mit Shows, also benutzerdefinierten Livestream-Infos mit OBS-Anbindung, und einem TikTok-artigen vertikalen Video-Karussell. [Nymchat](https://github.com/Spl0itable/NYM) [nimmt Marmot zurück und liefert erweiterte NIP-17-Gruppenchats aus](#nymchat-nimmt-marmot-zurück-und-liefert-erweiterte-nip-17-gruppenchats-aus), die rotierende ephemeral keys nutzen. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) liefert [exit node-Support und Umbrel-Paketierung](#nostr-vpn-liefert-exit-node-support-und-umbrel-paketierung-aus) über sechs Releases hinweg. [Amber](https://github.com/greenart7c3/Amber) springt auf [v6.0.0-pre1](#amber-v600-pre1-fügt-signing-keys-pro-verbindung-für-nip-46-hinzu) mit [NIP-46](/de/topics/nip-46/)-signing keys pro Verbindung und In-App-Updates über Zapstore. [Notedeck](https://github.com/damus-io/notedeck) erreicht [v0.10.0-beta](#notedeck-v0100-beta-liefert-zapstore-self-update-aus) mit APK-Self-Update via Zapstore, und [NIP-58](/de/topics/nip-58/) (Badges) erhält eine [kind-Migration](#nip-updates). Zwei NIP-Deep Dives behandeln [NIP-17](/de/topics/nip-17/) (Private Direct Messages) und [NIP-46](/de/topics/nip-46/) (Nostr Remote Signing).
+
+## Neuigkeiten
+
+### Amethyst liefert Arti Tor und integriert reines Kotlin MLS und Marmot
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), der von vitorpamplona gepflegte Android-Client, lieferte vier Releases von [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) bis [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) aus und mergte ein großes Paket noch unveröffentlichter Arbeit in seine [Quartz](/de/topics/quartz/)-Bibliothek, also das gemeinsame Kotlin-Multiplatform-Nostr-Modul. Das Hauptrelease ist v1.08.0 "Arti Tor", das die Tor-Anbindung der App von der C-basierten Tor-Bibliothek auf [Arti](https://gitlab.torproject.org/tpo/core/arti), die Rust-Implementierung des Tor Project, umstellt. Die Migration behebt zufällige Abstürze, die unter den bisherigen C-Tor-Bindings auftraten. Arti ist der langfristige Ersatz des Tor Project für die C-Codebasis, von Grund auf in Rust geschrieben für Memory Safety und async I/O.
+
+Der Release v1.07.3 gestaltet die Shorts-UI neu und ersetzt das seitenbasierte Design durch randlose Feeds für Bilder, Shorts und lange Videos. Derselbe Release migriert Badges auf kind `10008` und Bookmarks auf kind `10003` und richtet sich damit an der [NIP-58](/de/topics/nip-58/)-kind-Migration aus, die [diese Woche gemergt wurde](#nip-updates). v1.07.4 behebt ein Problem bei der Secret-Verarbeitung in Nostr Wallet Connect, und v1.07.5 behebt einen Absturz beim Bild-Upload.
+
+Auf `main`, aber noch nicht in einem getaggten Release, hat das Team eine vollständige Kotlin-Implementierung sowohl von [MLS](/de/topics/mls/) als auch des [Marmot](/de/topics/marmot/)-Protokolls geschrieben und damit den Bedarf an nativen C/Rust-Bibliotheks-Bindings ersetzt. [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) fügt die zentrale Marmot-MLS-Schicht für Gruppennachrichten hinzu, [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) fügt die Gruppenchat-UI hinzu, [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) fügt eingehende und ausgehende Message-Processor mit Subscription-Manager hinzu, [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) fügt Persistenz für MLS-Gruppenstatus und KeyPackage-Rotationsverwaltung hinzu, [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) fügt eine vollständige MLS-Testsuite mit verbessertem GroupInfo-Signing hinzu, und [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) fügt Tracking für den Veröffentlichungsstatus von KeyPackages hinzu. [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) fügt eine reine Kotlin-secp256k1-Implementierung für Nostr-Kryptographieoperationen hinzu und ersetzt damit die Abhängigkeit von der nativen C-Bibliothek. Zusammen mit der Kotlin-MLS-Implementierung kann [Quartz](/de/topics/quartz/) Nostr-Signing und Marmot-Gruppennachrichten ohne jegliche native Bindings ausführen, was den Weg für Kotlin-Multiplatform-Ziele einschließlich iOS öffnet.
+
+Das Team baut außerdem Unterstützung für [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls): [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) fügt eine vollständige Testsuite für die NIP-AC-Call-State-Machine hinzu, und [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) verhindert, dass veraltete Call Offers nach einem App-Neustart erneut ausgelöst werden.
+
+### Nostur v1.27.0 fügt Videoaufnahme und private Antworten hinzu
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), der iOS-Nostr-Client, lieferte [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) am 2. April aus. Der Release fügt Videoaufnahme direkt in der App mit Zuschneiden vor dem Upload hinzu, sodass Nutzer kurze Clips aufnehmen, auf Länge schneiden und veröffentlichen können, ohne den Client zu verlassen. Die Unterstützung für animierte GIFs erstreckt sich nun auch auf Profil- und Bannerbilder, zusätzlich kam Rendering für animierte WebP-Dateien hinzu. Eine neue Shortcuts-Integration erlaubt es Nutzern, Nostr-Posts aus Apple-Shortcuts-Automationen zu senden. Der Release fügt außerdem private Antworten hinzu und behebt DM-Kompatibilitätsprobleme, die die Zustellung zwischen Nostur und anderen Clients beeinträchtigten.
+
+### Shosho v0.15.0 startet Shows und ein vertikales Video-Karussell
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), die Nostr-Livestreaming-App, lieferte [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) und [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) am 7. April aus. Das Hauptfeature ist Shows: Streamer können vor dem Start eines Livestreams eigene Show-Informationen anlegen und ihre Show mit OBS oder einem anderen externen Encoder verbinden. Dadurch wird die Metadatenfrage "Was streame ich?" vom eigentlichen Go-Live getrennt, sodass Streamer Titel, Beschreibungen und Produkte vorbereiten können, bevor sie senden. Derselbe Release fügt außerdem ein TikTok-artiges vertikales Video-Karussell zum Durchwischen von Lives, Clips und Replays in einem Vollbild-Feed hinzu sowie Quick Add zum Veröffentlichen von Videoclips und Hinzufügen von Produkten direkt von einer Profilseite. v0.15.1 behebt einen Fehler, bei dem die Tastatur das Chat-Eingabefeld des Livestreams verdeckte.
+
+## Releases
+
+### Notedeck v0.10.0-beta liefert Zapstore-Self-Update aus
+
+[Notedeck](https://github.com/damus-io/notedeck), der Desktop- und Mobile-Client des Damus-Teams, lieferte [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) und [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) als Test-Prereleases für APK-Self-Update aus. [PR #1417](https://github.com/damus-io/notedeck/pull/1417) fügt APK-Self-Update über den Nostr/Zapstore-Updater auf Android hinzu und baut auf der [Nostr-nativen Release-Erkennung aus Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr) auf. Der Update-Flow entdeckt neue Releases über Nostr-Events, die an Relays veröffentlicht werden, lädt dann das APK dort herunter, wo der Entwickler es hostet, also etwa bei GitHub Releases, einem Blossom-CDN oder anderen Quellen, verifiziert den SHA-256-Hash gegen das signierte Nostr-Event und installiert es. [PR #1438](https://github.com/damus-io/notedeck/pull/1438) behebt einen Fehler im Welcome Screen, bei dem Login- und CreateAccount-Buttons sofort wieder zurücknavigierten, und [PR #1424](https://github.com/damus-io/notedeck/pull/1424) behebt Textüberlauf in der Agentium-AI-Session-Ansicht.
+
+### Amber v6.0.0-pre1 fügt signing keys pro Verbindung für NIP-46 hinzu
+
+[Amber](https://github.com/greenart7c3/Amber), die [NIP-55](/de/topics/nip-55/) (Android Signer Application) Signer-App, lieferte [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) am 4. April aus. Die wichtigste Änderung sind signing keys pro Verbindung für das [NIP-46](/de/topics/nip-46/) (Nostr Remote Signing) Bunker-Protokoll. Statt ein einziges Schlüsselpaar für alle Bunker-Verbindungen zu verwenden, erzeugt Amber nun für jeden verbundenen Client einen eigenen Schlüssel. Wird die Verbindung eines Clients kompromittiert, kann ein Angreifer den Signer nicht gegenüber anderen Clients imitieren.
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377) fügt In-App-Prüfung und Installation von Updates via Zapstore hinzu und folgt damit [Notedeck](#notedeck-v0100-beta-liefert-zapstore-self-update-aus) bei der Einführung Nostr-nativer App-Distribution. [PR #375](https://github.com/greenart7c3/Amber/pull/375) behandelt AndroidKeyStore-Fehler robust, indem eine Warnung angezeigt wird statt die App abstürzen zu lassen, und [PR #371](https://github.com/greenart7c3/Amber/pull/371) fügt Datenbankbereinigung mit Größenlimits und Inhaltskürzung hinzu, um unbegrenztes Speicherwachstum zu verhindern. Das Prerelease trägt außerdem die [NIP-42](/de/topics/nip-42/)-Relay-Auth-Whitelist und Mnemonic-Recovery-Phrase-Login aus dem [v5.0.x-Zyklus, den wir letzte Woche behandelt haben](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria liefert native Mobile-App aus
+
+[Nostria](https://github.com/nostria-app/nostria), der von SondreB gepflegte plattformübergreifende Nostr-Client, veröffentlichte eine native Mobile-App für Android mit acht Releases von [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) bis [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). Die wichtigste neue Fähigkeit ist native Unterstützung für lokale Signer wie [Amber](https://github.com/greenart7c3/Amber) und Aegis. [Desktop-Installer](https://www.nostria.app/download) für Linux, macOS und Windows sind ebenfalls verfügbar. [PR #610](https://github.com/nostria-app/nostria/pull/610) senkt den Speicherdruck im Feed mit adaptiven Runtime-Limits und Bereinigung von Preview-URLs. v3.1.14 behebt die Integration mit Brainstorm, einem Anbieter für [Web of Trust](/de/topics/web-of-trust/). v3.1.15 konzentriert sich auf Musik-Verbesserungen. Die neue Android-App ist auf [Zapstore](https://zapstore.dev/apps/app.nostria) verfügbar.
+
+### diVine 1.0.8 liefert fortsetzbare Uploads und DMs aus
+
+[diVine](https://github.com/divinevideo/divine-mobile), der Kurzform-Video-Client, lieferte [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) mit 87 gemergten PRs aus. Fortsetzbare Uploads erlauben es Creatorn, unterbrochene Uploads Chunk für Chunk wiederaufzunehmen, statt bei instabiler Verbindung von vorn zu beginnen. Der Release fügt Einstellungen für Videoqualität und Bitrate, Double-Tap zum Liken und DM-Verbesserungen hinzu. [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) fügt ein macOS-Kamera-Plugin für Desktop-Videoaufnahme hinzu, und [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migriert das Benachrichtigungssystem auf eine BLoC-Architektur mit Anreicherung und Gruppierung. Das Team ersetzte außerdem AI-generierte Sticker und Kategorie-Grafiken durch OpenMoji-SVGs ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 fügt Unschärfe für sensible Notizen und NIP-42-Auth hinzu
+
+[Manent](https://github.com/dtonon/manent), die private App für verschlüsselte Notizen und Dateispeicherung, lieferte [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) am 2. April aus. Nutzer können Notizen nun als sensibel markieren, damit sie in der Listenansicht unscharf dargestellt werden und private Inhalte beim beiläufigen Scrollen verborgen bleiben. Der Release fügt außerdem Unterstützung für [NIP-42](/de/topics/nip-42/) (Authentication of Clients to Relays) hinzu, sodass Manent sich bei Relays authentifizieren kann, die dies verlangen, bevor sie Events annehmen. Manent speichert alle Daten verschlüsselt auf Nostr-Relays unter Verwendung des Schlüsselpaares des Nutzers, daher erweitert NIP-42 die Menge an Relays, die es für die Speicherung nutzen kann.
+
+### Wisp v0.17.0 bis v0.17.3 fügen Livestream-Zaps und Wallet-Backup hinzu
+
+[Wisp](https://github.com/barrydeen/wisp), der Android-Nostr-Client, lieferte sechs Releases von [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) bis [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) mit 44 gemergten PRs aus. Der Release v0.17.0 fügt Sicherheitsabfragen für Wallet-Backups und Verbesserungen an der Zap-UX hinzu. [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) fügt plattformübergreifende Sichtbarkeit des Livestream-Chats und Livestream-Zap-Funktionalität hinzu. [PR #423](https://github.com/barrydeen/wisp/pull/423) fügt automatisches Suchen von Profilen, eine Zap-Erfolgsanimation und Verbesserungen bei Nutzerstatus hinzu. [PR #426](https://github.com/barrydeen/wisp/pull/426) behebt einen Out-of-Memory-Absturz in `computeId` bei Events mit großen Tag-Listen. Die v0.16.x-Releases fügten Emoji-Shortcode-Autocomplete, Verbesserungen an der Gruppenchat-UI und Filterung blockierter Nutzer über alle Benachrichtigungspfade hinweg hinzu.
+
+### Mostro liefert Deep Links, Nostr-Wechselkurse und einen Fix für doppelte Zahlungen aus
+
+[Mostro](https://github.com/MostroP2P/mostro), die auf Nostr basierende Peer-to-Peer-Bitcoin-Börse, sah diese Woche Updates sowohl am Server-Daemon als auch am Mobile-Client. Auf der Serverseite verhindert [PR #692](https://github.com/MostroP2P/mostro/pull/692), dass veraltete Order-Schreibvorgänge doppelte Zahlungen verursachen, also ein Fehlerbild, bei dem ein Verkäufer für denselben Trade zweimal bezahlt werden könnte. [PR #693](https://github.com/MostroP2P/mostro/pull/693) nutzt gezielte Updates für dev_fee-Schreibvorgänge statt vollständiger Order-Überschreibungen.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), der Flutter-Client, lieferte [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) am 3. April aus. Der Release behandelt Deep Links von unterschiedlichen Mostro-Instanzen, sodass Nutzer Links antippen können, die zum richtigen Exchange-Server führen. [PR #498](https://github.com/MostroP2P/mobile/pull/498) erkennt Admin- und Dispute-DMs in der Hintergrund-Benachrichtigungspipeline, und die App holt Wechselkurse nun von Nostr mit HTTP/Cache-Fallback. [PR #560](https://github.com/MostroP2P/mobile/pull/560) behebt einen blockierenden Relay-Verbindungsfehler, der die App unter bestimmten Netzwerkbedingungen daran hinderte, Relays zu erreichen.
+
+### Unfiltered v1.0.12 fügt Hashtags und Kommentare hinzu
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), ein Nostr-Client mit Fokus auf bildzentrierte Inhalte, lieferte [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12) aus. [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) fügt Unterstützung für Hashtags hinzu, und [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) fügt die Möglichkeit hinzu, Kommentare zu Beiträgen zu schreiben und anzuzeigen. [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) behebt Navigationsprobleme bei Beiträgen mit mehreren Bildern.
+
+### Primal Android liefert Wallet-Multi-Account-Sharing und Auto-Reconnect für Remote Signer aus
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), der Android-Nostr-Client, lieferte am 7. April einen Release aus. Das Update fügt Wallet-Multi-Account-Sharing sowie ein Overflow-Menü mit Wallet-Löschung in den Dev Tools hinzu. Der Remote Signer verbindet sich nun bei Verbindungsabbrüchen automatisch neu, und auch der Wallet-Service erhielt eine eigene Auto-Reconnect-Logik. Zu den Fixes gehören, dass Poll-Zap-Stimmen nicht länger als Top Zaps erscheinen, leere Poll-Optionen keinen Absturz mehr auslösen, Wallet-Guthaben verborgen wird, wenn keine Wallet existiert, und WalletException-Typen in NWC-Antworten auf Fehlercodes abgebildet werden.
+
+### Titan v0.1.0 startet nativen nsite://-Browser mit Bitcoin-Namensregistrierung
+
+[Titan](https://github.com/btcjt/titan), ein nativer Desktop-Browser für das Nostr-Web, lieferte [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) am 7. April aus. Titan löst `nsite://`-URLs auf, indem es menschenlesbare, auf Bitcoin registrierte Namen nachschlägt, Nostr-Relays nach den Content-Events der Website abfragt und Seiten rendert, die von [Blossom](/de/topics/blossom/)-Servern geladen werden. Das Ergebnis ist ein Browser-Erlebnis ohne DNS, ohne TLS-Zertifikate und ohne Hosting-Anbieter. Namen werden über eine [Weboberfläche](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) registriert, die mit Bitcoin-Transaktionen verknüpft ist. Der erste Release kommt als macOS-`.dmg` für ARM, mit Rosetta-2-Unterstützung für Intel, und enthält Unterstützung für Nix-Entwicklungsumgebungen.
+
+### Bikel v1.5.0 liefert nativen Foreground Service für de-Googled Phones aus
+
+[Bikel](https://github.com/Mnpezz/bikel), ein dezentraler Fahrrad-Tracker, der Fahrten über Nostr in öffentliche Infrastrukturdaten verwandelt, lieferte [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) am 4. April aus. Der Release migriert von dem von GMS abhängigen Expo TaskManager zu einem benutzerdefinierten nativen Foreground Service und sorgt damit für zuverlässiges Ride-Tracking im Hintergrund auf LineageOS, GrapheneOS und anderen de-Googled-Android-Varianten. Der Bikel Bot erhielt eine Dual-Pocket-Architektur mit autonomer eCash-Einsammlung via Cashu nutzaps. v1.4.3 und v1.4.2 beheben die Synchronisierung des Hintergrund-Trackings für nicht standardisierte Android-Umgebungen, und die App fügt Schalter für OSM-Fahrradständer-Kartenpunkte hinzu.
+
+### Sprout fügt NIP-01-, NIP-23- und NIP-33-Unterstützung hinzu
+
+[Sprout](https://github.com/block/sprout), eine Kommunikationsplattform von Block mit eingebautem Nostr-relay, lieferte [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) am 6. April aus. Diese Woche fügte das Team Unterstützung für [NIP-23](/en/topics/nip-23/) (Long-form Content) Artikel mit kind `30023`, [NIP-33](/en/topics/nip-33/) parametrisierbare ersetzbare Events mit `d`-Tag-basierter Ersetzung sowie [NIP-01](/de/topics/nip-01/)/[NIP-02](/en/topics/nip-02/) Textnotizen mit kind `1` und Follow-Listen mit kind `3` hinzu. Der Release fügt außerdem ein adaptives IDE-Theme-System mit 54 Themes, UX-Politur für Workflow- und Agent-Run-Historie sowie eine Bereinigung der Mitglieder-Sidebar hinzu.
+
+### mesh-llm v0.56.0 liefert verteiltes Config-Protokoll aus
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), ein verteiltes LLM-Inferenzsystem, das Nostr-Schlüsselpaare für Node-Identität nutzt, lieferte [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) am 7. April aus. Der Release fügt ein verteiltes Config-Protokoll mit Ownership-Semantik, asymmetrische KV-Cache-Quantisierung mit Q8_0-Keys und Q4-Werten zur Reduzierung des Speicherverbrauchs, OS-Keychain-Speicherung für Identity-Keystores, flüssiges Chat-Streaming mit Message-Queueing sowie Fixes für Fullscreen-Layout und KV-Cache-Splitting mit Flash Attention hinzu.
+
+### Nostr VPN liefert exit node-Support und Umbrel-Paketierung aus
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), ein Peer-to-Peer-VPN, das Nostr-Relays für Signalisierung und WireGuard für verschlüsselte Tunnel nutzt, lieferte diese Woche sechs Releases von [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) bis [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) aus. Der v0.3.x-Zyklus fügt exit node-Support auf Windows und macOS hinzu, sodass Peers Internetverkehr durch andere Nodes im Netzwerk leiten können. Invite- und Alias-Propagation synchronisieren nun über Nostr, sodass Nutzer Netzwerkzugang teilen können, ohne sich außerhalb des Protokolls abzustimmen. Die Releases fügen Umbrel-Paketierung für Self-Hosting-Deployments, NAT-Punch-Through mit gemerkten öffentlichen Endpunkten, automatische Bereinigung veralteter exit nodes und eine veröffentlichte Protokollspezifikation hinzu. Das Projekt stabilisierte außerdem die Routenbehandlung auf macOS mit selbstheilenden Default Routes und Underlay-Reparatur und fügte einen Android-Build via Tauri hinzu. Builds sind für macOS, Apple Silicon und Intel, Linux, AppImage und .deb, Windows und Android verfügbar.
+
+### Nymchat nimmt Marmot zurück und liefert erweiterte NIP-17-Gruppenchats aus
+
+[Nymchat](https://github.com/Spl0itable/NYM), der MLS-fähige Chat-Client, lieferte 14 Releases von [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) bis [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274) aus. Die bedeutendste Änderung ist ein Protokollwechsel: [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) fügte Marmot-MLS-Gruppenchats hinzu, aber [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) kehrte zu [NIP-17](/de/topics/nip-17/) zurück, weil die Multi-Device-Unterstützung von Marmot noch nicht fertig ist, was Probleme bei der Synchronisierung des Gruppenchatzustands über Geräte hinweg verursachte. v3.58.271 führt erweiterte NIP-17-Gruppenchats mit rotierenden ephemeral keys für alle Nachrichten ein, die Timing- und Korrelationsangriffe verhindern sollen. Die Woche brachte außerdem ein Friends-System mit granularer Kontrolle über Einstellungen ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), MLS-Gruppenchat-Nachrichtensynchronisierung in verschlüsselten App-Einstellungen und mehrere Fixes für Relay-Konnektivität.
+
+### nak v0.19.5 fügt Blossom-Multi-Server und Outbox-Publishing hinzu
+
+[nak](https://github.com/fiatjaf/nak), fiatjafs Kommandozeilen-Nostr-Toolkit, lieferte [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5) aus. Der `blossom`-Befehl akzeptiert nun mehrere `--server`-Flags, um in einem Aufruf auf mehrere [Blossom](/de/topics/blossom/)-Server hochzuladen. Ein neuer `key`-Befehl erweitert partielle Schlüssel durch Linkspadding mit Nullen. Der `event`-Befehl erhält ein `--outbox`-Flag zum Veröffentlichen von Events über das Outbox-Modell, und `fetch` beendet sich nun mit einem Fehlercode, wenn kein Event zurückgegeben wird.
+
+## In Entwicklung
+
+### White Noise fügt thumbhash-Vorschauen und Push-Registration-Bridge hinzu
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), der private Messenger auf Basis des [Marmot](/de/topics/marmot/)-Protokolls, mergte fünf PRs. [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) ersetzt blurhash-Bildvorschauen durch thumbhash, einen neueren Algorithmus, der schärfere Platzhalterbilder mit kleinerer Payload-Größe erzeugt, typischerweise unter 30 Byte statt blurhashs etwa 50 bis 100 Byte, und dabei Seitenverhältnis und Farbverteilung des Originalbilds bewahrt. Blurhash bleibt als Fallback für ältere Inhalte erhalten. [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) aktualisiert whitenoise-rs und fügt die [MIP-05](/de/topics/mip-05/) Push-Registration-Bridge hinzu, die die [Push-Benachrichtigungsspezifikation der letzten Woche](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications) mit dem Client verbindet. [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) fügt cursor-basierte Pagination für Chat-Nachrichten hinzu und ersetzt die bisherige Ladestrategie durch einen scrollgesteuerten Ansatz.
+
+### Route96 fügt dynamische Label-Konfiguration und Zero-Egress-Bereinigung hinzu
+
+[Route96](https://github.com/v0l/route96), der [Blossom](/de/topics/blossom/)-Medienserver von v0l, mergte drei PRs. [PR #80](https://github.com/v0l/route96/pull/80) fügt dynamische Konfiguration des Label-Modells über die Admin-API hinzu, sodass Betreiber Content-Klassifizierungsmodelle ohne Neustart des Servers austauschen können. [PR #82](https://github.com/v0l/route96/pull/82) fügt Felder zur Label-Konfiguration der Admin-UI hinzu. [PR #79](https://github.com/v0l/route96/pull/79) fügt eine Zero-Egress-Dateibereinigungsrichtlinie hinzu, die Dateien, die nie heruntergeladen wurden, automatisch entfernt und so die Speicherkosten für Betreiber senkt.
+
+### Snort liefert Sicherheitshärtung und DVM-Zahlungsrechnungen aus
+
+[Snort](https://github.com/v0l/snort), der Web-Client, lieferte diese Woche zwei Releases zusammen mit einem umfassenden Sicherheitsaudit aus. Zu den Fixes gehören Schnorr-Signaturprüfung, Schutz vor Relay-Message-Forgery in [NIP-46](/de/topics/nip-46/), also vor Angriffen, bei denen kompromittierte Relays Signing-Anfragen einschleusen könnten, Verbesserungen bei der PIN-Verschlüsselung und die Entfernung des Vertrauens in NIP-26-Delegation. Performance-Gewinne kommen durch gebündelte Schnorr-Verifikation in WASM, lazy-geladene Routen, vorkompilierte Übersetzungen und den Wegfall doppelter Verifikation pro Event. [PR #618](https://github.com/v0l/snort/pull/618) fügt die Anzeige von zahlungspflichtigen Rechnungen für [NIP-90](/en/topics/nip-90/) (Data Vending Machine) kind `7000` hinzu, sodass Snort die Lightning-Rechnung direkt im Feed rendert, wenn eine DVM eine Zahlungsanforderung zurückgibt.
+
+### Damus verbessert LMDB-Kompaktierung
+
+[Damus](https://github.com/damus-io/damus), der iOS-Client, mergte [PR #3719](https://github.com/damus-io/damus/pull/3719), das automatische LMDB-Kompaktierung nach Zeitplan hinzufügt und damit verhindert, dass die lokale Datenbank unbegrenzt wächst. [PR #3663](https://github.com/damus-io/damus/pull/3663) verbessert die BlurOverlayView, sodass sie schützend statt kaputt wirkt.
+
+### Captain's Log fügt Tag-Indizierung und Notiz-Sync hinzu
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), das Nostr-native Langform-Schreibwerkzeug von Nodetec, mergte diese Woche vier PRs. [PR #156](https://github.com/nodetec/captains-log/pull/156) fügt Tag-Indizierung und Sync-Unterstützung über Notizen hinweg hinzu, [PR #157](https://github.com/nodetec/captains-log/pull/157) refaktoriert Notiz-Sync und Tag-Verarbeitung, und [PR #159](https://github.com/nodetec/captains-log/pull/159) behebt den Sync gelöschter Notizen, damit entfernte Notizen auf allen Geräten gelöscht bleiben.
+
+### Relatr v0.2.x gestaltet das Plugin-System mit Nostr-nativem Validator-Marktplatz neu
+
+[Relatr](https://github.com/ContextVM/relatr), eine [Web of Trust](/de/topics/web-of-trust/)-Scoring-Engine, die Vertrauensrankings aus Distanz im sozialen Graphen und konfigurierbaren Validatoren berechnet, lieferte die v0.2.x-Familie mit einer vollständigen Neugestaltung des Plugin-Systems aus. Validatoren werden nun in Elo geschrieben, einer portablen funktionalen Ausdruckssprache, die geforkt wurde, um mehrstufige, host-orchestrierte Fähigkeiten zu unterstützen, darunter Nostr-Abfragen, Social-Graph-Lookups und NIP-05-Auflösung. Plugins werden als Nostr-Events mit kind `765` veröffentlicht und machen die Distribution damit nativ für das Relay-Netzwerk. Ein neuer [Plugin-Marktplatz](https://relatr.net) erlaubt es Betreibern, Validatoren im Browser zu entdecken, zu installieren und zu gewichten, ergänzt durch eine CLI namens `relo` für lokales Authoring und Publishing. Die Architektur ist sandboxed: Plugins können nur Fähigkeiten aufrufen, die der Host ausdrücklich bereitstellt, sodass ein bösartiger Validator seinen definierten Scope nicht verlassen kann. Relatr-Instanzen lassen sich nun von der Website aus verwalten, mit voller Transparenz darüber, welche Plugins den Scoring-Algorithmus zusammensetzen und welches einzelne Gewicht sie haben.
+
+### Shopstr verbessert Mobile-Navigation und Zugriffskontrolle
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), der Nostr-native Marktplatz für Kauf und Verkauf mit Bitcoin, pushte diese Woche 158 Commits über seine Haupt-App und das Begleitprojekt [Milk Market](https://github.com/shopstr-eng/milk-market). Zu den Fixes gehören Verbesserungen am Community-Layout auf Mobilgeräten, das Schließen von Menüs bei Navigation und automatisches Schließen von Dropdowns. Geschützte Routen lassen sich nicht mehr per direkter URL ohne Anmeldung aufrufen, und die Slug-Matching-Logik behandelt mehrere exakte Treffer nun korrekt.
+
+### Pollerama fügt Benachrichtigungen, Filmsuche und Rating-UI hinzu
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), eine auf Nostr basierende Umfrage-, Survey- und Social-Rating-App, fügte Thread-Benachrichtigungen, eine Filmsuche und eine überarbeitete Rating-UI hinzu. Der Release behebt außerdem Ladeprobleme im Feed und hebt Abhängigkeitsversionen an.
+
+### Purser baut Nostr-nativen Zahlungs-Daemon mit Marmot-Verschlüsselung
+
+[Purser](https://github.com/EthnTuttle/purser), ein Nostr-nativer Zahlungs-Daemon als Ersatz für Zaprite, mergte diese Woche neun PRs zum Ausbau seiner Kernarchitektur. Das Projekt nutzt [Marmot](/de/topics/marmot/) MLS über MDK für verschlüsselte Händler-Kunden-Kommunikation, mit Strike und Square als Zahlungsanbietern. Diese Woche landeten Konfigurations- und Katalogladen, Message-Schema-Validierung, die MDK-Kommunikationsschicht, Implementierungen für Strike und Square, eine Polling-Engine, Anti-Spam-Rate-Limiting, Persistenz ausstehender Zahlungen und die Order-Processing-Pipeline. Alle 99 Tests verwenden nun echte mdk-core-MLS-Operationen, nachdem das Team Mock-MLS zugunsten realer Verschlüsselung im lokalen Modus entfernt hat.
+
+### Vector refaktoriert DM-Anhänge und fügt Profilbearbeitung hinzu
+
+[Vector](https://github.com/VectorPrivacy/Vector), der mit Tauri gebaute datenschutzorientierte Nostr-Messenger, mergte [PR #55](https://github.com/VectorPrivacy/Vector/pull/55), das das Frontend refaktoriert. Entschlüsselung und Speichern von DM-Anhängen wurden in die vector-core-Bibliothek verschoben, und die App unterstützt nun Profilbearbeitung. Das Upload-Cancel-Flag ist jetzt korrekt durch TauriSendCallback verdrahtet, und ungenutzte Callbacks für Attachment-Vorschauen wurden entfernt.
+
+## Protokoll- und Spezifikationsarbeit
+
+### NIP-Updates
+
+Aktuelle Änderungen am [NIPs-Repository](https://github.com/nostr-protocol/nips):
+
+**Gemergt:**
+
+- **[NIP-58](/de/topics/nip-58/) (Badges): Profile Badges wechseln zu kind 10008, Badge Sets zu kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Migriert Profile Badges von kind `30008` zu kind `10008`, also einem ersetzbaren Event, eines pro pubkey, und führt kind `30008` für Badge Sets ein. Zuvor nutzten Profile Badges denselben kind `30008` wie Badge-Definitionen und waren damit parametrisierbare ersetzbare Events mit einem `d`-Tag als Schlüssel. Der neue kind `10008` ist ein einfaches ersetzbares Event, eines pro pubkey, ohne benötigten `d`-Tag. Clients fragen damit ein einzelnes ersetzbares Event pro Nutzer ab, statt parametrisierbare ersetzbare Events zu scannen. Amethyst v1.07.3 liefert diese Migration bereits aus.
+
+- **[NIP-34](/de/topics/nip-34/) (Git Stuff): Git-bezogene Follow-Listen hinzufügen** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): Fügt Konventionen für Follow-Listen zur Repository- und Issue-Verfolgung in NIP-34 hinzu. Nutzer veröffentlichen kind-`30000`-Follow-Sets mit `d`-Tags wie `git-repos` oder `git-issues`, die `a`-Tag-Referenzen auf Repositories enthalten, kind `30617`, die sie verfolgen möchten. Clients können diese Follow-Sets abonnieren, um Repository-Aktivität im Feed eines Nutzers anzuzeigen, ähnlich wie kind-`3`-Kontaktlisten für pubkeys funktionieren.
+
+**Offene PRs und Diskussionen:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): Erweitert das ursprüngliche NIP-100, umgesetzt von 0xChat, um drei Änderungen: Migration auf [NIP-44](/de/topics/nip-44/)-Verschlüsselung, verpackt in [NIP-59](/de/topics/nip-59/) gift wraps, um Metadatenlecks zu eliminieren, einen spezifizierten WebRTC-Workflow für Sprach- und Videoanrufe, also Offer, Answer und ICE Candidates, und ein Mesh-Modell für Gruppenanrufe, bei dem jeder Peer eine direkte WebRTC-Verbindung zu jedem anderen Peer aufbaut. Die Spezifikation ist nicht abwärtskompatibel zu NIP-100. Amethyst baut bereits dagegen, mit einer Testsuite für die Call-State-Machine ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) und dem Handling veralteter Call Offers ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)), die diese Woche landeten.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Schlägt Konventionen für Threshold-Signing mit [FROST](/de/topics/frost/) (Flexible Round-Optimized Schnorr Threshold) auf Nostr vor. FROST erlaubt es einer Gruppe von Signern, gemeinsam eine Nostr-Identität zu kontrollieren, bei der beliebige t-von-n-Mitglieder Events signieren können, ohne den vollständigen privaten Schlüssel zu rekonstruieren. Das NIP definiert, wie Signing-Runden koordiniert, Key Shares verteilt und threshold-signierte Events veröffentlicht werden, aufbauend auf der Igloo-Signer-Arbeit aus dem [FROSTR-Projekt](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Definiert ein `postMessage`-Protokoll für sandboxed Webanwendungen, sogenannte "napplets", die in iframes laufen und mit einer hostenden Anwendung, der "shell", kommunizieren. Die shell stellt dem napplet Nostr-Signing, Relay-Zugang und Nutzerkontext über eine strukturierte Message-API bereit, während die iframe-Sandbox direkten Zugriff auf Schlüssel verhindert. Das erweitert das Hosting-Modell für statische Websites aus [NIP-5A](/en/topics/nip-5a/) in Richtung interaktiver Anwendungen, die Nostr-Events lesen und schreiben können. Das NIP ist in aktiver Entwicklung und hat bereits eine funktionierende Runtime-Implementierung.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): Wurde gegenüber dem früheren Vorschlag NIP-A5 umbenannt. Definiert Konventionen für das Veröffentlichen und Entdecken von WebAssembly-Programmen auf Nostr. WASM-Binaries werden als Nostr-Events gespeichert, und Clients können sie in einer sandboxed Runtime herunterladen und ausführen. Eine [Demo-App](https://nprogram.netlify.app/) zeigt Scrolls, die im Browser laufen, mit Beispielprogrammen, die als Nostr-Events veröffentlicht sind und von jedem Client geladen und ausgeführt werden können.
+
+- **[NIP-85](/de/topics/nip-85/) (Trusted Assertions): Klarstellungen** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): Präzisiert die Spezifikationssprache rund um mehrere Schlüssel und Relays pro Service-Provider und klärt, wie Clients mit Assertions von Anbietern umgehen sollten, die über mehrere pubkeys oder Relay-Endpunkte arbeiten.
+
+- **[NIP-24](/de/topics/nip-24/) (Extra Metadata Fields): `published_at` für ersetzbare Events** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): Verallgemeinert den `published_at`-Tag aus [NIP-23](/en/topics/nip-23/) (Long-form Content) auf alle ersetzbaren und adressierbaren Events. Der Tag dient nur der Darstellung: Wenn `published_at` gleich `created_at` ist, zeigen Clients das Event als "created" zu diesem Zeitpunkt an, und wenn sie sich unterscheiden, weil das Event aktualisiert wurde, können Clients stattdessen "updated" anzeigen. Dadurch können Profile mit kind `0` ein "joined at"-Datum anzeigen, und andere ersetzbare Events behalten ihren ursprünglichen Veröffentlichungszeitpunkt über Updates hinweg. Ein komplementärer Vorschlag für [NIP-51](/de/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) fügt denselben Tag zu Listen-Events hinzu.
+
+- **[NIP-59](/de/topics/nip-59/) (Gift Wrap): Ephemeral gift wrap kind** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): Fügt kind `21059` als ephemeres Gegenstück zum bestehenden gift wrap mit kind `1059` hinzu. Ephemere Events, kinds `20000` bis `29999`, folgen der Semantik von [NIP-01](/de/topics/nip-01/): Relays müssen sie nicht speichern und können sie nach der Zustellung verwerfen. Dadurch können Anwendungen gift-wrapped Messages senden, die nach der Zustellung von Relays verschwinden, was die Speicheranforderungen für volumenstarke Nachrichten reduziert und dabei dasselbe Drei-Schichten-Verschlüsselungsmodell wie normale [NIP-17](/de/topics/nip-17/) DMs beibehält.
+
+### OpenSats kündigt sechzehnte Welle von Nostr-Grants an
+
+[OpenSats](https://opensats.org) kündigte am 8. April seine [sechzehnte Welle von Nostr-Grants](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) an und finanziert damit vier Erstförderungen und eine Verlängerung. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) erhält Förderung für den Contributor Robert Nagy, um auf Basis der [Quartz](/de/topics/quartz/)- und Commons-Module eine eigenständige Desktop-App zu bauen, die das Feature-Set des Android-Clients auf mausgesteuerte Oberflächen mit persistenten Relay-Verbindungen bringt. [Nostr Mail](https://github.com/nogringo/nostr-mail) erhält Förderung für den Bau eines vollständigen E-Mail-Systems auf Nostr unter Verwendung von kind-`1301`-Events, verpackt in [NIP-59](/de/topics/nip-59/) gift wraps, mit einem Flutter-Client und SMTP-Bridge-Servern für Gmail- und Outlook-Kompatibilität. [Nostrord](https://github.com/Nostrord/nostrord) erhält Förderung für einen Kotlin-Multiplatform-Gruppenclient auf Basis von [NIP-29](/en/topics/nip-29/) und Relay-basierten Gruppen, mit Discord-artigen Gruppenchats, Moderation und Threads. [Nurunuru](https://github.com/tami1A84/null--nostr) erhält Förderung für eine native iOS-Version des auf Japan fokussierten Nostr-Clients, modelliert an der vertrauten LINE-Oberfläche, mit passkey-basierter biometrischer Anmeldung für das Onboarding. HAMSTR erhielt eine Förderverlängerung, erstmals gefördert in der [elften Welle](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr).
+
+## NIP Deep Dive: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) definiert den aktuellen Standard für private Direktnachrichten auf Nostr. Es ersetzt das ältere Schema [NIP-04](/de/topics/nip-04/) (Encrypted Direct Messages), das Metadaten leckte, also Absender, Empfänger und Zeitstempel waren auf Relays sichtbar, und eine schwächere Verschlüsselungskonstruktion nutzte. NIP-17 kombiniert [NIP-44](/de/topics/nip-44/) (Encrypted Payloads) für die Verschlüsselung mit [NIP-59](/de/topics/nip-59/) (Gift Wrap) für den Schutz von Metadaten und schafft damit ein Dreischichtensystem, in dem Relays nicht sehen können, wer mit wem spricht.
+
+Das Protokoll verwendet drei ineinander verschachtelte Event-Kinds. Die innerste Schicht ist die eigentliche Nachricht, ein unsigniertes Event mit kind `14`:
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+Das Event mit kind `14` ist absichtlich unsigniert, also mit leerem `sig`. Die Spezifikation beschreibt das als Deniability, aber in der Praxis ist dieser Schutz begrenzt. Das Siegel mit kind `13`, das das rumor umhüllt, ist mit dem echten Schlüssel des Absenders signiert. Ein Empfänger kann das signierte Siegel einem Dritten zeigen und damit beweisen, dass der Absender mit ihm kommuniziert hat, auch ohne den Nachrichteninhalt offenzulegen. Mit Zero-Knowledge-Proofs kann ein Empfänger sogar den exakten Nachrichteninhalt beweisen, ohne seinen eigenen privaten Schlüssel offenzulegen. Das unsignierte rumor ist wie ein unsignierter Brief in einem signierten Umschlag: Die Signatur auf dem Umschlag verbindet den Absender mit dem Inhalt. Echte Deniability würde symmetrische Authentifizierung erfordern, wie HMACs bei Signal, was mit Nostrs dezentralem Relay-Modell unvereinbar ist, weil Nachrichten selbstauthentifizierend sein müssen. Die eigentlichen Stärken von NIP-17 sind Privatsphäre bei Metadaten und Geheimhaltung des Inhalts, nicht Deniability.
+
+Diese unsignierte Nachricht wird dann in ein Siegel mit kind `13` verpackt, das vom tatsächlichen Absender signiert und mit [NIP-44](/de/topics/nip-44/) für den Empfänger verschlüsselt wird:
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+Das Siegel hat keine Tags, daher würde es selbst nach einer Entschlüsselung den Empfänger nicht offenlegen. Das Siegel ist mit dem echten Schlüssel des Absenders signiert, was dem Empfänger erlaubt, die Nachricht zu authentifizieren, indem er prüft, dass der `pubkey` des Siegels mit dem `pubkey` des inneren kind-`14`-Events übereinstimmt.
+
+Das Siegel wird anschließend in ein gift wrap mit kind `1059` verpackt, signiert von einem zufälligen Wegwerf-Schlüssel und an den Empfänger adressiert:
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+Der `pubkey` des gift wrap ist ein zufälliger Schlüssel, der nur für diese Nachricht erzeugt wurde, und `created_at` wird um bis zu zwei Tage in die Vergangenheit randomisiert. Das ist die äußerste Schicht, die Relays tatsächlich sehen: eine Nachricht von einem unbekannten pubkey an den Empfänger, mit einem Zeitstempel, der nicht widerspiegelt, wann die Nachricht tatsächlich gesendet wurde. Der randomisierte Zeitstempel schützt vor nachträglicher Analyse gespeicherter Events, aber ein Angreifer, der aktiv mit Relays verbunden ist, kann weiterhin beobachten, wann das gift wrap erstmals auftaucht, daher ist diese Verteidigung auf passive Beobachter beschränkt, die Relay-Daten später abfragen. Weil der pubkey zufällig und der Zeitstempel gefälscht ist, können Relays den echten Absender nicht bestimmen. Um die Nachricht zu lesen, entschlüsselt der Empfänger das gift wrap mit seinem eigenen Schlüssel und dem zufälligen pubkey, findet darin das Siegel, entschlüsselt das Siegel mit seinem eigenen Schlüssel und dem pubkey des Absenders aus dem Siegel und findet darin die Nachricht mit kind `14`.
+
+NIP-17 bietet keine forward secrecy. Alle Nachrichten werden mit dem statischen Nostr-Schlüsselpaar verschlüsselt, über die Schlüsselableitung von NIP-44 aus den Schlüsseln von Absender und Empfänger. Wird ein privater Schlüssel kompromittiert, kann jede vergangene und zukünftige Nachricht entschlüsselt werden, die an diesen Schlüssel verschlüsselt wurde. Das ist ein bewusster Tradeoff: Weil die Verschlüsselung nur vom nsec abhängt, kann ein Nutzer, der seinen nsec sichert, seine gesamte Nachrichtenhistorie von jedem Relay wiederherstellen, das die gift wraps noch speichert. Protokolle wie MLS, wie es von [Marmot](/de/topics/marmot/) genutzt wird, bieten forward secrecy durch rotierendes Schlüsselmaterial, aber um den Preis von notwendiger State-Synchronisierung und der Unmöglichkeit, historische Nachrichten nach einer Schlüsselrotation wiederherzustellen.
+
+NIP-17 definiert außerdem kind `15` für verschlüsselte Dateinachrichten. Dieser fügt die Tags `file-type`, `encryption-algorithm`, `decryption-key` und `decryption-nonce` hinzu, damit der Empfänger eine angehängte Datei entschlüsseln kann, die vor dem Upload auf einen Blossom-Server mit AES-GCM verschlüsselt wurde. kind `10050` wird genutzt, um die bevorzugte DM-Relay-Liste des Nutzers zu veröffentlichen, damit Absender wissen, wohin sie gift wraps zustellen sollen. Die Menge aus `pubkey`- und `p`-Tags in einer Nachricht definiert einen Chatraum, und das Hinzufügen oder Entfernen eines Teilnehmers erzeugt einen neuen Raum mit sauberer Historie.
+
+Implementierungen decken die meisten großen Clients ab. [nospeak](https://github.com/psic4t/nospeak) nutzt NIP-17 für sämtliche Eins-zu-eins-Nachrichten. [Flotilla](https://gitea.coracle.social/coracle/flotilla) nutzt NIP-17 für seine Proof-of-Work-DMs. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel) und [Coracle](https://github.com/coracle-social/coracle) implementieren NIP-17 alle als ihr primäres DM-Protokoll. Die Spezifikation unterstützt auch verschwindende Nachrichten durch Setzen eines `expiration`-Tags im gift wrap.
+
+## NIP Deep Dive: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) definiert ein Protokoll, das den privaten Schlüssel des Nutzers von der Client-Anwendung trennt. Statt einen nsec in eine Web-App einzufügen, betreibt der Nutzer einen Remote Signer, auch "bunker" genannt, der den privaten Schlüssel hält und über Nostr-Relays auf Signing-Anfragen antwortet. Der Client sieht den privaten Schlüssel nie. Das reduziert die Angriffsfläche: Ein kompromittierter Client kann Signaturen anfordern, den Schlüssel selbst aber nicht extrahieren.
+
+Das Protokoll nutzt kind `24133` sowohl für Requests als auch für Responses, verschlüsselt mit [NIP-44](/de/topics/nip-44/) (Encrypted Payloads). Ein Client erzeugt für die Session ein Wegwerf-`client-keypair` und kommuniziert mit dem Remote Signer über NIP-44-verschlüsselte Nachrichten, die mit den pubkeys des jeweils anderen getaggt sind. Hier ist eine Signing-Anfrage von einem Client an einen Remote Signer:
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+Das verschlüsselte `content` enthält eine JSON-RPC-ähnliche Struktur:
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+Der Remote Signer entschlüsselt die Anfrage, legt sie dem Nutzer zur Freigabe vor, oder genehmigt sie automatisch auf Basis konfigurierter Berechtigungen, signiert das Event mit dem privaten Schlüssel des Nutzers und gibt das signierte Event in einer Response zurück:
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Verbindungen können von beiden Seiten initiiert werden. Ein Remote Signer stellt eine `bunker://`-URL bereit, die seinen pubkey und Relay-Informationen enthält. Ein Client stellt eine `nostrconnect://`-URL mit seinem Client-pubkey, Relays und einem Secret zur Verbindungsüberprüfung bereit. Der Parameter `secret` verhindert Connection-Spoofing: Nur die Partei, die die URL außerhalb des Protokolls erhalten hat, kann den Handshake abschließen.
+
+Acht Methoden sind definiert: `connect` zum Aufbau der Session, `sign_event` zum Signieren von Events, `get_public_key` zum Abrufen des pubkeys des Nutzers, `ping` für Keepalive, `nip04_encrypt` und `nip04_decrypt` für Legacy-Verschlüsselung, `nip44_encrypt` und `nip44_decrypt` für aktuelle Verschlüsselung sowie `switch_relays` für Relay-Management. Relay-Migration wird vom Remote Signer behandelt, der die Verbindung im Lauf der Zeit auf neue Relays verschieben kann, ohne die Session zu unterbrechen.
+
+Clients fordern beim Verbindungsaufbau spezifische Fähigkeiten über ein Berechtigungssystem an. Ein Berechtigungsstring wie `nip44_encrypt,sign_event:1,sign_event:14` fordert Zugriff auf NIP-44-Verschlüsselung und Signing-Rechte nur für Events mit kind `1` und kind `14` an. Der Remote Signer kann diese Berechtigungen akzeptieren, ablehnen oder verändern. Das bedeutet, dass ein Web-Client zum Lesen und Posten von Notizen vielleicht nur `sign_event:1` erhält, während ein DM-Client zusätzlich `sign_event:14` und `nip44_encrypt` bekommen kann.
+
+[Amber](https://github.com/greenart7c3/Amber) implementiert NIP-46 auf Android, und [v6.0.0-pre1](#amber-v600-pre1-fügt-signing-keys-pro-verbindung-für-nip-46-hinzu) dieser Woche fügt signing keys pro Verbindung hinzu, um Clients voneinander zu isolieren. [nsec.app](https://github.com/nicktee/nsecapp), früher Nostr Connect, bietet einen webbasierten bunker. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) enthält `BunkerSigner` für JavaScript-Clients, und [PR #530 der letzten Woche](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) fügte `skipSwitchRelays` für manuelles Relay-Management hinzu. Das Protokoll unterstützt außerdem Auth-Challenges: Wenn ein Remote Signer zusätzliche Authentifizierung benötigt, also Passwort, Biometrie oder Hardware-Token, antwortet er mit einer `auth_url`, die der Client in einem Browser öffnet, damit der Nutzer den Vorgang abschließen kann.
+
+---
+
+Das war's für diese Woche. Baust du etwas oder hast Neuigkeiten zu teilen? Schreib uns eine DM auf Nostr oder finde uns auf [nostrcompass.org](https://nostrcompass.org).

--- a/content/es/newsletters/2026-04-08-newsletter.md
+++ b/content/es/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Bienvenido de nuevo a Nostr Compass, tu guía semanal de Nostr.
+
+**Esta semana:** [Amethyst](https://github.com/vitorpamplona/amethyst) lanza [v1.08.0](#amethyst-lanza-arti-tor-y-fusiona-mls-y-marmot-puros-en-kotlin) con integración de Arti Tor y una UI de Shorts rediseñada, mientras fusiona implementaciones puras en Kotlin de [MLS](/es/topics/mls/) y [Marmot](/es/topics/marmot/) en su librería [Quartz](/es/topics/quartz/). [Nostur](https://github.com/nostur-com/nostur-ios-public) lanza [v1.27.0](#nostur-v1270-añade-grabación-de-vídeo-y-respuestas-privadas) con grabación de vídeo, perfiles con GIF animados y respuestas privadas. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) lanza [v0.15.0](#shosho-v0150-lanza-shows-y-carrusel-vertical-de-vídeo) con Shows (información personalizada de live stream conectada a OBS) y un carrusel vertical de vídeo al estilo TikTok. [Nymchat](https://github.com/Spl0itable/NYM) [revierte Marmot y lanza chats grupales NIP-17 mejorados](#nymchat-revierte-marmot-y-lanza-chats-grupales-nip-17-mejorados) con claves efímeras rotativas. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) lanza [soporte de exit node y empaquetado para Umbrel](#nostr-vpn-lanza-soporte-de-exit-node-y-empaquetado-para-umbrel) a lo largo de seis releases. [Amber](https://github.com/greenart7c3/Amber) salta a [v6.0.0-pre1](#amber-v600-pre1-añade-claves-de-firma-nip-46-por-conexión) con claves de firma [NIP-46](/es/topics/nip-46/) por conexión y actualizaciones dentro de la app mediante Zapstore. [Notedeck](https://github.com/damus-io/notedeck) alcanza [v0.10.0-beta](#notedeck-v0100-beta-lanza-autoactualización-con-zapstore) con autoactualización de APK vía Zapstore, y [NIP-58](/es/topics/nip-58/) (Badges) recibe una [migración de kind](#actualizaciones-de-nips). Dos análisis en profundidad de NIP cubren [NIP-17](/es/topics/nip-17/) (Private Direct Messages) y [NIP-46](/es/topics/nip-46/) (Nostr Remote Signing).
+
+## Noticias principales
+
+### Amethyst lanza Arti Tor y fusiona MLS y Marmot puros en Kotlin
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), el cliente Android mantenido por vitorpamplona, lanzó cuatro releases desde [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) hasta [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) y fusionó un gran lote de trabajo aún no publicado en su librería [Quartz](/es/topics/quartz/) (el módulo Nostr compartido de Kotlin Multiplatform). El release principal es v1.08.0 "Arti Tor", que migra la conectividad Tor de la app desde la librería Tor basada en C a [Arti](https://gitlab.torproject.org/tpo/core/arti), la implementación en Rust del Tor Project. La migración aborda crashes aleatorios que ocurrían con los bindings anteriores de C Tor. Arti es el reemplazo a largo plazo del Tor Project para la base de código en C, escrito desde cero en Rust para seguridad de memoria y async I/O.
+
+El release v1.07.3 rediseñó la UI de Shorts, reemplazando el diseño paginado por feeds de borde a borde para imágenes, shorts y vídeos largos. El mismo release migró badges a kind `10008` y bookmarks a kind `10003`, alineándose con la migración de kind de [NIP-58](/es/topics/nip-58/) [fusionada esta semana](#actualizaciones-de-nips). v1.07.4 corrigió un problema en el manejo de secretos de Nostr Wallet Connect, y v1.07.5 corrigió un crash en la subida de imágenes.
+
+En main, pero todavía no en un release etiquetado, el equipo escribió una implementación completa en Kotlin tanto de [MLS](/es/topics/mls/) como del protocolo [Marmot](/es/topics/marmot/), reemplazando la necesidad de bindings nativos de bibliotecas C/Rust. [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) añade la capa central de mensajería grupal Marmot MLS, [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) añade la UI de chat grupal, [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) añade procesadores de mensajes entrantes y salientes con un gestor de suscripciones, [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) añade persistencia del estado de grupos MLS y gestión de rotación de KeyPackage, [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) añade una suite completa de tests de MLS con firma de GroupInfo mejorada, y [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) añade seguimiento del estado de publicación de KeyPackage. [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) añade una implementación pura en Kotlin de secp256k1 para operaciones criptográficas de Nostr, reemplazando la dependencia de la biblioteca nativa en C. Combinado con la implementación MLS en Kotlin, [Quartz](/es/topics/quartz/) puede ejecutar firma Nostr y mensajería grupal Marmot sin ningún binding nativo, lo que abre la puerta a objetivos de Kotlin Multiplatform, incluyendo iOS.
+
+El equipo también está construyendo soporte para [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls): [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) añade una suite completa de tests para la máquina de estados de llamadas NIP-AC, y [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) evita que ofertas de llamada obsoletas se disparen de nuevo después de reiniciar la app.
+
+### Nostur v1.27.0 añade grabación de vídeo y respuestas privadas
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), el cliente Nostr para iOS, lanzó [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) el 2 de abril. El release añade grabación de vídeo dentro de la app con recorte antes de subir, de modo que los usuarios puedan capturar clips cortos, ajustarlos a la duración deseada y publicarlos sin salir del cliente. El soporte para GIF animados se extiende a fotos de perfil y banner, y también se añadió renderizado de WebP animado. Una nueva integración con Shortcuts permite a los usuarios enviar publicaciones de Nostr desde automatizaciones de Apple Shortcuts. El release también añade respuestas privadas y corrige problemas de compatibilidad de DMs que afectaban la entrega de mensajes entre Nostur y otros clientes.
+
+### Shosho v0.15.0 lanza Shows y carrusel vertical de vídeo
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), la app de live streaming sobre Nostr, lanzó [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) y [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) el 7 de abril. La función principal es Shows: los streamers pueden configurar información personalizada del show antes de salir en vivo y conectar su show a OBS o a cualquier codificador externo. Esto separa los metadatos de "qué estoy transmitiendo" del acto de entrar en directo, de modo que los streamers puedan preparar títulos, descripciones y productos antes de empezar a emitir. El mismo release añade un carrusel vertical de vídeo al estilo TikTok para deslizar entre lives, clips y replays en un feed a pantalla completa, y Quick Add para publicar clips de vídeo y añadir productos directamente desde una página de perfil. v0.15.1 corrige un bug por el que el teclado ocultaba el campo de entrada del chat del live stream.
+
+## Lanzamientos de esta semana
+
+### Notedeck v0.10.0-beta lanza autoactualización con Zapstore
+
+[Notedeck](https://github.com/damus-io/notedeck), el cliente de escritorio y móvil del equipo Damus, lanzó [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) y [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) como prereleases de prueba para autoactualización de APK. [PR #1417](https://github.com/damus-io/notedeck/pull/1417) añade autoactualización de APK a través del actualizador Nostr/Zapstore en Android, construyendo sobre el [trabajo de descubrimiento de actualizaciones nativo de Nostr cubierto en Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr). El flujo de actualización descubre nuevos releases a través de eventos Nostr publicados en relays, luego descarga el APK desde donde el desarrollador lo aloje (GitHub releases, Blossom CDN u otras fuentes), verifica el hash SHA-256 contra el evento Nostr firmado y lo instala. [PR #1438](https://github.com/damus-io/notedeck/pull/1438) corrige un bug en la pantalla de bienvenida donde los botones Login y CreateAccount volvían inmediatamente hacia atrás, y [PR #1424](https://github.com/damus-io/notedeck/pull/1424) corrige desbordamiento de texto en la vista de sesión de Agentium AI.
+
+### Amber v6.0.0-pre1 añade claves de firma NIP-46 por conexión
+
+[Amber](https://github.com/greenart7c3/Amber), la app firmante [NIP-55](/es/topics/nip-55/) (Android Signer Application), lanzó [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) el 4 de abril. El cambio más importante son las claves de firma por conexión para el protocolo bunker [NIP-46](/es/topics/nip-46/) (Nostr Remote Signing). En lugar de usar un único keypair para todas las conexiones bunker, Amber ahora genera una clave distinta para cada cliente conectado. Si una conexión de cliente se ve comprometida, el atacante no puede suplantar al firmante frente a otros clientes.
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377) añade comprobación e instalación de actualizaciones dentro de la app vía Zapstore, uniéndose a [Notedeck](#notedeck-v0100-beta-lanza-autoactualización-con-zapstore) en la adopción de distribución de apps nativa de Nostr. [PR #375](https://github.com/greenart7c3/Amber/pull/375) maneja los fallos de AndroidKeyStore de forma elegante mostrando una advertencia a los usuarios en lugar de crashear, y [PR #371](https://github.com/greenart7c3/Amber/pull/371) añade limpieza de base de datos con límites de tamaño y truncado de contenido para evitar crecimiento ilimitado del almacenamiento. El prerelease también incluye la whitelist de auth de relay [NIP-42](/es/topics/nip-42/) y el login con frase mnemónica de recuperación del [ciclo v5.0.x cubierto la semana pasada](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria lanza app móvil nativa
+
+[Nostria](https://github.com/nostria-app/nostria), el cliente Nostr multiplataforma mantenido por SondreB, lanzó una app móvil nativa para Android con ocho releases desde [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) hasta [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). La capacidad nueva más importante es el soporte nativo de firmante local para firmantes como [Amber](https://github.com/greenart7c3/Amber) y Aegis. También hay [instaladores de escritorio](https://www.nostria.app/download) para Linux, macOS y Windows. [PR #610](https://github.com/nostria-app/nostria/pull/610) reduce la presión de memoria del feed con límites adaptativos de runtime y limpieza de URLs de preview. v3.1.14 corrige la integración con Brainstorm, un proveedor de [Web of Trust](/es/topics/web-of-trust/). v3.1.15 se centra en mejoras de música. La nueva app Android está disponible en [Zapstore](https://zapstore.dev/apps/app.nostria).
+
+### diVine 1.0.8 lanza subidas reanudables y DMs
+
+[diVine](https://github.com/divinevideo/divine-mobile), el cliente de vídeo de formato corto, lanzó [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) con 87 PRs fusionados. Las subidas reanudables permiten a los creadores retomar subidas interrumpidas bloque por bloque en lugar de reiniciar desde cero en una conexión inestable. El release añade ajustes de calidad y bitrate de vídeo, doble toque para dar like y mejoras en DMs. [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) añade un plugin de cámara para macOS para captura de vídeo de escritorio, y [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migra el sistema de notificaciones a una arquitectura BLoC con enriquecimiento y agrupación. El equipo también reemplazó stickers y arte de categorías generados por AI con SVGs de OpenMoji ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 añade difuminado de notas sensibles y auth NIP-42
+
+[Manent](https://github.com/dtonon/manent), la app privada de notas cifradas y almacenamiento de archivos, lanzó [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) el 2 de abril. Los usuarios ahora pueden marcar notas como sensibles para difuminarlas en la vista de lista, manteniendo el contenido privado oculto durante el desplazamiento casual. El release también añade soporte para [NIP-42](/es/topics/nip-42/) (Authentication of Clients to Relays), permitiendo a Manent autenticarse en relays que lo exigen antes de aceptar eventos. Manent almacena todos los datos cifrados en relays Nostr usando el keypair del usuario, así que el soporte NIP-42 amplía el conjunto de relays que puede usar para almacenamiento.
+
+### Wisp v0.17.0 a v0.17.3 añaden zaps en live streams y backup de billetera
+
+[Wisp](https://github.com/barrydeen/wisp), el cliente Nostr para Android, lanzó seis releases desde [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) hasta [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) con 44 PRs fusionados. El release v0.17.0 añade avisos de seguridad para backup de billetera y mejoras de UX para zaps. [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) añade visibilidad del chat de live stream entre plataformas y funcionalidad de zaps en live streams. [PR #423](https://github.com/barrydeen/wisp/pull/423) añade auto-búsqueda de perfiles, una animación de zap exitoso y mejoras en el estado de usuario. [PR #426](https://github.com/barrydeen/wisp/pull/426) corrige un crash por falta de memoria en `computeId` para eventos con listas grandes de tags. Los releases v0.16.x añadieron autocompletado de shortcode de emoji, mejoras de UI para chats grupales y filtrado de usuarios bloqueados en todas las rutas de notificaciones.
+
+### Mostro lanza deep links, tipos de cambio de Nostr y una corrección de pagos duplicados
+
+[Mostro](https://github.com/MostroP2P/mostro), el exchange peer-to-peer de Bitcoin construido sobre Nostr, recibió actualizaciones tanto en su daemon de servidor como en su cliente móvil esta semana. Del lado del servidor, [PR #692](https://github.com/MostroP2P/mostro/pull/692) evita que escrituras obsoletas de órdenes provoquen pagos duplicados, un bug que podía hacer que un vendedor recibiera el pago dos veces por la misma operación. [PR #693](https://github.com/MostroP2P/mostro/pull/693) usa actualizaciones dirigidas para escrituras de dev_fee en lugar de sobrescribir la orden completa.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), el cliente Flutter, lanzó [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) el 3 de abril. El release maneja deep links de distintas instancias de Mostro, de modo que los usuarios puedan tocar enlaces que enruten al servidor de exchange correcto. [PR #498](https://github.com/MostroP2P/mobile/pull/498) detecta DMs de admin y disputa en el pipeline de notificaciones en segundo plano, y la app ahora obtiene tipos de cambio desde Nostr con fallback HTTP/cache. [PR #560](https://github.com/MostroP2P/mobile/pull/560) corrige un bug de bloqueo en la conexión al relay que impedía a la app alcanzar relays bajo ciertas condiciones de red.
+
+### Unfiltered v1.0.12 añade hashtags y comentarios
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), un cliente Nostr enfocado en contenido visual, lanzó [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12). [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) añade soporte para hashtags y [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) añade la capacidad de escribir y mostrar comentarios en publicaciones. [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) corrige problemas de navegación con múltiples imágenes por publicación.
+
+### Primal Android lanza uso compartido de billetera entre múltiples cuentas y auto-reconexión del firmante remoto
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), el cliente Nostr para Android, lanzó un release el 7 de abril. La actualización añade uso compartido de billetera entre múltiples cuentas y un menú overflow con eliminación de billetera en Dev Tools. El firmante remoto ahora se reconecta automáticamente cuando cae la conexión, y el servicio de billetera recibió su propia lógica de auto-reconexión. Entre las correcciones están que los votos zap de encuestas ya no aparecen como Top Zaps, la prevención de crashes por opciones vacías en encuestas, el ocultamiento del balance de billetera cuando no existe ninguna y el mapeo de tipos WalletException a códigos de error en respuestas NWC.
+
+### Titan v0.1.0 lanza navegador nativo nsite:// con registro de nombres en Bitcoin
+
+[Titan](https://github.com/btcjt/titan), un navegador nativo de escritorio para la web de Nostr, lanzó [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) el 7 de abril. Titan resuelve URLs `nsite://` buscando nombres legibles por humanos registrados en Bitcoin, consultando relays Nostr para los eventos de contenido del sitio y renderizando páginas obtenidas desde servidores [Blossom](/es/topics/blossom/). El resultado es una experiencia de navegación web sin DNS, sin certificados TLS y sin proveedores de hosting. Los nombres se registran a través de una [interfaz web](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) vinculada a transacciones de Bitcoin. El release inicial se distribuye como `.dmg` de macOS (ARM, con soporte Rosetta 2 para Intel) e incluye soporte para entorno de desarrollo Nix.
+
+### Bikel v1.5.0 lanza servicio nativo en primer plano para teléfonos de-Googled
+
+[Bikel](https://github.com/Mnpezz/bikel), un tracker de ciclismo descentralizado que convierte recorridos en datos de infraestructura pública usando Nostr, lanzó [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) el 4 de abril. El release migra desde Expo TaskManager dependiente de GMS a un servicio nativo personalizado en primer plano, asegurando seguimiento confiable de recorridos en segundo plano en LineageOS, GrapheneOS y otras variantes Android de-Googled. El Bikel Bot ganó una arquitectura de doble bolsillo con recolección autónoma de eCash mediante Cashu nutzaps. v1.4.3 y v1.4.2 corrigen la sincronización del tracking en segundo plano para entornos Android no estándar, y la app añade toggles para puntos de mapa de aparcabicis OSM.
+
+### Sprout añade soporte para NIP-01, NIP-23 y NIP-33
+
+[Sprout](https://github.com/block/sprout), una plataforma de comunicación de Block con relay Nostr integrado, lanzó [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) el 6 de abril. Esta semana el equipo añadió soporte para artículos kind `30023` de [NIP-23](/en/topics/nip-23/) (Long-form Content), eventos reemplazables parametrizados de [NIP-33](/en/topics/nip-33/) con reemplazo claveado por tag `d`, y notas de texto kind `1` y listas de follows kind `3` de [NIP-01](/es/topics/nip-01/)/[NIP-02](/en/topics/nip-02/). El release también añade un sistema adaptativo de temas IDE con 54 temas, mejoras de UX para historial de workflows y ejecuciones de agentes, y una limpieza de la barra lateral de miembros.
+
+### mesh-llm v0.56.0 lanza protocolo de configuración distribuida
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), un sistema distribuido de inferencia LLM que usa keypairs Nostr para identidad de nodo, lanzó [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) el 7 de abril. El release añade un protocolo de configuración distribuida con semántica de ownership, cuantización asimétrica de KV cache (claves Q8_0 con valores Q4) para reducir el uso de memoria, almacenamiento en keychain del sistema para keystores de identidad, streaming fluido de chat con cola de mensajes, y correcciones para el layout fullscreen y el particionado de KV cache con flash attention.
+
+### Nostr VPN lanza soporte de exit node y empaquetado para Umbrel
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), una VPN peer-to-peer que usa relays Nostr para señalización y WireGuard para túneles cifrados, lanzó seis releases desde [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) hasta [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) esta semana. El ciclo v0.3.x añade soporte de exit node en Windows y macOS, permitiendo que peers enruten tráfico de internet a través de otros nodos de la red. La propagación de invites y aliases ahora se sincroniza sobre Nostr, así que los usuarios pueden compartir acceso a la red sin coordinación fuera de banda. Los releases añaden empaquetado para Umbrel en despliegues autoalojados, NAT punch-through usando endpoints públicos recordados, limpieza automática de exit nodes obsoletos y una especificación de protocolo publicada. El proyecto también estabilizó el manejo de rutas en macOS con default routes autorreparables y reparación de underlay, y añadió una build Android vía Tauri. Hay builds disponibles para macOS (Apple Silicon e Intel), Linux (AppImage y .deb), Windows y Android.
+
+### Nymchat revierte Marmot y lanza chats grupales NIP-17 mejorados
+
+[Nymchat](https://github.com/Spl0itable/NYM), el cliente de chat con capacidad MLS, lanzó 14 releases desde [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) hasta [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274). El cambio más significativo es un giro de protocolo: [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) añadió chats grupales Marmot MLS, pero [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) revirtió a [NIP-17](/es/topics/nip-17/) porque el soporte multidispositivo de Marmot aún no está terminado, lo que causaba problemas con la sincronización del estado del chat grupal entre dispositivos. v3.58.271 introduce chats grupales NIP-17 mejorados con claves efímeras rotativas para todos los mensajes, diseñadas para prevenir ataques de timing y correlación. La semana también trajo un sistema de amigos con control granular de ajustes ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), sincronización de mensajes de chat grupal MLS en ajustes cifrados de la app, y múltiples correcciones de conectividad con relays.
+
+### nak v0.19.5 añade Blossom multi-servidor y publicación outbox
+
+[nak](https://github.com/fiatjaf/nak), el toolkit de línea de comandos Nostr de fiatjaf, lanzó [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5). El comando `blossom` ahora acepta múltiples flags `--server` para subir a varios servidores [Blossom](/es/topics/blossom/) en una sola llamada. Un nuevo comando `key` amplía claves parciales rellenando con ceros por la izquierda. El comando `event` gana un flag `--outbox` para publicar eventos a través del modelo outbox, y `fetch` ahora sale con código de error cuando no se devuelve ningún evento.
+
+## En desarrollo
+
+### White Noise añade previews con thumbhash y puente de registro push
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), el mensajero privado construido sobre el protocolo [Marmot](/es/topics/marmot/), fusionó cinco PRs. [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) reemplaza previews de imagen con blurhash por thumbhash, un algoritmo más nuevo que produce imágenes placeholder más nítidas con un payload más pequeño (normalmente menos de 30 bytes frente a los ~50-100 bytes de blurhash) mientras preserva la proporción y distribución de color de la imagen original. Blurhash se mantiene como fallback para contenido antiguo. [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) actualiza whitenoise-rs y añade el puente de registro push [MIP-05](/es/topics/mip-05/), conectando el [trabajo de especificación de notificaciones push de la semana pasada](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications) con el cliente. [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) añade paginación basada en cursor para mensajes de chat, reemplazando la estrategia anterior de carga por un enfoque guiado por scroll.
+
+### Route96 añade configuración dinámica de etiquetas y limpieza de zero-egress
+
+[Route96](https://github.com/v0l/route96), el servidor de medios [Blossom](/es/topics/blossom/) de v0l, fusionó tres PRs. [PR #80](https://github.com/v0l/route96/pull/80) añade configuración dinámica del modelo de etiquetas vía la API de admin, permitiendo a los operadores cambiar modelos de clasificación de contenido sin reiniciar el servidor. [PR #82](https://github.com/v0l/route96/pull/82) añade campos de configuración de etiquetas a la UI de admin. [PR #79](https://github.com/v0l/route96/pull/79) añade una política de limpieza de archivos zero-egress que elimina automáticamente archivos que nunca se han descargado, manteniendo bajos los costes de almacenamiento para los operadores.
+
+### Snort lanza endurecimiento de seguridad e invoices de pago para DVM
+
+[Snort](https://github.com/v0l/snort), el cliente web, lanzó dos releases esta semana con una auditoría de seguridad integral. Las correcciones incluyen verificación de firma Schnorr, protección frente a falsificación de mensajes de relay [NIP-46](/es/topics/nip-46/) (evitando que atacantes inyecten solicitudes de firma a través de relays comprometidos), mejoras en cifrado de PIN y eliminación de la confianza en delegación NIP-26. Las ganancias de rendimiento vienen de verificación Schnorr por lotes en WASM, rutas con lazy loading, traducciones precompiladas y eliminación de verificación doble por evento. [PR #618](https://github.com/v0l/snort/pull/618) añade la visualización de invoice requerido por pago para kind `7000` de [NIP-90](/en/topics/nip-90/) (Data Vending Machine), de modo que cuando un DVM responde con un requisito de pago, Snort renderiza el invoice Lightning directamente en el feed.
+
+### Damus mejora la compactación de LMDB
+
+[Damus](https://github.com/damus-io/damus), el cliente iOS, fusionó [PR #3719](https://github.com/damus-io/damus/pull/3719) que añade compactación automática programada de LMDB, evitando que la base de datos local crezca sin límite con el tiempo. [PR #3663](https://github.com/damus-io/damus/pull/3663) mejora BlurOverlayView para que parezca protector en lugar de roto.
+
+### Captain's Log añade indexación de tags y sincronización de notas
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), la herramienta de escritura long-form nativa de Nostr de Nodetec, fusionó cuatro PRs esta semana. [PR #156](https://github.com/nodetec/captains-log/pull/156) añade indexación de tags y soporte de sincronización entre notas, [PR #157](https://github.com/nodetec/captains-log/pull/157) refactoriza la sincronización de notas y el manejo de tags, y [PR #159](https://github.com/nodetec/captains-log/pull/159) corrige la sincronización de notas enviadas a la papelera para que las notas eliminadas permanezcan eliminadas entre dispositivos.
+
+### Relatr v0.2.x rediseña su sistema de plugins con marketplace nativo de Nostr para validadores
+
+[Relatr](https://github.com/ContextVM/relatr), un motor de puntuación de [Web of Trust](/es/topics/web-of-trust/) que calcula rankings de confianza a partir de la distancia en el grafo social y validadores configurables, lanzó la familia v0.2.x con un rediseño completo del sistema de plugins. Los validadores ahora se escriben en Elo, un lenguaje portable de expresiones funcionales bifurcado para soportar capacidades de múltiples pasos orquestadas por el host (consultas Nostr, búsquedas en el grafo social, resolución NIP-05). Los plugins se publican como eventos Nostr kind `765`, haciendo que la distribución sea nativa de la red de relays. Un nuevo [plugin marketplace](https://relatr.net) permite a operadores descubrir, instalar y ponderar validadores desde el navegador, con un CLI (`relo`) para autoría y publicación local. La arquitectura está aislada: los plugins solo pueden invocar capacidades que el host proporcione explícitamente, así que un validador malicioso no puede escapar de su ámbito definido. Las instancias de Relatr ahora pueden gestionarse desde el sitio web, con visibilidad completa de qué plugins componen el algoritmo de puntuación y sus pesos individuales.
+
+### Shopstr mejora la navegación móvil y el control de acceso
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), el marketplace nativo de Nostr para comprar y vender con Bitcoin, empujó 158 commits en su app principal y el proyecto complementario [Milk Market](https://github.com/shopstr-eng/milk-market) esta semana. Las correcciones incluyen mejoras en el layout de comunidades en móvil, comportamiento de cerrar menú al navegar y autocierre de dropdowns. Las rutas protegidas ya no pueden abrirse vía URL directa sin iniciar sesión, y la lógica de coincidencia de slugs ahora maneja correctamente múltiples coincidencias exactas.
+
+### Pollerama añade notificaciones, búsqueda de películas y UI de valoración
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), una app de encuestas, sondeos y ratings sociales construida sobre Nostr, añadió notificaciones de hilos, una función de búsqueda de películas y una revisión de la UI de valoración. El release también corrige problemas de carga del feed y actualiza versiones de dependencias.
+
+### Purser construye daemon de pagos nativo de Nostr con cifrado Marmot
+
+[Purser](https://github.com/EthnTuttle/purser), un daemon de pagos nativo de Nostr diseñado como reemplazo de Zaprite, fusionó nueve PRs esta semana construyendo su arquitectura central. El proyecto usa MLS de [Marmot](/es/topics/marmot/) vía MDK para mensajería cifrada entre comerciante y cliente, con Strike y Square como proveedores de pagos. Esta semana aterrizaron carga de config y catálogo, validación de esquema de mensajes, la capa de comunicación MDK, implementaciones de proveedores Strike y Square, un motor de polling, limitación anti-spam, persistencia de pagos pendientes y el pipeline de procesamiento de órdenes. Los 99 tests ahora ejercitan operaciones MLS reales de mdk-core después de que el equipo eliminara mock MLS en favor de cifrado real en modo local.
+
+### Vector refactoriza adjuntos de DMs y añade edición de perfil
+
+[Vector](https://github.com/VectorPrivacy/Vector), el mensajero Nostr centrado en privacidad construido con Tauri, fusionó [PR #55](https://github.com/VectorPrivacy/Vector/pull/55) refactorizando el frontend. El descifrado y guardado de adjuntos de DM se movió a la librería vector-core, y la app ahora soporta edición de perfil. La flag de cancelación de subida quedó correctamente conectada a través de TauriSendCallback, y se limpiaron callbacks de preview de adjuntos sin uso.
+
+## Trabajo de protocolo y especificación
+
+### Actualizaciones de NIPs
+
+Cambios recientes en el [repositorio de NIPs](https://github.com/nostr-protocol/nips):
+
+**Fusionados:**
+
+- **[NIP-58](/es/topics/nip-58/) (Badges): Profile Badges pasan a kind 10008, Badge Sets a kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Migra Profile Badges desde kind `30008` a kind `10008` (un evento reemplazable, uno por pubkey) e introduce kind `30008` para Badge Sets. Antes, Profile Badges usaba el mismo kind (`30008`) que las definiciones de Badge, lo que los convertía en eventos reemplazables parametrizados claveados por un tag `d`. El nuevo kind `10008` es un evento reemplazable simple: uno por pubkey, sin necesidad de tag `d`. Los clientes consultan un único evento reemplazable por usuario en lugar de escanear eventos reemplazables parametrizados. Amethyst v1.07.3 ya distribuye esta migración.
+
+- **[NIP-34](/es/topics/nip-34/) (Git Stuff): Añadir listas de follows relacionadas con git** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): Añade convenciones de listas de follows para seguimiento de repositorios y issues de NIP-34. Los usuarios publican follow sets kind `30000` con tags `d` como `git-repos` o `git-issues` que contienen referencias de tag `a` a repositorios (kind `30617`) que quieren seguir. Los clientes pueden suscribirse a estos follow sets para mostrar actividad de repositorios en el feed de un usuario, de forma similar a como funcionan las listas de contactos kind `3` para pubkeys.
+
+**PRs abiertos y discusiones:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): Amplía el NIP-100 original (implementado por 0xChat) con tres cambios: migración a cifrado [NIP-44](/es/topics/nip-44/) envuelto en gift wraps [NIP-59](/es/topics/nip-59/) para eliminar fugas de metadatos, un flujo WebRTC especificado para la configuración de llamadas de voz y vídeo (offer, answer, candidatos ICE), y un modelo mesh de llamadas grupales donde cada peer establece una conexión WebRTC directa con todos los demás peers. La especificación no es retrocompatible con NIP-100. Amethyst ya está construyendo contra ella, con una suite de tests para la máquina de estados de llamadas ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) y manejo de ofertas de llamada obsoletas ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)) aterrizando esta semana.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Propone convenciones para firma threshold de [FROST](/es/topics/frost/) (Flexible Round-Optimized Schnorr Threshold) en Nostr. FROST permite que un grupo de firmantes controle colectivamente una identidad Nostr donde cualquier subconjunto t-de-n puede firmar eventos sin reconstruir la clave privada completa. El NIP define cómo coordinar rondas de firma, distribuir key shares y publicar eventos firmados de forma threshold, construyendo sobre el trabajo del firmante Igloo del [proyecto FROSTR](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Define un protocolo `postMessage` para aplicaciones web aisladas ("napplets") que corren en iframes y se comunican con una aplicación anfitriona ("shell"). El shell proporciona a la napplet firma Nostr, acceso a relay y contexto de usuario mediante una API estructurada de mensajes, mientras el sandbox del iframe evita acceso directo a claves. Esto extiende el modelo de hosting de sitios web estáticos de [NIP-5A](/en/topics/nip-5a/) hacia aplicaciones interactivas que pueden leer y escribir eventos Nostr. El NIP está en desarrollo activo con una implementación de runtime funcional.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): Renombrado desde la propuesta anterior NIP-A5. Define convenciones para publicar y descubrir programas WebAssembly en Nostr. Los binarios WASM se almacenan como eventos Nostr, y los clientes pueden descargarlos y ejecutarlos en un runtime aislado. Una [demo app](https://nprogram.netlify.app/) muestra scrolls corriendo en el navegador, con programas de ejemplo publicados como eventos Nostr que cualquier cliente puede obtener y ejecutar.
+
+- **[NIP-85](/es/topics/nip-85/) (Trusted Assertions): Aclaraciones** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): Ajusta el lenguaje de la especificación alrededor de múltiples claves y relays por proveedor de servicio, aclarando cómo deberían manejar los clientes afirmaciones de proveedores que operan a través de varios pubkeys o endpoints de relay.
+
+- **[NIP-24](/es/topics/nip-24/) (Extra Metadata Fields): `published_at` para eventos reemplazables** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): Generaliza el tag `published_at` de [NIP-23](/en/topics/nip-23/) (Long-form Content) a todos los eventos reemplazables y direccionables. El tag es solo de visualización: si `published_at` es igual a `created_at`, los clientes muestran el evento como "created" en ese momento; si difieren (porque el evento fue actualizado), los clientes pueden mostrar "updated" en su lugar. Esto permite que perfiles kind `0` muestren fechas de "joined at" y que otros eventos reemplazables preserven su marca de tiempo de publicación original a través de actualizaciones. Una propuesta complementaria de [NIP-51](/es/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) añade el mismo tag a eventos de listas.
+
+- **[NIP-59](/es/topics/nip-59/) (Gift Wrap): kind efímero de gift wrap** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): Añade kind `21059` como contraparte efímera del gift wrap kind `1059` existente. Los eventos efímeros (kinds `20000`-`29999`) siguen la semántica de [NIP-01](/es/topics/nip-01/): no se espera que los relays los almacenen y pueden descartarlos tras la entrega. Esto permite a las aplicaciones enviar mensajes envueltos en gift wrap que desaparecen de los relays una vez entregados, reduciendo requisitos de almacenamiento para mensajería de alto volumen mientras conservan el mismo modelo de cifrado de tres capas que los DMs regulares de [NIP-17](/es/topics/nip-17/).
+
+### OpenSats anuncia la decimosexta ola de grants de Nostr
+
+[OpenSats](https://opensats.org) anunció su [decimosexta ola de grants de Nostr](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) el 8 de abril, financiando cuatro grants por primera vez y una renovación. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) recibe financiación para que el colaborador Robert Nagy construya una app de escritorio independiente sobre los módulos [Quartz](/es/topics/quartz/) y Commons, llevando el conjunto de funciones del cliente Android a interfaces guiadas por ratón con conexiones persistentes a relays. [Nostr Mail](https://github.com/nogringo/nostr-mail) recibe financiación para construir un sistema completo de email sobre Nostr usando eventos kind `1301` envueltos en gift wraps [NIP-59](/es/topics/nip-59/), con un cliente Flutter y servidores puente SMTP para compatibilidad con Gmail/Outlook. [Nostrord](https://github.com/Nostrord/nostrord) recibe financiación para un cliente grupal basado en relay [NIP-29](/en/topics/nip-29/) en Kotlin Multiplatform con mensajería grupal estilo Discord, moderación e hilos. [Nurunuru](https://github.com/tami1A84/null--nostr) recibe financiación para construir una versión nativa iOS del cliente Nostr enfocado en japonés, modelado sobre la interfaz familiar de LINE, con login biométrico basado en passkeys para el onboarding. HAMSTR recibió una renovación de grant (financiado por primera vez en la [undécima ola](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)).
+
+## NIP en profundidad: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) define el estándar actual para mensajes directos privados en Nostr. Reemplaza el esquema más antiguo de [NIP-04](/es/topics/nip-04/) (Encrypted Direct Messages), que filtraba metadatos (remitente, receptor y timestamps eran visibles en los relays) y usaba una construcción de cifrado más débil. NIP-17 combina [NIP-44](/es/topics/nip-44/) (Encrypted Payloads) para el cifrado con [NIP-59](/es/topics/nip-59/) (Gift Wrap) para proteger metadatos, creando un sistema de tres capas donde los relays no pueden ver quién habla con quién.
+
+El protocolo usa tres kinds de evento apilados uno dentro de otro. La capa más interna es el mensaje real, un evento kind `14` sin firma:
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+El evento kind `14` es deliberadamente unsigned (`sig` vacío). La especificación describe esto como una forma de proporcionar negabilidad, pero en la práctica la protección es limitada. El seal kind `13` que envuelve el rumor está firmado por la clave real del remitente. Un receptor puede mostrar el seal firmado a un tercero, probando que el remitente se comunicó con él, incluso sin revelar el contenido del mensaje. Con pruebas de conocimiento cero, un receptor puede probar el contenido exacto del mensaje sin revelar su propia clave privada. El rumor unsigned es como una carta sin firmar dentro de un sobre firmado: la firma del sobre vincula al remitente con el contenido. La verdadera negabilidad requeriría autenticación simétrica (como los HMAC de Signal), lo cual es incompatible con el modelo descentralizado de relay de Nostr, donde los mensajes deben ser autoautenticables. Las fortalezas reales de NIP-17 son la privacidad de metadatos y el secreto del contenido, no la negabilidad.
+
+Este mensaje unsigned se envuelve luego en un seal kind `13`, firmado por el remitente real y cifrado con [NIP-44](/es/topics/nip-44/) para el receptor:
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+El seal no tiene tags, así que incluso si se descifrara no revelaría al receptor. El seal está firmado por la clave real del remitente, lo que permite al receptor autenticar el mensaje comprobando que el `pubkey` del seal coincide con el `pubkey` del kind `14` interno.
+
+El seal se envuelve después en un gift wrap kind `1059`, firmado por una clave aleatoria desechable y dirigido al receptor:
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+El `pubkey` del gift wrap es una clave aleatoria generada solo para este mensaje, y `created_at` se aleatoriza hasta dos días hacia el pasado. Esta es la capa más externa que los relays ven realmente: un mensaje de un pubkey desconocido dirigido al receptor, con un timestamp que no refleja cuándo se envió realmente el mensaje. El timestamp aleatorizado protege frente a análisis posteriores de eventos almacenados, pero un adversario conectado activamente a relays aún puede observar cuándo apareció por primera vez el gift wrap, así que esta defensa se limita a observadores pasivos que consultan datos del relay más tarde. Como el pubkey es aleatorio y el timestamp es falso, los relays no pueden determinar el remitente real. Para leer el mensaje, el receptor descifra el gift wrap usando su propia clave y el pubkey aleatorio, encuentra el seal dentro, descifra el seal usando su propia clave y el pubkey del remitente tomado del seal, y encuentra dentro el mensaje kind `14`.
+
+NIP-17 no proporciona forward secrecy. Todos los mensajes se cifran usando el keypair estático de Nostr (mediante la derivación de claves de NIP-44 a partir de las claves del remitente y el receptor). Si una clave privada se ve comprometida, todo mensaje pasado y futuro cifrado para esa clave puede descifrarse. Es un tradeoff deliberado: como el cifrado depende solo del nsec, un usuario que haga backup de su nsec puede recuperar todo su historial de mensajes desde cualquier relay que aún almacene los gift wraps. Protocolos como MLS (usado por [Marmot](/es/topics/marmot/)) proporcionan forward secrecy mediante rotación de material de claves, pero al coste de requerir sincronización de estado y de hacer imposible la recuperación histórica de mensajes después de la rotación de claves.
+
+NIP-17 también define kind `15` para mensajes de archivo cifrados, que añade tags `file-type`, `encryption-algorithm`, `decryption-key` y `decryption-nonce` para que el receptor pueda descifrar un archivo adjunto cifrado con AES-GCM antes de subirse a un servidor Blossom. Kind `10050` se usa para publicar la lista preferida de relays de DM del usuario, para que los remitentes sepan dónde entregar gift wraps. El conjunto de tags `pubkey` + `p` en un mensaje define una sala de chat; añadir o eliminar un participante crea una sala nueva con historial limpio.
+
+Las implementaciones cubren a la mayoría de los clientes principales. [nospeak](https://github.com/psic4t/nospeak) usa NIP-17 para toda la mensajería uno a uno. [Flotilla](https://gitea.coracle.social/coracle/flotilla) usa NIP-17 para sus DMs con proof-of-work. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel) y [Coracle](https://github.com/coracle-social/coracle) implementan NIP-17 como su protocolo principal de DM. La especificación también soporta mensajes que desaparecen estableciendo un tag `expiration` en el gift wrap.
+
+## NIP en profundidad: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) define un protocolo para separar la clave privada del usuario de la aplicación cliente. En lugar de pegar un nsec en una web app, el usuario ejecuta un firmante remoto (también llamado "bunker") que guarda la clave privada y responde a solicitudes de firma a través de relays Nostr. El cliente nunca ve la clave privada. Esto reduce la superficie de ataque: un cliente comprometido puede solicitar firmas, pero no puede extraer la propia clave.
+
+El protocolo usa kind `24133` tanto para solicitudes como para respuestas, cifradas con [NIP-44](/es/topics/nip-44/) (Encrypted Payloads). Un cliente genera un `client-keypair` desechable para la sesión y se comunica con el firmante remoto mediante mensajes cifrados con NIP-44 etiquetados con los pubkeys de ambos. Aquí hay una solicitud de firma de un cliente a un firmante remoto:
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+El `content` cifrado contiene una estructura similar a JSON-RPC:
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+El firmante remoto descifra la solicitud, la presenta al usuario para su aprobación (o la aprueba automáticamente según los permisos configurados), firma el evento con la clave privada del usuario y devuelve el evento firmado en una respuesta:
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Las conexiones pueden iniciarse desde cualquiera de los dos lados. Un firmante remoto proporciona una URL `bunker://` que contiene su pubkey e información de relay. Un cliente proporciona una URL `nostrconnect://` con su pubkey de cliente, relays y un secreto para verificación de conexión. El parámetro `secret` evita suplantación de conexión: solo la parte que recibió la URL fuera de banda puede completar el handshake.
+
+Se definen ocho métodos: `connect` para establecer la sesión, `sign_event` para firmar eventos, `get_public_key` para conocer el pubkey del usuario, `ping` para keepalive, `nip04_encrypt`/`nip04_decrypt` para cifrado legacy, `nip44_encrypt`/`nip44_decrypt` para cifrado actual, y `switch_relays` para gestión de relays. La migración de relay la maneja el firmante remoto, que puede mover la conexión a nuevos relays con el tiempo sin romper la sesión.
+
+Los clientes solicitan capacidades específicas en el momento de conexión mediante un sistema de permisos. Una cadena de permisos como `nip44_encrypt,sign_event:1,sign_event:14` solicita acceso a cifrado NIP-44 y acceso de firma solo para eventos kind `1` y kind `14`. El firmante remoto puede aceptar, rechazar o modificar estos permisos. Esto significa que un cliente web para leer y publicar notas podría recibir solo permiso `sign_event:1`, mientras que un cliente de DM podría recibir también permisos `sign_event:14` y `nip44_encrypt`.
+
+[Amber](https://github.com/greenart7c3/Amber) implementa NIP-46 en Android, y su [v6.0.0-pre1](#amber-v600-pre1-añade-claves-de-firma-nip-46-por-conexión) de esta semana añade claves de firma por conexión para aislar clientes entre sí. [nsec.app](https://github.com/nicktee/nsecapp) (antes Nostr Connect) proporciona un bunker basado en web. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) incluye `BunkerSigner` para clientes JavaScript, y [el PR #530 de la semana pasada](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) añadió `skipSwitchRelays` para gestión manual de relays. El protocolo también soporta desafíos de auth: cuando un firmante remoto necesita autenticación adicional (contraseña, biometría o token hardware), responde con una `auth_url` que el cliente abre en un navegador para que el usuario la complete.
+
+---
+
+Eso es todo por esta semana. ¿Estás construyendo algo o tienes noticias para compartir? Envíanos un DM en Nostr o encuéntranos en [nostrcompass.org](https://nostrcompass.org).

--- a/content/fr/newsletters/2026-04-08-newsletter.md
+++ b/content/fr/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Bienvenue dans Nostr Compass, votre guide hebdomadaire sur Nostr.
+
+**Cette semaine :** [Amethyst](https://github.com/vitorpamplona/amethyst) livre [v1.08.0](#amethyst-livre-arti-tor-integre-mls-et-marmot-en-pur-kotlin) avec l'intégration d'Arti Tor et une interface Shorts repensée, tout en fusionnant des implémentations en pur Kotlin de [MLS](/fr/topics/mls/) et [Marmot](/fr/topics/marmot/) dans sa bibliothèque [Quartz](/fr/topics/quartz/). [Nostur](https://github.com/nostur-com/nostur-ios-public) livre [v1.27.0](#nostur-v1270-ajoute-lenregistrement-video-et-les-reponses-privees) avec enregistrement vidéo, profils GIF animés et réponses privées. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) lance [v0.15.0](#shosho-v0150-lance-shows-et-un-carrousel-video-vertical) avec Shows (informations de live personnalisées connectées à OBS) et un carrousel vidéo vertical de style TikTok. [Nymchat](https://github.com/Spl0itable/NYM) [abandonne Marmot et livre des chats de groupe NIP-17 renforcés](#nymchat-abandonne-marmot-et-livre-des-chats-de-groupe-nip-17-renforces) avec des clés éphémères rotatives. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) livre [le support des exit nodes et le packaging Umbrel](#nostr-vpn-livre-le-support-des-exit-nodes-et-le-packaging-umbrel) à travers six versions. [Amber](https://github.com/greenart7c3/Amber) passe à [v6.0.0-pre1](#amber-v600-pre1-ajoute-des-cles-de-signature-nip-46-par-connexion) avec des clés de signature [NIP-46](/fr/topics/nip-46/) par connexion et des mises à jour in-app via Zapstore. [Notedeck](https://github.com/damus-io/notedeck) atteint [v0.10.0-beta](#notedeck-v0100-beta-livre-lauto-update-via-zapstore) avec l'auto-update APK via Zapstore, et [NIP-58](/fr/topics/nip-58/) (Badges) reçoit une [migration de kind](#mises-a-jour-des-nip). Deux deep dives NIP couvrent [NIP-17](/fr/topics/nip-17/) (Private Direct Messages) et [NIP-46](/fr/topics/nip-46/) (Nostr Remote Signing).
+
+## Actualités
+
+### Amethyst livre Arti Tor, intègre MLS et Marmot en pur Kotlin
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), le client Android maintenu par vitorpamplona, a livré quatre versions de [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) à [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) et a fusionné un gros lot de travail non encore publié dans sa bibliothèque [Quartz](/fr/topics/quartz/) (le module Nostr Kotlin Multiplatform partagé). La version phare est v1.08.0 « Arti Tor », qui migre la connectivité Tor de l'application depuis la bibliothèque Tor en C vers [Arti](https://gitlab.torproject.org/tpo/core/arti), l'implémentation Rust du Tor Project. La migration corrige des crashes aléatoires qui survenaient avec les anciens bindings Tor en C. Arti est le remplaçant de long terme du Tor Project pour le codebase en C, réécrit depuis zéro en Rust pour la sûreté mémoire et les async I/O.
+
+La version v1.07.3 a repensé l'interface Shorts, en remplaçant le design paginé par des flux bord à bord pour les images, les shorts et les vidéos longues. La même version a migré les badges vers le kind `10008` et les bookmarks vers le kind `10003`, en s'alignant sur la migration de kind [NIP-58](/fr/topics/nip-58/) [fusionnée cette semaine](#mises-a-jour-des-nip). v1.07.4 a corrigé un problème de gestion de secret Nostr Wallet Connect, et v1.07.5 a corrigé un crash lors du téléversement d'images.
+
+Sur `main` mais pas encore dans une release taguée, l'équipe a écrit une implémentation complète en Kotlin de [MLS](/fr/topics/mls/) et du protocole [Marmot](/fr/topics/marmot/), supprimant le besoin de bindings natifs vers des bibliothèques C/Rust. [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) ajoute la couche centrale de messagerie de groupe MLS de Marmot, [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) ajoute l'interface de chat de groupe, [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) ajoute les processeurs de messages entrants et sortants avec un gestionnaire d'abonnements, [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) ajoute la persistance d'état de groupe MLS et la gestion de rotation des KeyPackage, [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) ajoute une suite de tests MLS complète avec une signature GroupInfo améliorée, et [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) ajoute le suivi du statut de publication des KeyPackage. [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) ajoute une implémentation secp256k1 en pur Kotlin pour les opérations cryptographiques Nostr, remplaçant la dépendance à la bibliothèque C native. Combiné à l'implémentation MLS en Kotlin, [Quartz](/fr/topics/quartz/) peut exécuter la signature Nostr et la messagerie de groupe Marmot sans aucun binding natif, ce qui ouvre la voie à des cibles Kotlin Multiplatform, y compris iOS.
+
+L'équipe construit aussi le support de [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls) : [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) ajoute une suite de tests complète pour la machine d'état d'appel NIP-AC, et [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) empêche d'anciennes offres d'appel de se redéclencher après un redémarrage de l'application.
+
+### Nostur v1.27.0 ajoute l'enregistrement vidéo et les réponses privées
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), le client Nostr iOS, a livré [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) le 2 avril. La version ajoute l'enregistrement vidéo in-app avec découpe avant téléversement, de sorte que les utilisateurs puissent capturer de courts clips, les raccourcir et les publier sans quitter le client. Le support des GIFs animés s'étend aux photos de profil et de bannière, avec aussi l'ajout du rendu WebP animé. Une nouvelle intégration Shortcuts permet aux utilisateurs d'envoyer des posts Nostr depuis les automatisations Apple Shortcuts. La version ajoute aussi les réponses privées et corrige des problèmes de compatibilité DM qui affectaient la livraison des messages entre Nostur et d'autres clients.
+
+### Shosho v0.15.0 lance Shows et un carrousel vidéo vertical
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), l'application de live streaming Nostr, a livré [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) et [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) le 7 avril. La fonctionnalité phare est Shows : les streamers peuvent préparer des informations d'émission personnalisées avant de passer en direct et connecter leur show à OBS ou à n'importe quel encodeur externe. Cela sépare les métadonnées « qu'est-ce que je diffuse » de l'acte de passer en direct, de sorte que les streamers puissent préparer titres, descriptions et produits avant de commencer la diffusion. La même version ajoute un carrousel vidéo vertical de style TikTok pour parcourir lives, clips et replays dans un flux plein écran, ainsi que Quick Add pour publier des clips vidéo et ajouter des produits directement depuis une page de profil. v0.15.1 corrige un bug où le clavier masquait le champ de saisie du chat de live.
+
+## Versions
+
+### Notedeck v0.10.0-beta livre l'auto-update via Zapstore
+
+[Notedeck](https://github.com/damus-io/notedeck), le client desktop et mobile de l'équipe Damus, a livré [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) et [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) comme préreleases de test pour l'auto-update APK. [PR #1417](https://github.com/damus-io/notedeck/pull/1417) ajoute l'auto-update APK via l'updater Nostr/Zapstore sur Android, en prolongeant [le travail de découverte de mises à jour natif à Nostr de la Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr). Le flux de mise à jour découvre les nouvelles releases via des événements Nostr publiés sur des relays, puis télécharge l'APK depuis l'endroit où le développeur l'héberge (GitHub releases, Blossom CDN ou autres sources), vérifie le hash SHA-256 contre l'événement Nostr signé, puis l'installe. [PR #1438](https://github.com/damus-io/notedeck/pull/1438) corrige un bug d'écran d'accueil où les boutons Login et CreateAccount revenaient immédiatement en arrière, et [PR #1424](https://github.com/damus-io/notedeck/pull/1424) corrige un débordement de texte dans la vue de session Agentium AI.
+
+### Amber v6.0.0-pre1 ajoute des clés de signature NIP-46 par connexion
+
+[Amber](https://github.com/greenart7c3/Amber), l'application signataire [NIP-55](/fr/topics/nip-55/) (Android Signer Application), a livré [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) le 4 avril. Le changement le plus important est l'ajout de clés de signature par connexion pour le protocole bunker [NIP-46](/fr/topics/nip-46/) (Nostr Remote Signing). Au lieu d'utiliser une seule paire de clés pour toutes les connexions bunker, Amber génère désormais une clé distincte pour chaque client connecté. Si la connexion d'un client est compromise, l'attaquant ne peut pas usurper le signataire auprès des autres clients.
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377) ajoute la vérification et l'installation de mises à jour in-app via Zapstore, rejoignant [Notedeck](#notedeck-v0100-beta-livre-lauto-update-via-zapstore) dans l'adoption d'une distribution d'apps native à Nostr. [PR #375](https://github.com/greenart7c3/Amber/pull/375) gère les échecs AndroidKeyStore proprement en affichant un avertissement aux utilisateurs au lieu de crasher, et [PR #371](https://github.com/greenart7c3/Amber/pull/371) ajoute un nettoyage de base de données avec limites de taille et troncature de contenu pour empêcher une croissance de stockage non bornée. La prérelease reprend aussi la liste blanche d'auth relay [NIP-42](/fr/topics/nip-42/) et la connexion par phrase mnémonique de récupération du [cycle v5.0.x couvert la semaine dernière](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria livre une application mobile native
+
+[Nostria](https://github.com/nostria-app/nostria), le client Nostr cross-platform maintenu par SondreB, a publié une application mobile native pour Android avec huit versions de [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) à [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). La nouveauté la plus importante est le support natif d'un signataire local pour des signataires comme [Amber](https://github.com/greenart7c3/Amber) et Aegis. Des [installeurs desktop](https://www.nostria.app/download) pour Linux, macOS et Windows sont aussi disponibles. [PR #610](https://github.com/nostria-app/nostria/pull/610) réduit la pression mémoire du flux avec des limites runtime adaptatives et un nettoyage des URLs d'aperçu. v3.1.14 corrige l'intégration avec Brainstorm, un fournisseur [Web of Trust](/fr/topics/web-of-trust/). v3.1.15 se concentre sur des améliorations musicales. La nouvelle application Android est disponible sur [Zapstore](https://zapstore.dev/apps/app.nostria).
+
+### diVine 1.0.8 livre des téléversements reprenables et des DMs
+
+[diVine](https://github.com/divinevideo/divine-mobile), le client vidéo short-form, a livré [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) avec 87 PRs fusionnées. Les téléversements reprenables permettent aux créateurs de reprendre des téléversements interrompus morceau par morceau au lieu de repartir de zéro sur une connexion instable. La version ajoute des réglages de qualité vidéo et de bitrate, le double tap pour liker, et des améliorations des DMs. [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) ajoute un plugin caméra macOS pour la capture vidéo desktop, et [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migre le système de notifications vers une architecture BLoC avec enrichissement et regroupement. L'équipe a aussi remplacé les stickers et illustrations de catégories générés par AI par des SVG OpenMoji ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 ajoute le floutage des notes sensibles et l'auth NIP-42
+
+[Manent](https://github.com/dtonon/manent), l'application privée de notes chiffrées et de stockage de fichiers, a livré [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) le 2 avril. Les utilisateurs peuvent maintenant marquer des notes comme sensibles afin de les flouter dans la vue liste, ce qui garde le contenu privé caché lors d'un défilement occasionnel. La version ajoute aussi le support [NIP-42](/fr/topics/nip-42/) (Authentication of Clients to Relays), permettant à Manent de s'authentifier auprès des relays qui l'exigent avant d'accepter les événements. Manent stocke toutes les données chiffrées sur les relays Nostr à l'aide de la paire de clés de l'utilisateur, donc le support NIP-42 élargit l'ensemble des relays qu'il peut utiliser pour le stockage.
+
+### Wisp v0.17.0 à v0.17.3 ajoutent les zaps sur live stream et la sauvegarde du portefeuille
+
+[Wisp](https://github.com/barrydeen/wisp), le client Nostr Android, a livré six versions de [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) à [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) avec 44 PRs fusionnées. La version v0.17.0 ajoute des invites de sécurité pour la sauvegarde du portefeuille et des améliorations UX pour les zaps. [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) ajoute la visibilité du chat de live stream à travers les plateformes et la fonctionnalité de zap sur live stream. [PR #423](https://github.com/barrydeen/wisp/pull/423) ajoute l'auto-search des profils, une animation de succès de zap et des améliorations du statut utilisateur. [PR #426](https://github.com/barrydeen/wisp/pull/426) corrige un crash out-of-memory dans `computeId` pour des événements avec de grandes listes de tags. Les versions v0.16.x avaient ajouté l'autocomplétion des shortcodes emoji, des améliorations de l'interface de chat de groupe et le filtrage des utilisateurs bloqués sur tous les chemins de notification.
+
+### Mostro livre des deep links, des taux de change Nostr et un correctif de paiement en double
+
+[Mostro](https://github.com/MostroP2P/mostro), l'échange Bitcoin pair à pair construit sur Nostr, a connu cette semaine des mises à jour à la fois sur son daemon serveur et son client mobile. Côté serveur, [PR #692](https://github.com/MostroP2P/mostro/pull/692) empêche que des écritures d'ordres obsolètes causent des paiements en double, un bug qui pouvait conduire à payer deux fois un vendeur pour la même transaction. [PR #693](https://github.com/MostroP2P/mostro/pull/693) utilise des mises à jour ciblées pour les écritures `dev_fee` au lieu d'écrasements complets d'ordres.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), le client Flutter, a livré [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) le 3 avril. La version gère les deep links provenant de différentes instances Mostro, de sorte que les utilisateurs puissent toucher des liens qui routent vers le bon serveur d'échange. [PR #498](https://github.com/MostroP2P/mobile/pull/498) détecte les DMs admin et de litige dans le pipeline de notifications en arrière-plan, et l'application récupère désormais les taux de change depuis Nostr avec un fallback HTTP/cache. [PR #560](https://github.com/MostroP2P/mobile/pull/560) corrige un bug bloquant la connexion relay qui empêchait l'application d'atteindre les relays dans certaines conditions réseau.
+
+### Unfiltered v1.0.12 ajoute les hashtags et les commentaires
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), un client Nostr centré sur le contenu image-first, a livré [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12). [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) ajoute le support des hashtags et [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) ajoute la possibilité d'écrire et d'afficher des commentaires sur les posts. [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) corrige des problèmes de navigation avec plusieurs images par post.
+
+### Primal Android livre le partage multi-comptes du portefeuille et l'auto-reconnexion du signataire distant
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), le client Nostr Android, a livré une version le 7 avril. La mise à jour ajoute le partage multi-comptes du portefeuille et un menu overflow avec suppression du portefeuille dans Dev Tools. Le signataire distant se reconnecte désormais automatiquement lors des pertes de connexion, et le service portefeuille a gagné sa propre logique d'auto-reconnexion. Les correctifs incluent le fait que les votes zap de sondage n'apparaissent plus comme Top Zaps, la prévention des crashes sur option de sondage vide, le masquage du solde du portefeuille quand aucun portefeuille n'existe, et le mapping des types de WalletException vers des codes d'erreur dans les réponses NWC.
+
+### Titan v0.1.0 lance un navigateur natif `nsite://` avec enregistrement de noms sur Bitcoin
+
+[Titan](https://github.com/btcjt/titan), un navigateur desktop natif pour le web Nostr, a livré [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) le 7 avril. Titan résout les URLs `nsite://` en recherchant des noms lisibles par l'humain enregistrés sur Bitcoin, en interrogeant les relays Nostr pour les événements de contenu du site, puis en rendant les pages récupérées depuis des serveurs [Blossom](/fr/topics/blossom/). Le résultat est une expérience de navigation web sans DNS, sans certificats TLS et sans hébergeurs. Les noms sont enregistrés via une [interface web](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) liée à des transactions Bitcoin. La version initiale est livrée sous forme de `.dmg` macOS (ARM, avec support Rosetta 2 pour Intel) et inclut le support d'un environnement de développement Nix.
+
+### Bikel v1.5.0 livre un service d'avant-plan natif pour les téléphones de-Googlés
+
+[Bikel](https://github.com/Mnpezz/bikel), un tracker cycliste décentralisé qui transforme les trajets en données d'infrastructure publique via Nostr, a livré [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) le 4 avril. La version migre depuis Expo TaskManager dépendant de GMS vers un service d'avant-plan natif personnalisé, garantissant un suivi fiable des trajets en arrière-plan sur LineageOS, GrapheneOS et d'autres variantes Android de-Googlées. Le Bikel Bot a reçu une architecture dual-pocket avec collecte eCash autonome via des Cashu nutzaps. v1.4.3 et v1.4.2 corrigent la synchronisation du suivi en arrière-plan pour les environnements Android non standard, et l'application ajoute des bascules de points de carte pour les racks à vélos OSM.
+
+### Sprout ajoute le support de NIP-01, NIP-23 et NIP-33
+
+[Sprout](https://github.com/block/sprout), une plateforme de communication de Block avec relay Nostr intégré, a livré [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) le 6 avril. Cette semaine, l'équipe a ajouté le support des articles kind `30023` [NIP-23](/en/topics/nip-23/) (Long-form Content), des événements remplaçables paramétrés [NIP-33](/en/topics/nip-33/) avec remplacement indexé par tag `d`, et des text notes kind `1` et follow lists kind `3` [NIP-01](/fr/topics/nip-01/)/[NIP-02](/en/topics/nip-02/). La version ajoute aussi un système de thèmes IDE adaptatifs avec 54 thèmes, des améliorations UX de workflow et d'historique d'exécution d'agents, ainsi qu'un nettoyage de la sidebar membres.
+
+### mesh-llm v0.56.0 livre un protocole de configuration distribué
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), un système d'inférence LLM distribué qui utilise des paires de clés Nostr pour l'identité des nœuds, a livré [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) le 7 avril. La version ajoute un protocole de configuration distribué avec une sémantique de propriété, une quantification asymétrique du cache KV (clés Q8_0 avec valeurs Q4) pour réduire l'usage mémoire, le stockage dans l'OS keychain pour les keystores d'identité, un streaming de chat fluide avec mise en file des messages, et des correctifs pour la mise en page fullscreen et le découpage du cache KV avec flash attention.
+
+### Nostr VPN livre le support des exit nodes et le packaging Umbrel
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), un VPN pair à pair qui utilise les relays Nostr pour le signalement et WireGuard pour les tunnels chiffrés, a livré six versions de [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) à [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) cette semaine. Le cycle v0.3.x ajoute le support des exit nodes sur Windows et macOS, permettant à des pairs de router le trafic internet via d'autres nœuds du réseau. La propagation des invitations et des alias se synchronise désormais sur Nostr, de sorte que les utilisateurs puissent partager l'accès réseau sans coordination hors bande. Les versions ajoutent le packaging Umbrel pour un déploiement auto-hébergé, le NAT punch-through en utilisant des endpoints publics mémorisés, le nettoyage automatique des exit nodes obsolètes, et une spécification de protocole publiée. Le projet a aussi stabilisé la gestion des routes macOS avec des routes par défaut auto-réparatrices et une réparation de l'underlay, et a ajouté une build Android via Tauri. Des builds sont disponibles pour macOS (Apple Silicon et Intel), Linux (AppImage et .deb), Windows et Android.
+
+### Nymchat abandonne Marmot et livre des chats de groupe NIP-17 renforcés
+
+[Nymchat](https://github.com/Spl0itable/NYM), le client de chat capable de MLS, a livré 14 versions de [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) à [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274). Le changement le plus significatif est un pivot protocolaire : [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) a ajouté des chats de groupe MLS Marmot, mais [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) est revenu à [NIP-17](/fr/topics/nip-17/) parce que le support multi-appareils de Marmot n'est pas encore terminé, ce qui causait des problèmes de synchronisation de l'état des chats de groupe entre appareils. v3.58.271 introduit des chats de groupe NIP-17 renforcés avec des clés éphémères rotatives pour tous les messages, conçues pour prévenir les attaques de timing et de corrélation. La semaine a aussi apporté un système d'amis avec contrôle granulaire des paramètres ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), la synchronisation des messages de groupe MLS dans les paramètres applicatifs chiffrés, et plusieurs correctifs de connectivité relay.
+
+### nak v0.19.5 ajoute Blossom multi-serveur et la publication outbox
+
+[nak](https://github.com/fiatjaf/nak), la boîte à outils Nostr en ligne de commande de fiatjaf, a livré [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5). La commande `blossom` accepte désormais plusieurs flags `--server` pour téléverser vers plusieurs serveurs [Blossom](/fr/topics/blossom/) en un seul appel. Une nouvelle commande `key` complète les clés partielles en les left-padding avec des zéros. La commande `event` gagne un flag `--outbox` pour publier des événements via le modèle outbox, et `fetch` sort maintenant avec un code d'erreur quand aucun événement n'est renvoyé.
+
+## En développement
+
+### White Noise ajoute des aperçus thumbhash et un pont d'enregistrement push
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), la messagerie privée construite sur le protocole [Marmot](/fr/topics/marmot/), a fusionné cinq PRs. [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) remplace les aperçus d'images blurhash par thumbhash, un algorithme plus récent qui produit des images placeholder plus nettes avec une charge utile plus petite (généralement moins de 30 bytes contre environ 50-100 bytes pour blurhash) tout en conservant le ratio d'aspect et la distribution de couleurs de l'image d'origine. Blurhash est conservé comme fallback pour les anciens contenus. [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) met à jour whitenoise-rs et ajoute le pont d'enregistrement push [MIP-05](/fr/topics/mip-05/), connectant [le travail sur la spécification des notifications push de la semaine dernière](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications) au client. [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) ajoute une pagination à curseur pour les messages de chat, remplaçant l'ancienne stratégie de chargement par une approche pilotée par le scroll.
+
+### Route96 ajoute une configuration dynamique des labels et un nettoyage zéro-egress
+
+[Route96](https://github.com/v0l/route96), le serveur média [Blossom](/fr/topics/blossom/) de v0l, a fusionné trois PRs. [PR #80](https://github.com/v0l/route96/pull/80) ajoute la configuration dynamique des modèles de labels via l'API d'administration, permettant aux opérateurs de changer de modèles de classification de contenu sans redémarrer le serveur. [PR #82](https://github.com/v0l/route96/pull/82) ajoute les champs de configuration de labels à l'interface d'administration. [PR #79](https://github.com/v0l/route96/pull/79) ajoute une politique de nettoyage de fichiers zéro-egress qui supprime automatiquement les fichiers qui n'ont jamais été téléchargés, afin de réduire les coûts de stockage pour les opérateurs.
+
+### Snort livre du durcissement de sécurité et des factures de paiement DVM
+
+[Snort](https://github.com/v0l/snort), le client web, a livré deux versions cette semaine avec un audit de sécurité complet. Les correctifs incluent la vérification des signatures Schnorr, la protection [NIP-46](/fr/topics/nip-46/) contre la falsification de messages relay (empêchant des attaquants d'injecter des requêtes de signature via des relays compromis), des améliorations du chiffrement du PIN, et la suppression de la confiance de délégation NIP-26. Les gains de performances viennent d'une vérification Schnorr batchée en WASM, de routes chargées paresseusement, de traductions précompilées et de l'élimination d'une double vérification par événement. [PR #618](https://github.com/v0l/snort/pull/618) ajoute l'affichage de factures kind `7000` [NIP-90](/en/topics/nip-90/) (Data Vending Machine) requérant paiement, de sorte que lorsqu'un DVM répond avec une exigence de paiement, Snort rend la facture Lightning directement dans le flux.
+
+### Damus améliore la compaction LMDB
+
+[Damus](https://github.com/damus-io/damus), le client iOS, a fusionné [PR #3719](https://github.com/damus-io/damus/pull/3719) ajoutant une compaction LMDB automatique planifiée, empêchant la base de données locale de croître sans borne au fil du temps. [PR #3663](https://github.com/damus-io/damus/pull/3663) améliore BlurOverlayView pour lui donner un aspect protecteur plutôt que cassé.
+
+### Captain's Log ajoute l'indexation des tags et la synchronisation des notes
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), l'outil d'écriture long-form natif à Nostr de Nodetec, a fusionné quatre PRs cette semaine. [PR #156](https://github.com/nodetec/captains-log/pull/156) ajoute l'indexation des tags et le support de synchronisation entre les notes, [PR #157](https://github.com/nodetec/captains-log/pull/157) refactorise la synchronisation des notes et la gestion des tags, et [PR #159](https://github.com/nodetec/captains-log/pull/159) corrige la synchronisation des notes mises à la corbeille afin que les notes supprimées restent supprimées sur tous les appareils.
+
+### Relatr v0.2.x repense le système de plugins avec une marketplace de validateurs native à Nostr
+
+[Relatr](https://github.com/ContextVM/relatr), un moteur de scoring [Web of Trust](/fr/topics/web-of-trust/) qui calcule des classements de confiance à partir de la distance dans le graphe social et de validateurs configurables, a livré la famille v0.2.x avec une refonte complète de son système de plugins. Les validateurs sont désormais écrits en Elo, un langage d'expressions fonctionnelles portable forké pour supporter des capacités multi-étapes orchestrées par l'hôte (requêtes Nostr, lookups de graphe social, résolution NIP-05). Les plugins sont publiés comme événements Nostr kind `765`, rendant leur distribution native au réseau relay. Une nouvelle [plugin marketplace](https://relatr.net) permet aux opérateurs de découvrir, installer et pondérer des validateurs depuis le navigateur, avec un CLI (`relo`) pour l'écriture et la publication locales. L'architecture est sandboxée : les plugins ne peuvent invoquer que les capacités que l'hôte fournit explicitement, de sorte qu'un validateur malveillant ne peut pas sortir de son périmètre défini. Les instances Relatr peuvent maintenant être gérées depuis le site web, avec une visibilité complète sur les plugins qui composent l'algorithme de scoring et sur leurs pondérations individuelles.
+
+### Shopstr améliore la navigation mobile et le contrôle d'accès
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), la marketplace native à Nostr pour acheter et vendre avec Bitcoin, a poussé 158 commits cette semaine à travers son application principale et le projet compagnon [Milk Market](https://github.com/shopstr-eng/milk-market). Les correctifs incluent des améliorations de mise en page mobile pour les communautés, la fermeture des menus à la navigation et la fermeture automatique des menus déroulants. Les routes protégées ne peuvent plus être atteintes par URL directe sans connexion, et la logique de matching des slugs gère désormais correctement plusieurs correspondances exactes.
+
+### Pollerama ajoute des notifications, la recherche de films et une nouvelle interface de notation
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), une application de sondages, enquêtes et notation sociale construite sur Nostr, a ajouté des notifications de fil, une fonctionnalité de recherche de films et une refonte de l'interface de notation. La version corrige aussi des problèmes de chargement du flux et augmente les versions de dépendances.
+
+### Purser construit un daemon de paiement natif à Nostr avec chiffrement Marmot
+
+[Purser](https://github.com/EthnTuttle/purser), un daemon de paiement natif à Nostr conçu comme remplaçant de Zaprite, a fusionné neuf PRs cette semaine pour construire son architecture centrale. Le projet utilise [Marmot](/fr/topics/marmot/) MLS via MDK pour la messagerie chiffrée entre commerçants et clients, avec Strike et Square comme fournisseurs de paiement. Cette semaine ont atterri le chargement de configuration et de catalogue, la validation du schéma des messages, la couche de communication MDK, les implémentations des fournisseurs Strike et Square, un moteur de polling, une limitation anti-spam, la persistance des paiements en attente et le pipeline de traitement des commandes. Les 99 tests exercent maintenant de vraies opérations MLS mdk-core après que l'équipe a retiré le mock MLS au profit d'un chiffrement réel en mode local.
+
+### Vector refactorise les pièces jointes DM et ajoute l'édition de profil
+
+[Vector](https://github.com/VectorPrivacy/Vector), la messagerie Nostr centrée sur la confidentialité construite avec Tauri, a fusionné [PR #55](https://github.com/VectorPrivacy/Vector/pull/55) refactorisant le frontend. Le déchiffrement et la sauvegarde des pièces jointes DM ont été déplacés vers la bibliothèque vector-core, et l'application supporte maintenant l'édition de profil. Le flag d'annulation d'upload est correctement câblé via TauriSendCallback, et les callbacks inutilisés d'aperçu de pièces jointes ont été nettoyés.
+
+## Travail sur le protocole et les spécifications
+
+### Mises à jour des NIP
+
+Changements récents dans le [dépôt NIPs](https://github.com/nostr-protocol/nips) :
+
+**Fusionnés :**
+
+- **[NIP-58](/fr/topics/nip-58/) (Badges) : les Profile Badges passent au kind 10008, les Badge Sets au kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)) : migre les Profile Badges du kind `30008` vers le kind `10008` (un événement remplaçable, un par pubkey) et introduit le kind `30008` pour les Badge Sets. Auparavant, les Profile Badges utilisaient le même kind (`30008`) que les définitions de badges, ce qui en faisait des événements remplaçables paramétrés indexés par un tag `d`. Le nouveau kind `10008` est un événement remplaçable simple : un par pubkey, sans besoin de tag `d`. Les clients interrogent un seul événement remplaçable par utilisateur au lieu de scanner des événements remplaçables paramétrés. Amethyst v1.07.3 embarque déjà cette migration.
+
+- **[NIP-34](/fr/topics/nip-34/) (Git Stuff) : ajout de follow lists liées à git** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)) : ajoute des conventions de follow lists pour le suivi des dépôts et des issues NIP-34. Les utilisateurs publient des ensembles de follow kind `30000` avec des tags `d` comme `git-repos` ou `git-issues` contenant des références de tag `a` vers les dépôts (kind `30617`) qu'ils veulent suivre. Les clients peuvent s'abonner à ces follow sets pour afficher l'activité des dépôts dans le flux d'un utilisateur, de manière similaire au fonctionnement des contact lists kind `3` pour les pubkeys.
+
+**PRs ouvertes et discussions :**
+
+- **NIP-AC : P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)) : étend le NIP-100 original (implémenté par 0xChat) avec trois changements : migration vers le chiffrement [NIP-44](/fr/topics/nip-44/) enveloppé dans des gift wraps [NIP-59](/fr/topics/nip-59/) pour éliminer les fuites de métadonnées, workflow WebRTC spécifié pour l'établissement d'appels audio et vidéo (offer, answer, ICE candidates), et modèle d'appel de groupe en mesh où chaque pair établit une connexion WebRTC directe avec chaque autre pair. La spécification n'est pas rétrocompatible avec NIP-100. Amethyst construit déjà contre elle, avec une suite de tests de machine d'état d'appel ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) et la gestion des offres d'appel obsolètes ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)) livrées cette semaine.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)) : propose des conventions pour la signature à seuil [FROST](/fr/topics/frost/) (Flexible Round-Optimized Schnorr Threshold) sur Nostr. FROST permet à un groupe de signataires de contrôler collectivement une identité Nostr où n'importe quels membres t-of-n peuvent signer des événements sans reconstruire la clé privée complète. Le NIP définit comment coordonner les rounds de signature, distribuer les key shares et publier des événements signés à seuil, en s'appuyant sur le travail du signataire Igloo du [projet FROSTR](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)) : définit un protocole `postMessage` pour des applications web sandboxées (« napplets ») tournant dans des iframes et communiquant avec une application hôte (« shell »). Le shell fournit à la napplet la signature Nostr, l'accès relay et le contexte utilisateur via une API de messages structurée, tandis que la sandbox iframe empêche l'accès direct aux clés. Cela étend le modèle d'hébergement de sites web statiques de [NIP-5A](/en/topics/nip-5a/) vers des applications interactives capables de lire et d'écrire des événements Nostr. Le NIP est en développement actif avec une implémentation runtime fonctionnelle.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)) : renommé depuis l'ancienne proposition NIP-A5. Définit des conventions pour publier et découvrir des programmes WebAssembly sur Nostr. Les binaires WASM sont stockés comme événements Nostr, et les clients peuvent les télécharger puis les exécuter dans un runtime sandboxé. Une [demo app](https://nprogram.netlify.app/) montre des scrolls s'exécutant dans le navigateur, avec des programmes exemples publiés comme événements Nostr que n'importe quel client peut récupérer et exécuter.
+
+- **[NIP-85](/fr/topics/nip-85/) (Trusted Assertions) : clarifications** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)) : resserre le langage de la spécification autour de multiples clés et relays par fournisseur de services, en clarifiant comment les clients doivent gérer des assertions provenant de fournisseurs opérant à travers plusieurs pubkeys ou endpoints relay.
+
+- **[NIP-24](/fr/topics/nip-24/) (Extra Metadata Fields) : `published_at` pour les événements remplaçables** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)) : généralise le tag `published_at` depuis [NIP-23](/en/topics/nip-23/) (Long-form Content) à tous les événements remplaçables et adressables. Le tag est seulement destiné à l'affichage : si `published_at` égale `created_at`, les clients affichent l'événement comme « créé » à ce moment-là ; s'ils diffèrent (parce que l'événement a été mis à jour), les clients peuvent l'afficher comme « mis à jour » à la place. Cela permet aux profils kind `0` d'afficher des dates « joined at » et à d'autres événements remplaçables de préserver leur timestamp de publication d'origine à travers les mises à jour. Une proposition complémentaire [NIP-51](/fr/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) ajoute le même tag aux événements de listes.
+
+- **[NIP-59](/fr/topics/nip-59/) (Gift Wrap) : kind de gift wrap éphémère** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)) : ajoute le kind `21059` comme contrepartie éphémère au gift wrap kind `1059` existant. Les événements éphémères (kinds `20000`-`29999`) suivent la sémantique [NIP-01](/fr/topics/nip-01/) : les relays ne sont pas censés les stocker et peuvent les supprimer après livraison. Cela permet aux applications d'envoyer des messages gift-wrapped qui disparaissent des relays une fois livrés, réduisant les besoins de stockage pour la messagerie à fort volume tout en conservant le même modèle de chiffrement à trois couches que les DMs [NIP-17](/fr/topics/nip-17/) classiques.
+
+### OpenSats annonce sa seizième vague de subventions Nostr
+
+[OpenSats](https://opensats.org) a annoncé sa [seizième vague de subventions Nostr](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) le 8 avril, finançant quatre premières subventions et un renouvellement. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) reçoit un financement pour que le contributeur Robert Nagy construise une application desktop autonome au-dessus des modules [Quartz](/fr/topics/quartz/) et Commons, apportant l'ensemble des fonctionnalités du client Android à des interfaces pilotées à la souris avec connexions relay persistantes. [Nostr Mail](https://github.com/nogringo/nostr-mail) reçoit un financement pour construire un système email complet sur Nostr en utilisant des événements kind `1301` enveloppés dans des gift wraps [NIP-59](/fr/topics/nip-59/), avec un client Flutter et des serveurs de pont SMTP pour la compatibilité Gmail/Outlook. [Nostrord](https://github.com/Nostrord/nostrord) reçoit un financement pour un client de groupe basé sur relay [NIP-29](/en/topics/nip-29/) en Kotlin Multiplatform avec messagerie de groupe, modération et fils à la Discord. [Nurunuru](https://github.com/tami1A84/null--nostr) reçoit un financement pour construire une version iOS native du client Nostr japonais inspirée de l'interface familière de LINE, avec connexion biométrique basée sur passkey pour l'onboarding. HAMSTR a reçu un renouvellement de subvention (financé pour la première fois lors de la [onzième vague](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)).
+
+## Deep Dive NIP : NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) définit le standard actuel des messages directs privés sur Nostr. Il remplace l'ancien schéma [NIP-04](/fr/topics/nip-04/) (Encrypted Direct Messages), qui laissait fuiter des métadonnées (expéditeur, destinataire et timestamps étaient tous visibles sur les relays) et utilisait une construction de chiffrement plus faible. NIP-17 combine [NIP-44](/fr/topics/nip-44/) (Encrypted Payloads) pour le chiffrement avec [NIP-59](/fr/topics/nip-59/) (Gift Wrap) pour la protection des métadonnées, créant un système à trois couches où les relays ne peuvent pas voir qui parle avec qui.
+
+Le protocole utilise trois kinds d'événements empilés les uns dans les autres. La couche la plus interne est le message réel, un événement kind `14` non signé :
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+L'événement kind `14` est volontairement non signé (`sig` vide). La spécification présente cela comme une forme de déni plausible, mais en pratique cette protection reste limitée. Le seal kind `13` qui enveloppe la rumor est signé avec la vraie clé de l'expéditeur. Un destinataire peut montrer ce seal signé à un tiers, prouvant que l'expéditeur a communiqué avec lui, même sans révéler le contenu du message. Avec des preuves à divulgation nulle de connaissance, un destinataire peut prouver le contenu exact du message sans révéler sa propre clé privée. La rumor non signée ressemble à une lettre non signée placée dans une enveloppe signée : la signature de l'enveloppe relie l'expéditeur au contenu. Un véritable déni exigerait une authentification symétrique (comme les HMACs de Signal), ce qui est incompatible avec le modèle relay décentralisé de Nostr où les messages doivent être auto-authentifiants. Les véritables forces de NIP-17 sont la confidentialité des métadonnées et le secret du contenu, pas le déni plausible.
+
+Ce message non signé est ensuite enveloppé dans un seal kind `13`, signé par l'expéditeur réel et chiffré avec [NIP-44](/fr/topics/nip-44/) pour le destinataire :
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+Le seal n'a pas de tags, donc même déchiffré il ne révélerait pas le destinataire. Le seal est signé avec la vraie clé de l'expéditeur, ce qui permet au destinataire d'authentifier le message en vérifiant que le `pubkey` du seal correspond au `pubkey` du kind `14` interne.
+
+Le seal est ensuite enveloppé dans un gift wrap kind `1059`, signé avec une clé aléatoire jetable et adressé au destinataire :
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+Le `pubkey` du gift wrap est une clé aléatoire générée uniquement pour ce message, et `created_at` est randomisé jusqu'à deux jours dans le passé. C'est la couche la plus externe que les relays voient réellement : un message provenant d'un pubkey inconnu adressé au destinataire, avec un timestamp qui ne reflète pas le moment réel d'envoi. Le timestamp randomisé protège contre les analyses a posteriori d'événements stockés, mais un adversaire activement connecté aux relays peut quand même observer quand le gift wrap apparaît pour la première fois, donc cette défense se limite aux observateurs passifs qui interrogent plus tard les données relay. Parce que le pubkey est aléatoire et que le timestamp est faux, les relays ne peuvent pas déterminer l'expéditeur réel. Pour lire le message, le destinataire déchiffre le gift wrap en utilisant sa propre clé et le pubkey aléatoire, trouve le seal à l'intérieur, déchiffre le seal en utilisant sa propre clé et le pubkey de l'expéditeur présent dans le seal, puis trouve le message kind `14` à l'intérieur.
+
+NIP-17 ne fournit pas de forward secrecy. Tous les messages sont chiffrés à l'aide de la paire de clés Nostr statique (via la dérivation de clés de NIP-44 à partir des clés de l'expéditeur et du destinataire). Si une clé privée est compromise, chaque message passé et futur chiffré pour cette clé peut être déchiffré. C'est un compromis délibéré : comme le chiffrement dépend seulement du nsec, un utilisateur qui sauvegarde son nsec peut récupérer tout son historique de messages depuis n'importe quel relay qui stocke encore les gift wraps. Des protocoles comme MLS (utilisé par [Marmot](/fr/topics/marmot/)) fournissent la forward secrecy via une rotation du matériel de clé, mais au prix d'exiger une synchronisation d'état et de rendre impossible la récupération de l'historique après rotation des clés.
+
+NIP-17 définit aussi le kind `15` pour les messages de fichiers chiffrés, qui ajoute les tags `file-type`, `encryption-algorithm`, `decryption-key` et `decryption-nonce` afin que le destinataire puisse déchiffrer un fichier joint chiffré avec AES-GCM avant téléversement vers un serveur Blossom. Le kind `10050` est utilisé pour publier la liste des relays DM préférés de l'utilisateur, afin que les expéditeurs sachent où livrer les gift wraps. L'ensemble des tags `pubkey` + `p` dans un message définit un salon de chat ; ajouter ou retirer un participant crée un nouveau salon avec un historique propre.
+
+Les implémentations couvrent la plupart des grands clients. [nospeak](https://github.com/psic4t/nospeak) utilise NIP-17 pour toute la messagerie one-on-one. [Flotilla](https://gitea.coracle.social/coracle/flotilla) utilise NIP-17 pour ses DMs proof-of-work. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel), et [Coracle](https://github.com/coracle-social/coracle) implémentent tous NIP-17 comme protocole DM principal. La spécification supporte aussi les messages éphémères en définissant un tag `expiration` dans le gift wrap.
+
+## Deep Dive NIP : NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) définit un protocole permettant de séparer la clé privée de l'utilisateur de l'application cliente. Au lieu de coller un nsec dans une web app, l'utilisateur exécute un signataire distant (aussi appelé « bunker ») qui détient la clé privée et répond aux requêtes de signature via les relays Nostr. Le client ne voit jamais la clé privée. Cela réduit la surface d'attaque : un client compromis peut demander des signatures, mais ne peut pas extraire la clé elle-même.
+
+Le protocole utilise le kind `24133` à la fois pour les requêtes et les réponses, chiffrées avec [NIP-44](/fr/topics/nip-44/) (Encrypted Payloads). Un client génère une `client-keypair` jetable pour la session et communique avec le signataire distant via des messages chiffrés NIP-44 tagués avec les pubkeys respectifs. Voici une requête de signature d'un client vers un signataire distant :
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+Le `content` chiffré contient une structure de type JSON-RPC :
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+Le signataire distant déchiffre la requête, la présente à l'utilisateur pour approbation (ou l'auto-approuve selon les permissions configurées), signe l'événement avec la clé privée de l'utilisateur, puis renvoie l'événement signé dans une réponse :
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Les connexions peuvent être initiées depuis n'importe quel côté. Un signataire distant fournit une URL `bunker://` contenant son pubkey et les informations relay. Un client fournit une URL `nostrconnect://` avec son pubkey client, ses relays et un secret de vérification de connexion. Le paramètre `secret` empêche l'usurpation de connexion : seule la partie qui a reçu l'URL hors bande peut terminer le handshake.
+
+Huit méthodes sont définies : `connect` pour établir la session, `sign_event` pour signer des événements, `get_public_key` pour apprendre le pubkey de l'utilisateur, `ping` pour le keepalive, `nip04_encrypt`/`nip04_decrypt` pour l'ancien chiffrement, `nip44_encrypt`/`nip44_decrypt` pour le chiffrement actuel, et `switch_relays` pour la gestion des relays. La migration relay est gérée par le signataire distant, qui peut déplacer la connexion vers de nouveaux relays au fil du temps sans casser la session.
+
+Les clients demandent des capacités spécifiques au moment de la connexion via un système de permissions. Une chaîne de permissions comme `nip44_encrypt,sign_event:1,sign_event:14` demande l'accès au chiffrement NIP-44 et l'accès à la signature pour les événements kind `1` et kind `14` seulement. Le signataire distant peut accepter, rejeter ou modifier ces permissions. Cela signifie qu'un client web pour lire et publier des notes peut n'obtenir que la permission `sign_event:1`, tandis qu'un client DM peut aussi obtenir `sign_event:14` et `nip44_encrypt`.
+
+[Amber](https://github.com/greenart7c3/Amber) implémente NIP-46 sur Android, et sa [v6.0.0-pre1](#amber-v600-pre1-ajoute-des-cles-de-signature-nip-46-par-connexion) de cette semaine ajoute des clés de signature par connexion pour isoler les clients. [nsec.app](https://github.com/nicktee/nsecapp) (anciennement Nostr Connect) fournit un bunker web. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) inclut `BunkerSigner` pour les clients JavaScript, et [la PR #530 de la semaine dernière](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) a ajouté `skipSwitchRelays` pour une gestion manuelle des relays. Le protocole supporte aussi les défis d'auth : lorsqu'un signataire distant a besoin d'une authentification supplémentaire (mot de passe, biométrie ou token matériel), il répond avec une `auth_url` que le client ouvre dans un navigateur pour que l'utilisateur termine l'opération.
+
+---
+
+C'est tout pour cette semaine. Vous construisez quelque chose ou avez des nouvelles à partager ? Envoyez-nous un DM sur Nostr ou retrouvez-nous sur [nostrcompass.org](https://nostrcompass.org).

--- a/content/it/newsletters/2026-04-08-newsletter.md
+++ b/content/it/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Bentornati a Nostr Compass, la vostra guida settimanale a Nostr.
+
+**Questa settimana:** [Amethyst](https://github.com/vitorpamplona/amethyst) distribuisce la [v1.08.0](#amethyst-distribuisce-arti-tor-e-integra-mls-e-marmot-in-puro-kotlin) con integrazione Arti Tor e una UI Shorts ridisegnata, mentre integra implementazioni in puro Kotlin di [MLS](/it/topics/mls/) e [Marmot](/it/topics/marmot/) nella sua libreria [Quartz](/it/topics/quartz/). [Nostur](https://github.com/nostur-com/nostur-ios-public) distribuisce la [v1.27.0](#nostur-v1270-aggiunge-registrazione-video-e-risposte-private) con registrazione video, profili GIF animati e risposte private. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) lancia la [v0.15.0](#shosho-v0150-lancia-shows-e-un-carousel-video-verticale) con Shows (informazioni personalizzate sul live stream collegate a OBS) e un carousel video verticale in stile TikTok. [Nymchat](https://github.com/Spl0itable/NYM) [torna da Marmot e distribuisce chat di gruppo NIP-17 potenziate](#nymchat-abbandona-marmot-e-distribuisce-chat-di-gruppo-nip-17-potenziate) con chiavi ephemeral a rotazione. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) distribuisce [supporto exit node e packaging Umbrel](#nostr-vpn-distribuisce-supporto-exit-node-e-packaging-umbrel) attraverso sei rilasci. [Amber](https://github.com/greenart7c3/Amber) sale alla [v6.0.0-pre1](#amber-v600-pre1-aggiunge-chiavi-di-firma-nip-46-per-connessione) con chiavi di firma [NIP-46](/it/topics/nip-46/) per connessione e aggiornamenti in-app via Zapstore. [Notedeck](https://github.com/damus-io/notedeck) raggiunge la [v0.10.0-beta](#notedeck-v0100-beta-distribuisce-lauto-aggiornamento-via-zapstore) con auto-aggiornamento APK via Zapstore, e [NIP-58](/it/topics/nip-58/) (Badges) riceve una [migrazione di kind](#aggiornamenti-nip). Due approfondimenti NIP coprono [NIP-17](/it/topics/nip-17/) (Private Direct Messages) e [NIP-46](/it/topics/nip-46/) (Nostr Remote Signing).
+
+## Notizie Principali
+
+### Amethyst distribuisce Arti Tor e integra MLS e Marmot in puro Kotlin
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), il client Android mantenuto da vitorpamplona, ha distribuito quattro rilasci dalla [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) alla [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) e ha integrato un ampio blocco di lavoro non ancora rilasciato nella sua libreria [Quartz](/it/topics/quartz/) (il modulo Nostr condiviso Kotlin Multiplatform). Il rilascio di punta è la v1.08.0 "Arti Tor", che sposta la connettività Tor dell'app dalla libreria Tor basata su C a [Arti](https://gitlab.torproject.org/tpo/core/arti), l'implementazione Rust del Tor Project. La migrazione affronta i crash casuali che si verificavano con i precedenti binding C di Tor. Arti è il sostituto a lungo termine del Tor Project per la codebase C, riscritto da zero in Rust per memory safety e async I/O.
+
+Il rilascio v1.07.3 ha ridisegnato la UI Shorts, sostituendo il design paginato con feed edge-to-edge per immagini, short e video lunghi. Lo stesso rilascio ha migrato i badge al kind `10008` e i bookmark al kind `10003`, allineandosi alla migrazione di kind [NIP-58](/it/topics/nip-58/) [unita questa settimana](#aggiornamenti-nip). La v1.07.4 ha corretto un problema nella gestione dei secret di Nostr Wallet Connect, e la v1.07.5 ha corretto un crash durante l'upload di immagini.
+
+Sul branch main, ma non ancora in un rilascio taggato, il team ha scritto un'implementazione completa in Kotlin sia di [MLS](/it/topics/mls/) sia del protocollo [Marmot](/it/topics/marmot/), eliminando la necessità di binding a librerie native C/Rust. La [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) aggiunge il layer centrale di messaggistica di gruppo Marmot MLS, la [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) aggiunge la UI della chat di gruppo, la [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) aggiunge i processor dei messaggi in ingresso e in uscita con un subscription manager, la [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) aggiunge la persistenza dello stato dei gruppi MLS e la gestione della rotazione dei KeyPackage, la [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) aggiunge una suite di test MLS completa con una firma di GroupInfo migliorata, e la [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) aggiunge il tracciamento dello stato di pubblicazione dei KeyPackage. La [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) aggiunge un'implementazione secp256k1 in puro Kotlin per le operazioni crittografiche Nostr, sostituendo la dipendenza dalla libreria C nativa. Combinata con l'implementazione Kotlin di MLS, [Quartz](/it/topics/quartz/) può eseguire firma Nostr e messaggistica di gruppo Marmot senza alcun binding nativo, aprendo la strada ai target Kotlin Multiplatform inclusi quelli iOS.
+
+Il team sta anche costruendo il supporto a [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls): la [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) aggiunge una suite di test completa per la call state machine di NIP-AC, e la [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) impedisce che offerte di chiamata stale vengano riattivate dopo il riavvio dell'app.
+
+### Nostur v1.27.0 aggiunge registrazione video e risposte private
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), il client Nostr per iOS, ha distribuito la [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) il 2 aprile. Il rilascio aggiunge la registrazione video in-app con trim prima dell'upload, così gli utenti possono registrare clip brevi, tagliarle alla lunghezza desiderata e pubblicarle senza uscire dal client. Il supporto alle GIF animate si estende alle foto profilo e banner, con l'aggiunta anche del rendering WebP animato. Una nuova integrazione con Shortcuts permette agli utenti di inviare post Nostr dalle automazioni Apple Shortcuts. Il rilascio aggiunge anche le risposte private e corregge problemi di compatibilità DM che influivano sulla consegna dei messaggi tra Nostur e altri client.
+
+### Shosho v0.15.0 lancia Shows e un carousel video verticale
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), l'app di live streaming Nostr, ha distribuito la [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) e la [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) il 7 aprile. La funzione principale è Shows: gli streamer possono preparare informazioni personalizzate sul proprio show prima di andare live e collegare lo show a OBS o a qualsiasi encoder esterno. Questo separa i metadati del "cosa sto trasmettendo" dall'atto di andare in diretta, così gli streamer possono preparare titoli, descrizioni e prodotti prima di iniziare la trasmissione. Lo stesso rilascio aggiunge un carousel video verticale in stile TikTok per scorrere live, clip e replay in un feed a schermo intero, e Quick Add per pubblicare clip video e aggiungere prodotti direttamente dalla pagina profilo. La v0.15.1 corregge un bug per cui la tastiera nascondeva il campo di input della chat del live stream.
+
+## Rilasci di Questa Settimana
+
+### Notedeck v0.10.0-beta distribuisce l'auto-aggiornamento via Zapstore
+
+[Notedeck](https://github.com/damus-io/notedeck), il client desktop e mobile del team Damus, ha distribuito [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) e [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) come prerelease di test per l'auto-aggiornamento APK. La [PR #1417](https://github.com/damus-io/notedeck/pull/1417) aggiunge l'auto-aggiornamento APK via updater Nostr/Zapstore su Android, costruendo sul [lavoro di discovery degli aggiornamenti nativo Nostr dalla Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr). Il flusso di aggiornamento scopre i nuovi rilasci tramite event Nostr pubblicati sui relay, poi scarica l'APK da dove lo sviluppatore lo ospita (GitHub releases, Blossom CDN o altre sorgenti), verifica l'hash SHA-256 rispetto all'event Nostr firmato e lo installa. La [PR #1438](https://github.com/damus-io/notedeck/pull/1438) corregge un bug della welcome screen in cui i pulsanti Login e CreateAccount tornavano subito indietro, e la [PR #1424](https://github.com/damus-io/notedeck/pull/1424) corregge l'overflow del testo nella vista sessione di Agentium AI.
+
+### Amber v6.0.0-pre1 aggiunge chiavi di firma NIP-46 per connessione
+
+[Amber](https://github.com/greenart7c3/Amber), l'app signer [NIP-55](/it/topics/nip-55/) (Android Signer Application), ha distribuito la [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) il 4 aprile. Il cambiamento più importante è l'introduzione di chiavi di firma per connessione per il protocollo bunker [NIP-46](/it/topics/nip-46/) (Nostr Remote Signing). Invece di usare una singola keypair per tutte le connessioni bunker, Amber ora genera una chiave distinta per ogni client connesso. Se una connessione client viene compromessa, l'attaccante non può impersonare il signer verso gli altri client.
+
+La [PR #377](https://github.com/greenart7c3/Amber/pull/377) aggiunge il controllo e l'installazione degli aggiornamenti in-app via Zapstore, unendosi a [Notedeck](#notedeck-v0100-beta-distribuisce-lauto-aggiornamento-via-zapstore) nell'adozione della distribuzione app nativa Nostr. La [PR #375](https://github.com/greenart7c3/Amber/pull/375) gestisce con grazia i fallimenti di AndroidKeyStore mostrando un avviso agli utenti invece di far crashare l'app, e la [PR #371](https://github.com/greenart7c3/Amber/pull/371) aggiunge cleanup del database con limiti di dimensione e troncamento dei contenuti per prevenire una crescita di storage senza limiti. La prerelease include anche la whitelist relay auth [NIP-42](/it/topics/nip-42/) e il login tramite frase mnemonica di recovery dal [ciclo v5.0.x trattato la settimana scorsa](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria distribuisce un'app mobile nativa
+
+[Nostria](https://github.com/nostria-app/nostria), il client Nostr cross-platform mantenuto da SondreB, ha rilasciato un'app mobile nativa per Android con otto rilasci dalla [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) alla [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). La capacità nuova più importante è il supporto nativo ai signer locali come [Amber](https://github.com/greenart7c3/Amber) e Aegis. Sono disponibili anche gli [installer desktop](https://www.nostria.app/download) per Linux, macOS e Windows. La [PR #610](https://github.com/nostria-app/nostria/pull/610) riduce la pressione sulla memoria del feed con limiti runtime adattivi e cleanup delle preview URL. La v3.1.14 corregge l'integrazione con Brainstorm, un provider [Web of Trust](/it/topics/web-of-trust/). La v3.1.15 si concentra sui miglioramenti musicali. La nuova app Android è disponibile su [Zapstore](https://zapstore.dev/apps/app.nostria).
+
+### diVine 1.0.8 distribuisce upload resumable e DM
+
+[diVine](https://github.com/divinevideo/divine-mobile), il client per video brevi, ha distribuito la [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) con 87 PR unite. Gli upload resumable permettono ai creator di riprendere upload interrotti chunk per chunk invece di ricominciare da zero su una connessione instabile. Il rilascio aggiunge impostazioni di qualità video e bitrate, doppio tap per mettere like e miglioramenti ai DM. La [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) aggiunge un plugin fotocamera macOS per la cattura video desktop, e la [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migra il sistema di notifiche a un'architettura BLoC con enrichment e grouping. Il team ha anche sostituito sticker e artwork di categoria generati da AI con SVG OpenMoji ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 aggiunge blur per note sensibili e auth NIP-42
+
+[Manent](https://github.com/dtonon/manent), l'app per note private cifrate e storage file, ha distribuito la [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) il 2 aprile. Gli utenti possono ora segnare le note come sensibili per sfocarle nella list view, mantenendo nascosto il contenuto privato durante lo scorrimento casuale. Il rilascio aggiunge anche il supporto [NIP-42](/it/topics/nip-42/) (Authentication of Clients to Relays), permettendo a Manent di autenticarsi verso relay che lo richiedono prima di accettare event. Manent archivia tutti i dati cifrati sui relay Nostr usando la keypair dell'utente, quindi il supporto NIP-42 amplia l'insieme di relay che può usare per lo storage.
+
+### Wisp da v0.17.0 a v0.17.3 aggiunge zap ai live stream e backup wallet
+
+[Wisp](https://github.com/barrydeen/wisp), il client Nostr Android, ha distribuito sei rilasci dalla [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) alla [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) con 44 PR unite. La v0.17.0 aggiunge prompt di sicurezza per il backup del wallet e miglioramenti alla UX degli zap. La [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) aggiunge la visibilità della chat del live stream tra piattaforme e la funzionalità zap per i live stream. La [PR #423](https://github.com/barrydeen/wisp/pull/423) aggiunge la ricerca automatica dei profili, un'animazione di successo per gli zap e miglioramenti allo stato utente. La [PR #426](https://github.com/barrydeen/wisp/pull/426) corregge un crash out-of-memory in `computeId` per event con grandi liste di tag. I rilasci v0.16.x avevano aggiunto autocompletamento degli shortcode emoji, miglioramenti alla UI della chat di gruppo e filtraggio degli utenti bloccati in tutti i percorsi delle notifiche.
+
+### Mostro distribuisce deep link, tassi di cambio da Nostr e una correzione ai pagamenti duplicati
+
+[Mostro](https://github.com/MostroP2P/mostro), l'exchange Bitcoin peer-to-peer costruito su Nostr, ha registrato aggiornamenti questa settimana sia nel daemon server sia nel client mobile. Sul lato server, la [PR #692](https://github.com/MostroP2P/mostro/pull/692) impedisce che scritture stale degli ordini causino pagamenti duplicati, un bug che poteva portare a pagare due volte un venditore per lo stesso trade. La [PR #693](https://github.com/MostroP2P/mostro/pull/693) usa aggiornamenti mirati per le scritture di dev_fee invece di riscrivere l'intero ordine.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), il client Flutter, ha distribuito la [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) il 3 aprile. Il rilascio gestisce deep link provenienti da diverse istanze Mostro, così gli utenti possono toccare link che instradano verso il server exchange corretto. La [PR #498](https://github.com/MostroP2P/mobile/pull/498) rileva DM di admin e dispute nella pipeline di notifiche in background, e l'app ora recupera i tassi di cambio da Nostr con fallback HTTP/cache. La [PR #560](https://github.com/MostroP2P/mobile/pull/560) corregge un bug bloccante nella connessione ai relay che impediva all'app di raggiungerli in certe condizioni di rete.
+
+### Unfiltered v1.0.12 aggiunge hashtag e commenti
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), un client Nostr focalizzato su contenuti image-forward, ha distribuito la [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12). La [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) aggiunge il supporto agli hashtag e la [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) aggiunge la possibilità di scrivere e visualizzare commenti sui post. La [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) corregge problemi di navigazione con più immagini per post.
+
+### Primal Android distribuisce condivisione wallet multi-account e auto-reconnect del remote signer
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), il client Nostr Android, ha distribuito un rilascio il 7 aprile. L'aggiornamento aggiunge la condivisione wallet multi-account e un menu overflow con cancellazione del wallet nei Dev Tools. Il remote signer ora si riconnette automaticamente quando la connessione cade, e il servizio wallet ha ottenuto una propria logica di auto-reconnect. Le correzioni includono i voti zap dei sondaggi che non appaiono più come Top Zaps, la prevenzione del crash con opzioni di sondaggio vuote, l'occultamento del saldo wallet quando non esiste alcun wallet, e il mapping dei tipi WalletException in codici errore nelle risposte NWC.
+
+### Titan v0.1.0 lancia un browser nativo nsite:// con registrazione dei nomi su Bitcoin
+
+[Titan](https://github.com/btcjt/titan), un browser desktop nativo per il web di Nostr, ha distribuito la [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) il 7 aprile. Titan risolve gli URL `nsite://` cercando nomi leggibili registrati su Bitcoin, interrogando i relay Nostr per gli event di contenuto del sito e renderizzando pagine recuperate da server [Blossom](/it/topics/blossom/). Il risultato è un'esperienza di navigazione web senza DNS, senza certificati TLS e senza hosting provider. I nomi vengono registrati tramite una [web interface](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) legata a transazioni Bitcoin. Il rilascio iniziale è distribuito come `.dmg` per macOS (ARM, con supporto Rosetta 2 per Intel) e include il supporto all'ambiente di sviluppo Nix.
+
+### Bikel v1.5.0 distribuisce un native foreground service per telefoni de-Googled
+
+[Bikel](https://github.com/Mnpezz/bikel), un tracker ciclistico decentralizzato che trasforma le corse in dati di infrastruttura pubblica usando Nostr, ha distribuito la [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) il 4 aprile. Il rilascio migra da Expo TaskManager dipendente da GMS a un foreground service nativo personalizzato, garantendo un tracking affidabile in background su LineageOS, GrapheneOS e altre varianti Android de-Googled. Il Bikel Bot ha ottenuto un'architettura dual-pocket con raccolta eCash autonoma via Cashu nutzaps. La v1.4.3 e la v1.4.2 correggono la sincronizzazione del tracking in background per ambienti Android non standard, e l'app aggiunge toggle per i punti mappa dei portabici OSM.
+
+### Sprout aggiunge supporto a NIP-01, NIP-23 e NIP-33
+
+[Sprout](https://github.com/block/sprout), una piattaforma di comunicazione di Block con relay Nostr integrato, ha distribuito la [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) il 6 aprile. Questa settimana il team ha aggiunto supporto agli articoli kind `30023` di [NIP-23](/en/topics/nip-23/) (Long-form Content), agli event replaceable parametrizzati di [NIP-33](/en/topics/nip-33/) con sostituzione indicizzata dal tag `d`, e alle text note kind `1` e follow list kind `3` di [NIP-01](/it/topics/nip-01/)/[NIP-02](/en/topics/nip-02/). Il rilascio aggiunge anche un sistema di temi IDE adattivi con 54 temi, rifiniture UX per workflow e cronologia delle esecuzioni degli agenti, e cleanup della sidebar membri.
+
+### mesh-llm v0.56.0 distribuisce un protocollo di configurazione distribuito
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), un sistema distribuito di inferenza LLM che usa keypair Nostr per l'identità dei nodi, ha distribuito la [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) il 7 aprile. Il rilascio aggiunge un protocollo di configurazione distribuito con semantiche di ownership, quantizzazione asimmetrica della cache KV (chiavi Q8_0 con valori Q4) per ridurre l'uso di memoria, storage nel keychain del sistema operativo per i keystore di identità, streaming chat fluido con coda dei messaggi, e correzioni al layout fullscreen e alla suddivisione della cache KV con flash attention.
+
+### Nostr VPN distribuisce supporto exit node e packaging Umbrel
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), una VPN peer-to-peer che usa relay Nostr per la segnalazione e WireGuard per i tunnel cifrati, ha distribuito sei rilasci dalla [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) alla [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) questa settimana. Il ciclo v0.3.x aggiunge il supporto agli exit node su Windows e macOS, permettendo ai peer di instradare il traffico Internet attraverso altri nodi della rete. La propagazione di invite e alias ora si sincronizza via Nostr, così gli utenti possono condividere l'accesso alla rete senza coordinamento out-of-band. I rilasci aggiungono packaging Umbrel per deployment self-hosted, NAT punch-through usando endpoint pubblici ricordati, cleanup automatico degli exit node stale e una specifica di protocollo pubblicata. Il progetto ha anche stabilizzato la gestione delle route su macOS con default route auto-riparanti e underlay repair, e ha aggiunto un build Android via Tauri. Sono disponibili build per macOS (Apple Silicon e Intel), Linux (AppImage e .deb), Windows e Android.
+
+### Nymchat abbandona Marmot e distribuisce chat di gruppo NIP-17 potenziate
+
+[Nymchat](https://github.com/Spl0itable/NYM), il client chat capace di MLS, ha distribuito 14 rilasci dalla [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) alla [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274). Il cambiamento più significativo è una svolta di protocollo: la [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) aveva aggiunto chat di gruppo Marmot MLS, ma la [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) è tornata a [NIP-17](/it/topics/nip-17/) perché il supporto multi-device di Marmot non è ancora completo, e questo causava problemi nella sincronizzazione dello stato delle chat di gruppo tra dispositivi. La v3.58.271 introduce chat di gruppo NIP-17 potenziate con chiavi ephemeral a rotazione per tutti i messaggi, progettate per prevenire timing attack e correlation attack. La settimana ha portato anche un sistema amici con controllo granulare delle impostazioni ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), sincronizzazione dei messaggi delle chat di gruppo MLS nelle impostazioni cifrate dell'app, e diverse correzioni alla connettività relay.
+
+### nak v0.19.5 aggiunge Blossom multi-server e pubblicazione outbox
+
+[nak](https://github.com/fiatjaf/nak), il toolkit Nostr a riga di comando di fiatjaf, ha distribuito la [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5). Il comando `blossom` ora accetta più flag `--server` per caricare su diversi server [Blossom](/it/topics/blossom/) in una sola chiamata. Un nuovo comando `key` espande chiavi parziali aggiungendo zeri a sinistra. Il comando `event` guadagna un flag `--outbox` per pubblicare event attraverso il modello outbox, e `fetch` ora termina con un codice errore quando non viene restituito alcun event.
+
+## In Sviluppo
+
+### White Noise aggiunge anteprime thumbhash e il bridge per la registrazione push
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), il messenger privato costruito sul protocollo [Marmot](/it/topics/marmot/), ha unito cinque PR. La [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) sostituisce le anteprime immagine blurhash con thumbhash, un algoritmo più recente che produce immagini placeholder più nitide con una dimensione payload minore (tipicamente sotto i 30 byte contro i ~50-100 byte di blurhash) preservando il rapporto d'aspetto e la distribuzione dei colori dell'immagine originale. Blurhash viene mantenuto come fallback per i contenuti più vecchi. La [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) aggiorna whitenoise-rs e aggiunge il bridge di registrazione push [MIP-05](/it/topics/mip-05/), collegando al client il [lavoro sulla specifica delle push notification della settimana scorsa](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications). La [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) aggiunge la paginazione basata su cursore per i messaggi chat, sostituendo la strategia di caricamento precedente con un approccio guidato dallo scroll.
+
+### Route96 aggiunge configurazione dinamica delle label e cleanup zero-egress
+
+[Route96](https://github.com/v0l/route96), il media server [Blossom](/it/topics/blossom/) di v0l, ha unito tre PR. La [PR #80](https://github.com/v0l/route96/pull/80) aggiunge la configurazione dinamica del modello di label tramite admin API, permettendo agli operatori di sostituire i modelli di classificazione dei contenuti senza riavviare il server. La [PR #82](https://github.com/v0l/route96/pull/82) aggiunge i campi di configurazione delle label alla admin UI. La [PR #79](https://github.com/v0l/route96/pull/79) aggiunge una policy di cleanup dei file zero-egress che rimuove automaticamente i file mai scaricati, mantenendo bassi i costi di storage per gli operatori.
+
+### Snort distribuisce hardening di sicurezza e invoice di pagamento DVM
+
+[Snort](https://github.com/v0l/snort), il client web, ha distribuito due rilasci questa settimana insieme a un audit di sicurezza completo. Le correzioni includono verifica delle firme Schnorr, protezione [NIP-46](/it/topics/nip-46/) contro la falsificazione dei messaggi relay (impedendo ad attaccanti di iniettare richieste di firma attraverso relay compromessi), miglioramenti alla cifratura del PIN e rimozione della fiducia nella delega NIP-26. I miglioramenti prestazionali arrivano dalla verifica Schnorr batch in WASM, route lazy-loaded, traduzioni precompilate ed eliminazione della doppia verifica per event. La [PR #618](https://github.com/v0l/snort/pull/618) aggiunge la visualizzazione dell'invoice kind `7000` con pagamento richiesto di [NIP-90](/en/topics/nip-90/) (Data Vending Machine), così quando un DVM risponde con un requisito di pagamento, Snort renderizza direttamente la Lightning invoice nel feed.
+
+### Damus migliora la compattazione LMDB
+
+[Damus](https://github.com/damus-io/damus), il client iOS, ha unito la [PR #3719](https://github.com/damus-io/damus/pull/3719) che aggiunge la compattazione automatica di LMDB su base pianificata, impedendo al database locale di crescere senza limiti nel tempo. La [PR #3663](https://github.com/damus-io/damus/pull/3663) migliora la BlurOverlayView in modo che sembri protettiva invece che rotta.
+
+### Captain's Log aggiunge indicizzazione dei tag e sync delle note
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), lo strumento di scrittura long-form nativo Nostr di Nodetec, ha unito quattro PR questa settimana. La [PR #156](https://github.com/nodetec/captains-log/pull/156) aggiunge indicizzazione dei tag e supporto alla sincronizzazione tra note, la [PR #157](https://github.com/nodetec/captains-log/pull/157) rifattorizza il sync delle note e la gestione dei tag, e la [PR #159](https://github.com/nodetec/captains-log/pull/159) corregge la sincronizzazione delle note cestinate in modo che gli elementi eliminati restino eliminati su tutti i dispositivi.
+
+### Relatr v0.2.x ridisegna il sistema plugin con un marketplace di validator nativo Nostr
+
+[Relatr](https://github.com/ContextVM/relatr), un motore [Web of Trust](/it/topics/web-of-trust/) che calcola ranking di fiducia dalla distanza nel grafo sociale e da validator configurabili, ha distribuito la famiglia v0.2.x con un redesign completo del sistema plugin. I validator sono ora scritti in Elo, un linguaggio di espressioni funzionali portabile forkato per supportare capacità orchestrate dall'host in più passi (query Nostr, lookup del grafo sociale, risoluzione NIP-05). I plugin vengono pubblicati come event Nostr kind `765`, rendendo la distribuzione nativa alla rete relay. Un nuovo [plugin marketplace](https://relatr.net) permette agli operatori di scoprire, installare e pesare i validator dal browser, con una CLI (`relo`) per authoring e pubblicazione locale. L'architettura è sandboxed: i plugin possono invocare solo le capacità che l'host fornisce esplicitamente, quindi un validator malevolo non può uscire dal proprio scope definito. Le istanze Relatr ora possono essere gestite dal sito web, con visibilità completa su quali plugin compongono l'algoritmo di scoring e sui pesi individuali di ciascuno.
+
+### Shopstr migliora navigazione mobile e controllo accessi
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), il marketplace nativo Nostr per comprare e vendere con Bitcoin, ha spinto 158 commit questa settimana nella sua app principale e nel progetto companion [Milk Market](https://github.com/shopstr-eng/milk-market). Le correzioni includono miglioramenti al layout mobile delle community, comportamento di chiusura del menu durante la navigazione e auto-chiusura dei dropdown. Le route protette non possono più essere raggiunte via URL diretto senza login, e la logica di matching degli slug ora gestisce correttamente più corrispondenze esatte.
+
+### Pollerama aggiunge notifiche, ricerca film e nuova rating UI
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), un'app di polling, survey e rating sociale costruita su Nostr, ha aggiunto notifiche dei thread, una funzione di ricerca film e un overhaul della rating UI. Il rilascio corregge anche problemi di caricamento del feed e aggiorna le versioni delle dipendenze.
+
+### Purser costruisce un payment daemon nativo Nostr con cifratura Marmot
+
+[Purser](https://github.com/EthnTuttle/purser), un payment daemon nativo Nostr progettato come sostituto di Zaprite, ha unito nove PR questa settimana che costruiscono la sua architettura centrale. Il progetto usa MLS di [Marmot](/it/topics/marmot/) tramite MDK per la messaggistica cifrata merchant-customer, con Strike e Square come payment provider. Questa settimana sono arrivati caricamento di configurazione e catalogo, validazione dello schema dei messaggi, il layer di comunicazione MDK, le implementazioni dei provider Strike e Square, un motore di polling, anti-spam rate limiting, persistenza dei pagamenti pending e la pipeline di elaborazione degli ordini. Tutti i 99 test ora esercitano operazioni MLS reali di mdk-core dopo che il team ha rimosso il mock MLS in favore della cifratura reale in modalità locale.
+
+### Vector rifattorizza gli allegati DM e aggiunge la modifica del profilo
+
+[Vector](https://github.com/VectorPrivacy/Vector), il messenger Nostr focalizzato sulla privacy costruito con Tauri, ha unito la [PR #55](https://github.com/VectorPrivacy/Vector/pull/55) che rifattorizza il frontend. La decrittazione e il salvataggio degli allegati DM sono stati spostati nella libreria vector-core, e l'app ora supporta la modifica del profilo. Il flag di cancellazione dell'upload è collegato correttamente attraverso TauriSendCallback, e i callback inutilizzati per l'anteprima degli allegati sono stati ripuliti.
+
+## Lavoro su Protocollo e Specifiche
+
+### Aggiornamenti NIP
+
+Modifiche recenti al [repository NIPs](https://github.com/nostr-protocol/nips):
+
+**Uniti:**
+
+- **[NIP-58](/it/topics/nip-58/) (Badges): i Profile Badges passano al kind 10008, i Badge Sets al kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Migra i Profile Badges dal kind `30008` al kind `10008` (un event replaceable, uno per pubkey) e introduce il kind `30008` per i Badge Sets. In precedenza i Profile Badges usavano lo stesso kind (`30008`) delle definizioni dei badge, rendendoli event replaceable parametrizzati indicizzati da un tag `d`. Il nuovo kind `10008` è un semplice event replaceable: uno per pubkey, nessun tag `d` necessario. I client interrogano un singolo event replaceable per utente invece di scandire event replaceable parametrizzati. Amethyst v1.07.3 distribuisce già questa migrazione.
+
+- **[NIP-34](/it/topics/nip-34/) (Git Stuff): aggiungere follow list relative a git** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): Aggiunge convenzioni di follow list per il tracciamento di repository e issue NIP-34. Gli utenti pubblicano follow set kind `30000` con tag `d` come `git-repos` o `git-issues` contenenti riferimenti tag `a` ai repository (kind `30617`) che vogliono seguire. I client possono sottoscrivere questi follow set per mostrare l'attività dei repository nel feed di un utente, in modo simile a come le contact list kind `3` funzionano per le pubkey.
+
+**PR aperte e discussioni:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): Estende il NIP-100 originale (implementato da 0xChat) con tre cambiamenti: migrazione alla cifratura [NIP-44](/it/topics/nip-44/) avvolta in gift wrap [NIP-59](/it/topics/nip-59/) per eliminare i metadata leak, un workflow WebRTC specificato per setup di chiamate vocali e video (offer, answer, ICE candidates), e un modello di mesh group call in cui ogni peer stabilisce una connessione WebRTC diretta con tutti gli altri peer. La specifica non è backwards-compatible con NIP-100. Amethyst ci sta già lavorando, con una suite di test per la call state machine ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) e la gestione delle call offer stale ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)) arrivate questa settimana.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Propone convenzioni per la threshold signing [FROST](/it/topics/frost/) (Flexible Round-Optimized Schnorr Threshold) su Nostr. FROST permette a un gruppo di signer di controllare collettivamente un'identità Nostr dove qualsiasi insieme t-of-n di membri può firmare event senza ricostruire la chiave privata completa. Il NIP definisce come coordinare i round di firma, distribuire key share e pubblicare event firmati in threshold, costruendo sul lavoro del signer Igloo dal [progetto FROSTR](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Definisce un protocollo `postMessage` per applicazioni web sandboxed ("napplets") eseguite in iframe che comunicano con un'applicazione host ("shell"). La shell fornisce alla napplet firma Nostr, accesso relay e contesto utente tramite una structured message API, mentre la sandbox iframe impedisce l'accesso diretto alle chiavi. Questo estende il modello di hosting di siti web statici di [NIP-5A](/en/topics/nip-5a/) verso applicazioni interattive in grado di leggere e scrivere event Nostr. Il NIP è in sviluppo attivo con un'implementazione runtime funzionante.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): Rinominato dalla precedente proposta NIP-A5. Definisce convenzioni per pubblicare e scoprire programmi WebAssembly su Nostr. I binari WASM vengono archiviati come event Nostr, e i client possono scaricarli ed eseguirli in un runtime sandboxed. Una [demo app](https://nprogram.netlify.app/) mostra scrolls in esecuzione nel browser, con programmi di esempio pubblicati come event Nostr che qualsiasi client può recuperare ed eseguire.
+
+- **[NIP-85](/it/topics/nip-85/) (Trusted Assertions): chiarimenti** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): Stringe il linguaggio della specifica intorno a chiavi multiple e relay multipli per provider di servizi, chiarendo come i client dovrebbero gestire assertion provenienti da provider che operano attraverso più pubkey o endpoint relay.
+
+- **[NIP-24](/it/topics/nip-24/) (Extra Metadata Fields): `published_at` per event replaceable** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): Generalizza il tag `published_at` da [NIP-23](/en/topics/nip-23/) (Long-form Content) a tutti gli event replaceable e addressable. Il tag è solo display-only: se `published_at` è uguale a `created_at`, i client mostrano l'event come "created" in quel momento; se differiscono (perché l'event è stato aggiornato), i client possono mostrare "updated" invece. Questo permette ai profili kind `0` di mostrare date "joined at" e agli altri event replaceable di preservare il timestamp di pubblicazione originale attraverso gli aggiornamenti. Una proposta complementare [NIP-51](/it/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) aggiunge lo stesso tag agli event di lista.
+
+- **[NIP-59](/it/topics/nip-59/) (Gift Wrap): kind di gift wrap ephemeral** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): Aggiunge il kind `21059` come controparte ephemeral del gift wrap esistente kind `1059`. Gli event ephemeral (kind `20000`-`29999`) seguono la semantica di [NIP-01](/it/topics/nip-01/): i relay non sono tenuti a memorizzarli e possono scartarli dopo la consegna. Questo permette alle applicazioni di inviare messaggi gift-wrapped che scompaiono dai relay dopo la consegna, riducendo i requisiti di storage per la messaggistica ad alto volume mantenendo lo stesso modello di cifratura a tre layer dei normali DM [NIP-17](/it/topics/nip-17/).
+
+### OpenSats annuncia la sedicesima ondata di grant Nostr
+
+[OpenSats](https://opensats.org) ha annunciato la sua [sedicesima ondata di grant Nostr](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) l'8 aprile, finanziando quattro grant alla prima assegnazione e un rinnovo. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) riceve fondi per permettere al contributor Robert Nagy di costruire un'app desktop standalone sopra i moduli [Quartz](/it/topics/quartz/) e Commons, portando il set di funzionalità del client Android a interfacce guidate dal mouse con connessioni relay persistenti. [Nostr Mail](https://github.com/nogringo/nostr-mail) riceve fondi per costruire un sistema email completo su Nostr usando event kind `1301` avvolti in gift wrap [NIP-59](/it/topics/nip-59/), con un client Flutter e server bridge SMTP per compatibilità con Gmail/Outlook. [Nostrord](https://github.com/Nostrord/nostrord) riceve fondi per un client di gruppo Kotlin Multiplatform basato su relay [NIP-29](/en/topics/nip-29/) con messaggistica di gruppo, moderazione e thread in stile Discord. [Nurunuru](https://github.com/tami1A84/null--nostr) riceve fondi per costruire una versione iOS nativa del client Nostr orientato al pubblico giapponese modellata sull'interfaccia familiare di LINE, con login biometrico basato su passkey per l'onboarding. HAMSTR ha ricevuto un rinnovo del grant (finanziato la prima volta nell'[undicesima ondata](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)).
+
+## NIP Deep Dive: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) definisce lo standard attuale per i messaggi diretti privati su Nostr. Sostituisce il vecchio schema [NIP-04](/it/topics/nip-04/) (Encrypted Direct Messages), che perdeva metadati (mittente, destinatario e timestamp erano tutti visibili sui relay) e usava una costruzione crittografica più debole. NIP-17 combina [NIP-44](/it/topics/nip-44/) (Encrypted Payloads) per la cifratura con [NIP-59](/it/topics/nip-59/) (Gift Wrap) per la protezione dei metadati, creando un sistema a tre layer in cui i relay non possono vedere chi sta parlando con chi.
+
+Il protocollo usa tre event kind annidati l'uno dentro l'altro. Il layer più interno è il messaggio vero e proprio, un event kind `14` non firmato:
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+L'event kind `14` è deliberatamente non firmato (`sig` vuoto). La specifica descrive questo aspetto come una forma di deniability, ma nella pratica la protezione è limitata. Il seal kind `13` che avvolge il rumor è firmato con la chiave reale del mittente. Un destinatario può mostrare il seal firmato a una terza parte, provando che il mittente ha comunicato con lui, anche senza rivelare il contenuto del messaggio. Con prove a conoscenza zero, un destinatario può persino dimostrare il contenuto esatto del messaggio senza rivelare la propria chiave privata. Il rumor non firmato è come una lettera non firmata in una busta firmata: la firma sulla busta collega il mittente al contenuto. La vera deniability richiederebbe autenticazione simmetrica (come gli HMAC di Signal), incompatibile con il modello relay decentralizzato di Nostr dove i messaggi devono essere self-authenticating. I veri punti di forza di NIP-17 sono la privacy dei metadati e la segretezza del contenuto, non la deniability.
+
+Questo messaggio non firmato viene avvolto in un seal kind `13`, firmato dal mittente effettivo e cifrato con [NIP-44](/it/topics/nip-44/) per il destinatario:
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+Il seal non ha tag, quindi anche se venisse decrittato non rivelerebbe il destinatario. Il seal è firmato con la chiave reale del mittente, il che permette al destinatario di autenticare il messaggio controllando che il `pubkey` del seal corrisponda al `pubkey` del kind `14` interno.
+
+Il seal viene poi avvolto in un gift wrap kind `1059`, firmato con una chiave casuale usa-e-getta e indirizzato al destinatario:
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+Il `pubkey` del gift wrap è una chiave casuale generata solo per questo messaggio, e il `created_at` è randomizzato fino a due giorni nel passato. Questo è il layer più esterno che i relay vedono davvero: un messaggio da una pubkey sconosciuta indirizzato al destinatario, con un timestamp che non riflette quando il messaggio è stato effettivamente inviato. Il timestamp randomizzato protegge dall'analisi retrospettiva degli event archiviati, ma un avversario collegato attivamente ai relay può comunque osservare quando il gift wrap è apparso per la prima volta, quindi questa difesa è limitata agli osservatori passivi che interrogano i dati del relay in seguito. Poiché la pubkey è casuale e il timestamp è fittizio, i relay non possono determinare il mittente reale. Per leggere il messaggio, il destinatario decripta il gift wrap usando la propria chiave e la pubkey casuale, trova il seal all'interno, decripta il seal usando la propria chiave e la pubkey del mittente ricavata dal seal, e trova all'interno il messaggio kind `14`.
+
+NIP-17 non fornisce forward secrecy. Tutti i messaggi sono cifrati usando la keypair Nostr statica (tramite la derivazione delle chiavi di NIP-44 dalle chiavi del mittente e del destinatario). Se una chiave privata viene compromessa, ogni messaggio passato e futuro cifrato verso quella chiave può essere decrittato. È un tradeoff deliberato: poiché la cifratura dipende solo dall'nsec, un utente che fa il backup del proprio nsec può recuperare l'intera cronologia dei messaggi da qualsiasi relay che conservi ancora i gift wrap. Protocolli come MLS (usato da [Marmot](/it/topics/marmot/)) forniscono forward secrecy attraverso la rotazione del materiale di chiave, ma al costo di richiedere sincronizzazione dello stato e rendere impossibile il recupero storico dei messaggi dopo la rotazione delle chiavi.
+
+NIP-17 definisce anche il kind `15` per i messaggi file cifrati, che aggiunge i tag `file-type`, `encryption-algorithm`, `decryption-key` e `decryption-nonce` così il destinatario può decrittare un file allegato cifrato con AES-GCM prima dell'upload a un server Blossom. Il kind `10050` viene usato per pubblicare la relay list DM preferita dell'utente, così i mittenti sanno dove consegnare i gift wrap. L'insieme di tag `pubkey` + `p` in un messaggio definisce una chat room; aggiungere o rimuovere un partecipante crea una nuova stanza con cronologia pulita.
+
+Le implementazioni coprono la maggior parte dei client principali. [nospeak](https://github.com/psic4t/nospeak) usa NIP-17 per tutta la messaggistica uno-a-uno. [Flotilla](https://gitea.coracle.social/coracle/flotilla) usa NIP-17 per i suoi DM con proof-of-work. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel) e [Coracle](https://github.com/coracle-social/coracle) implementano tutti NIP-17 come protocollo DM principale. La specifica supporta anche i messaggi a scomparsa impostando un tag `expiration` nel gift wrap.
+
+## NIP Deep Dive: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) definisce un protocollo per separare la chiave privata dell'utente dall'applicazione client. Invece di incollare un nsec in una web app, l'utente esegue un remote signer (chiamato anche "bunker") che custodisce la chiave privata e risponde alle richieste di firma via relay Nostr. Il client non vede mai la chiave privata. Questo riduce la superficie d'attacco: un client compromesso può richiedere firme ma non può estrarre la chiave stessa.
+
+Il protocollo usa il kind `24133` sia per le richieste sia per le risposte, cifrate con [NIP-44](/it/topics/nip-44/) (Encrypted Payloads). Un client genera una `client-keypair` usa-e-getta per la sessione e comunica con il remote signer attraverso messaggi cifrati NIP-44 taggati con le reciproche pubkey. Ecco una richiesta di firma da un client a un remote signer:
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+Il `content` cifrato contiene una struttura in stile JSON-RPC:
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+Il remote signer decripta la richiesta, la presenta all'utente per l'approvazione (o la approva automaticamente in base ai permessi configurati), firma l'event con la chiave privata dell'utente e restituisce l'event firmato in una risposta:
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Le connessioni possono essere avviate da entrambi i lati. Un remote signer fornisce un URL `bunker://` contenente la sua pubkey e le informazioni relay. Un client fornisce un URL `nostrconnect://` con la propria pubkey client, i relay e un secret per la verifica della connessione. Il parametro `secret` previene il connection spoofing: solo la parte che ha ricevuto l'URL fuori banda può completare l'handshake.
+
+Sono definiti otto metodi: `connect` per stabilire la sessione, `sign_event` per firmare event, `get_public_key` per ottenere la pubkey dell'utente, `ping` per keepalive, `nip04_encrypt`/`nip04_decrypt` per la cifratura legacy, `nip44_encrypt`/`nip44_decrypt` per la cifratura corrente, e `switch_relays` per la gestione dei relay. La migrazione relay è gestita dal remote signer, che può spostare nel tempo la connessione verso nuovi relay senza rompere la sessione.
+
+I client richiedono capacità specifiche al momento della connessione attraverso un sistema di permessi. Una stringa di permessi come `nip44_encrypt,sign_event:1,sign_event:14` richiede accesso alla cifratura NIP-44 e accesso alla firma per i soli event kind `1` e kind `14`. Il remote signer può accettare, rifiutare o modificare questi permessi. Questo significa che un client web per leggere e pubblicare note potrebbe ricevere solo il permesso `sign_event:1`, mentre un client DM potrebbe ricevere anche i permessi `sign_event:14` e `nip44_encrypt`.
+
+[Amber](https://github.com/greenart7c3/Amber) implementa NIP-46 su Android, e la sua [v6.0.0-pre1](#amber-v600-pre1-aggiunge-chiavi-di-firma-nip-46-per-connessione) di questa settimana aggiunge chiavi di firma per connessione per isolare i client tra loro. [nsec.app](https://github.com/nicktee/nsecapp) (precedentemente Nostr Connect) fornisce un bunker web-based. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) include `BunkerSigner` per i client JavaScript, e [la PR #530 della settimana scorsa](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) ha aggiunto `skipSwitchRelays` per la gestione manuale dei relay. Il protocollo supporta anche auth challenge: quando un remote signer richiede autenticazione aggiuntiva (password, biometria o token hardware), risponde con un `auth_url` che il client apre in un browser perché l'utente completi il flusso.
+
+---
+
+Questo è tutto per questa settimana. Stai costruendo qualcosa o hai notizie da condividere? Scrivici in DM su Nostr o vieni a trovarci su [nostrcompass.org](https://nostrcompass.org).

--- a/content/ja/newsletters/2026-04-08-newsletter.md
+++ b/content/ja/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Nostr Compassへようこそ。Nostrの週刊ガイドです。
+
+**今週の内容:** [Amethyst](https://github.com/vitorpamplona/amethyst)が、Arti Tor統合と再設計されたShorts UIを備えた[v1.08.0](#amethystがarti-torを出荷しpure-kotlinのmlsとmarmotを統合)を出荷し、[MLS](/ja/topics/mls/)と[Marmot](/ja/topics/marmot/)のpure Kotlin実装を[Quartz](/ja/topics/quartz/)ライブラリへ統合しました。[Nostur](https://github.com/nostur-com/nostur-ios-public)は、動画録画、アニメーションGIFプロフィール、プライベート返信を備えた[v1.27.0](#nostur-v1270が動画録画とプライベート返信を追加)を出荷しました。[Shosho](https://github.com/r0d8lsh0p/shosho-releases)は、Shows（OBSに接続できるカスタム配信情報）とTikTok風の縦型動画カルーセルを備えた[v0.15.0](#shosho-v0150がshowsと縦型動画カルーセルをローンチ)を開始しました。[Nymchat](https://github.com/Spl0itable/NYM)は、ローテーションするephemeral keysを使う[強化版NIP-17グループチャットへ戻すためMarmotを巻き戻し](#nymchatがmarmotを巻き戻し強化版nip-17グループチャットを出荷)、[Nostr VPN](https://github.com/mmalmi/nostr-vpn)は6リリースにわたり[exit node対応とUmbrelパッケージング](#nostr-vpnがexit-node対応とumbrelパッケージングを出荷)を進めました。[Amber](https://github.com/greenart7c3/Amber)は接続ごとの[NIP-46](/ja/topics/nip-46/)署名鍵とZapstoreアプリ内更新を備えた[v6.0.0-pre1](#amber-v600-pre1が接続ごとのnip-46署名鍵を追加)へ進みました。[Notedeck](https://github.com/damus-io/notedeck)はZapstore経由のAPK self-updateを備えた[v0.10.0-beta](#notedeck-v0100-betaがzapstore-self-updateを出荷)に到達し、[NIP-58](/ja/topics/nip-58/)（Badges）では[kind migration](#nipアップデート)が入りました。今週のNIPディープダイブは[NIP-17](/ja/topics/nip-17/)（Private Direct Messages）と[NIP-46](/ja/topics/nip-46/)（Nostr Remote Signing）です。
+
+## トップストーリー
+
+### AmethystがArti Torを出荷し、pure KotlinのMLSとMarmotを統合
+
+[Amethyst](https://github.com/vitorpamplona/amethyst)はvitorpamplonaがメンテナンスするAndroidクライアントで、[v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3)から[v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0)まで4リリースを出荷し、未リリース作業の大きなまとまりを[Quartz](/ja/topics/quartz/)ライブラリ（共有Kotlin Multiplatform Nostrモジュール）へ統合しました。見出しとなるリリースはv1.08.0「Arti Tor」で、アプリのTor接続をCベースのTorライブラリから、Tor ProjectによるRust実装の[Arti](https://gitlab.torproject.org/tpo/core/arti)へ移行します。この移行は、従来のC Torバインディング下で起きていたランダムクラッシュに対処するものです。Artiはメモリ安全性とasync I/Oを目的にRustでゼロから書かれた、Tor ProjectによるCコードベースの長期的な置き換えです。
+
+v1.07.3ではShorts UIも再設計され、ページ送り型のデザインが、画像、shorts、長尺動画向けのedge-to-edgeフィードへ置き換えられました。同じリリースでbadgesはkind `10008`へ、bookmarksはkind `10003`へ移行され、今週[マージされた](#nipアップデート)[NIP-58](/ja/topics/nip-58/)のkind migrationと足並みをそろえています。v1.07.4ではNostr Wallet Connectのsecret処理問題が修正され、v1.07.5では画像アップロード時のクラッシュが修正されました。
+
+mainには入っているものの、まだタグ付きリリースには含まれていない作業として、チームは[MLS](/ja/topics/mls/)と[Marmot](/ja/topics/marmot/)プロトコルの完全なKotlin実装を書き上げ、ネイティブC/Rustライブラリバインディングを不要にしました。[PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147)はMarmot MLSグループメッセージングの中核層を追加し、[PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149)はグループチャットUIを追加し、[PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146)はsubscription manager付きの送受信メッセージプロセッサを追加します。[PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141)はMLS group stateの永続化とKeyPackage rotation管理を追加し、[PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150)は改良されたGroupInfo署名を備えた完全なMLS test suiteを追加し、[PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158)はKeyPackage公開状態の追跡を追加します。[PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166)はNostrの暗号処理向けにpure Kotlinのsecp256k1実装を追加し、ネイティブCライブラリ依存を置き換えます。Kotlin版MLS実装と組み合わせることで、[Quartz](/ja/topics/quartz/)はネイティブバインディングなしでNostr署名とMarmotグループメッセージングを実行できるようになり、iOSを含むKotlin Multiplatformターゲットへの道が開かれます。
+
+チームは[NIP-AC](/en/topics/nip-ac/)（P2P Voice and Video Calls）サポートも進めています。[PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)はNIP-AC call state machine向けの完全なtest suiteを追加し、[PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)はアプリ再起動後に古いcall offerが再発火しないようにしています。
+
+### Nostur v1.27.0が動画録画とプライベート返信を追加
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public)はiOS Nostrクライアントで、4月2日に[v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0)を出荷しました。このリリースは、アップロード前トリミング付きのアプリ内動画録画を追加しており、ユーザーは短いクリップを撮影し、長さを整え、クライアントを離れずに公開できます。アニメーションGIF対応はプロフィール写真とバナー写真にも広がり、アニメーションWebPレンダリングも追加されました。新しいShortcuts統合により、Apple Shortcutsの自動化からNostr投稿を送れるようにもなっています。さらに、private repliesが追加され、Nosturと他クライアントの間でメッセージ配信に影響していたDM互換性問題も修正されました。
+
+### Shosho v0.15.0がShowsと縦型動画カルーセルをローンチ
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases)はNostrライブ配信アプリで、4月7日に[v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0)と[v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1)を出荷しました。目玉機能はShowsです。配信者はライブ開始前にカスタムの番組情報を設定し、その番組をOBSや任意の外部エンコーダへ接続できます。これにより、「今何を配信しているのか」というメタデータが、実際に配信を開始する操作から切り離され、配信者はタイトル、説明、商品を事前に準備できるようになります。同じリリースでは、ライブ、クリップ、リプレイをフルスクリーンフィードでスワイプして見ていけるTikTok風の縦型動画カルーセルと、プロフィールページから直接動画クリップを公開したり商品を追加したりできるQuick Addも入りました。v0.15.1では、キーボードがライブ配信チャット入力欄を隠していたバグが修正されています。
+
+## 今週のリリース
+
+### Notedeck v0.10.0-betaがZapstore self-updateを出荷
+
+[Notedeck](https://github.com/damus-io/notedeck)はDamusチームによるデスクトップおよびモバイルクライアントで、APK self-update向けのテスト用プレリリースとして[v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1)と[v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2)を出荷しました。[PR #1417](https://github.com/damus-io/notedeck/pull/1417)はAndroidでNostr/Zapstore updater経由のAPK self-updateを追加し、[Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr)で扱ったNostrネイティブな更新発見の作業を土台にしています。更新フローは、relayへ公開されたNostrイベントを通じて新しいリリースを発見し、その後、開発者がホストしている場所（GitHub releases、Blossom CDN、そのほかの配布元）からAPKをダウンロードし、署名済みNostrイベントに対してSHA-256 hashを検証してからインストールします。[PR #1438](https://github.com/damus-io/notedeck/pull/1438)はLoginボタンとCreateAccountボタンが即座に前画面へ戻ってしまうwelcome screenのバグを修正し、[PR #1424](https://github.com/damus-io/notedeck/pull/1424)はAgentium AI session viewでのテキストあふれを修正します。
+
+### Amber v6.0.0-pre1が接続ごとのNIP-46署名鍵を追加
+
+[Amber](https://github.com/greenart7c3/Amber)は[NIP-55](/ja/topics/nip-55/)（Android Signer Application）署名者アプリで、4月4日に[v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1)を出荷しました。最も重要な変更は、[NIP-46](/ja/topics/nip-46/)（Nostr Remote Signing）bunkerプロトコル向けの接続ごとの署名鍵です。Amberは、すべてのbunker接続に単一のkeypairを使う代わりに、接続された各クライアントごとに別の鍵を生成するようになりました。1つのクライアント接続が侵害されても、攻撃者は他のクライアントに対して署名者になりすますことができません。
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377)はZapstore経由のアプリ内更新確認とインストールを追加し、[Notedeck](#notedeck-v0100-betaがzapstore-self-updateを出荷)と並んでNostrネイティブなアプリ配布を採用しました。[PR #375](https://github.com/greenart7c3/Amber/pull/375)はAndroidKeyStore障害時にクラッシュさせず警告を表示するようにし、[PR #371](https://github.com/greenart7c3/Amber/pull/371)は無制限なストレージ増大を防ぐため、サイズ制限とcontent切り詰めを伴うデータベースクリーンアップを追加しています。このプレリリースには、[先週扱ったv5.0.xサイクル](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504)から[NIP-42](/ja/topics/nip-42/) relay auth whitelistとmnemonic recovery phrase loginも引き継がれています。
+
+### Nostriaがネイティブモバイルアプリを出荷
+
+[Nostria](https://github.com/nostria-app/nostria)はSondreBがメンテナンスするクロスプラットフォームNostrクライアントで、Android向けのネイティブモバイルアプリを、[v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11)から[v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18)まで8リリースにわたり公開しました。最も重要な新機能は、[Amber](https://github.com/greenart7c3/Amber)やAegisのような署名者向けのネイティブlocal signer対応です。Linux、macOS、Windows向けの[デスクトップインストーラー](https://www.nostria.app/download)も利用できます。[PR #610](https://github.com/nostria-app/nostria/pull/610)は適応的runtime制限とpreview URL cleanupによりフィードのメモリ負荷を下げ、v3.1.14では[Web of Trust](/ja/topics/web-of-trust/)プロバイダーであるBrainstormとの統合が修正されました。v3.1.15は音楽機能の改善に集中しています。新しいAndroidアプリは[Zapstore](https://zapstore.dev/apps/app.nostria)で入手できます。
+
+### diVine 1.0.8がresumable uploadsとDMsを出荷
+
+[diVine](https://github.com/divinevideo/divine-mobile)は短尺動画クライアントで、87件のマージ済みPRを含む[1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8)を出荷しました。resumable uploadsにより、接続が不安定な環境でアップロードが中断されても、クリエイターは最初からやり直すのではなく、チャンク単位で続きから再開できます。このリリースでは動画品質とビットレート設定、ダブルタップでのlike、DM改善も追加されました。[PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722)はデスクトップ動画撮影向けのmacOS camera pluginを追加し、[PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820)は通知システムをenrichmentとgroupingを備えたBLoCアーキテクチャへ移行します。チームはAI生成のステッカーとカテゴリ画像もOpenMoji SVGへ置き換えました（[PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844)、[PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)）。
+
+### Manent v1.3.0が機密ノートのぼかし表示とNIP-42 authを追加
+
+[Manent](https://github.com/dtonon/manent)はプライベートな暗号化ノートおよびファイルストレージアプリで、4月2日に[v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0)を出荷しました。ユーザーはノートをsensitiveとしてマークできるようになり、一覧表示ではぼかして、何気ないスクロール中に私的な内容が露出しないようにできます。このリリースでは[NIP-42](/ja/topics/nip-42/)（Authentication of Clients to Relays）対応も追加され、Manentはイベントを受け入れる前に認証を要求するrelayへも接続できるようになりました。Manentはすべてのデータをユーザーのkeypairを使ってNostr relays上に暗号化して保存するため、NIP-42対応はストレージに使えるrelayの集合を広げます。
+
+### Wisp v0.17.0からv0.17.3がライブ配信zapsとwallet backupを追加
+
+[Wisp](https://github.com/barrydeen/wisp)はAndroid Nostrクライアントで、[v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta)から[v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta)まで6リリース、44件のマージ済みPRを出荷しました。v0.17.0ではwallet backup向けの安全プロンプトとzap UX改善が追加されています。[v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta)はプラットフォーム横断のライブ配信チャット可視化とライブ配信zap機能を追加しました。[PR #423](https://github.com/barrydeen/wisp/pull/423)はprofileのauto-search、zap success animation、ユーザーステータス改善を追加し、[PR #426](https://github.com/barrydeen/wisp/pull/426)は大きなtag listを持つイベントで`computeId`がout-of-memoryクラッシュする問題を修正します。v0.16.x系列ではemoji shortcode autocomplete、グループチャットUI改善、すべての通知経路にわたるブロック済みユーザーフィルタリングも入りました。
+
+### Mostroがdeep links、Nostr為替レート、重複支払い修正を出荷
+
+[Mostro](https://github.com/MostroP2P/mostro)はNostr上に構築されたP2P Bitcoin取引所で、今週はサーバーデーモンとモバイルクライアントの両方で更新がありました。サーバー側では、[PR #692](https://github.com/MostroP2P/mostro/pull/692)が古い注文書き込みによって重複支払いが起きるのを防ぎます。このバグは、同じ取引に対して売り手へ二重に支払いが行われる可能性がありました。[PR #693](https://github.com/MostroP2P/mostro/pull/693)はorder全体の上書きではなく、dev_fee書き込みに対して対象を絞った更新を使います。
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile)はFlutterクライアントで、4月3日に[v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3)を出荷しました。このリリースは異なるMostroインスタンスからのdeep linksを扱えるため、ユーザーは正しい取引所サーバーへルーティングされるリンクをそのままタップできます。[PR #498](https://github.com/MostroP2P/mobile/pull/498)はバックグラウンド通知パイプラインでadminおよびdispute DMを検出し、アプリはHTTP/cache fallback付きでNostrから為替レートを取得するようになりました。[PR #560](https://github.com/MostroP2P/mobile/pull/560)は、特定のネットワーク条件でアプリがrelayへ到達できなくなるrelay connection blockingバグを修正します。
+
+### Unfiltered v1.0.12がhashtagsとcommentsを追加
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered)は画像中心のcontentに焦点を当てたNostrクライアントで、[v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12)を出荷しました。[PR #69](https://github.com/dmcarrington/unfiltered/pull/69)はhashtag対応を追加し、[PR #72](https://github.com/dmcarrington/unfiltered/pull/72)は投稿へcommentsを書いて表示する機能を追加します。[PR #71](https://github.com/dmcarrington/unfiltered/pull/71)は、1投稿に複数画像がある場合のナビゲーション問題を修正しました。
+
+### Primal Androidがwallet multi-account sharingとremote signer auto-reconnectを出荷
+
+[Primal](https://github.com/PrimalHQ/primal-android-app)はAndroid Nostrクライアントで、4月7日にリリースを出荷しました。この更新ではwallet multi-account sharingが追加され、Dev Toolsにはwallet削除付きのoverflow menuが入りました。remote signerは接続断時に自動再接続するようになり、wallet serviceにも独自のauto-reconnectロジックが追加されています。修正には、poll zap votesがTop Zapsに表示されなくなる変更、空のpoll optionでのクラッシュ防止、wallet未設定時の残高非表示、NWCレスポンス内でWalletException型をerror codeへマッピングする対応が含まれます。
+
+### Titan v0.1.0がBitcoin名登録付きネイティブ`nsite://`ブラウザをローンチ
+
+[Titan](https://github.com/btcjt/titan)はNostr web向けのネイティブデスクトップブラウザで、4月7日に[v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0)を出荷しました。Titanは、Bitcoin上に登録された人間可読名を参照して`nsite://` URLを解決し、Nostr relaysへサイトのcontent eventsを問い合わせ、[Blossom](/ja/topics/blossom/)サーバーから取得したページをレンダリングします。その結果、DNSもTLS証明書もホスティング事業者も要らないweb閲覧体験が生まれます。名前はBitcoinトランザクションに結び付いた[web interface](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register)を通じて登録されます。初期リリースはmacOS `.dmg`（ARM、Intel向けRosetta 2対応）として提供され、Nix開発環境サポートも含みます。
+
+### Bikel v1.5.0がde-Googled phones向けネイティブforeground serviceを出荷
+
+[Bikel](https://github.com/Mnpezz/bikel)は、Nostrを使ってライド記録を公共インフラデータへ変える分散型サイクリングトラッカーで、4月4日に[v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0)を出荷しました。このリリースでは、GMS依存のExpo TaskManagerからカスタムのネイティブforeground serviceへ移行し、LineageOS、GrapheneOS、そのほかのde-Googled Android環境で信頼性の高いバックグラウンド走行追跡を確保します。Bikel BotはCashu nutzapsによる自律的なeCash回収を行うdual-pocket architectureも獲得しました。v1.4.3とv1.4.2では非標準Android環境向けのバックグラウンド追跡同期が修正され、アプリにはOSM bike rack map pointの切り替えも追加されています。
+
+### SproutがNIP-01、NIP-23、NIP-33対応を追加
+
+[Sprout](https://github.com/block/sprout)はBlockによる、Nostr relayを内蔵したコミュニケーションプラットフォームで、4月6日に[desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7)を出荷しました。今週、チームは[NIP-23](/en/topics/nip-23/)（Long-form Content）のkind `30023`記事、`d`タグをキーに置き換える[NIP-33](/en/topics/nip-33/) parameterized replaceable events、そして[NIP-01](/ja/topics/nip-01/)/[NIP-02](/en/topics/nip-02/)のkind `1` text notesとkind `3` follow listsへの対応を追加しました。リリースには、54テーマを持つ適応型IDEテーマシステム、workflowおよびagent実行履歴のUX改善、members sidebarの整理も含まれています。
+
+### mesh-llm v0.56.0が分散config protocolを出荷
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm)は、ノードアイデンティティにNostr keypairsを使う分散LLM推論システムで、4月7日に[v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0)を出荷しました。このリリースは、ownership semanticsを備えた分散config protocol、メモリ使用量を減らすための非対称KV cache quantization（Q8_0 keysとQ4 values）、アイデンティティkeystore向けのOS keychain保存、メッセージキューイングを伴う滑らかなchat streaming、fullscreen layoutとflash attention付きKV cache splittingの修正を追加します。
+
+### Nostr VPNがexit node対応とUmbrelパッケージングを出荷
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn)は、シグナリングにNostr relays、暗号化トンネルにWireGuardを使うP2P VPNで、今週は[v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0)から[v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6)まで6リリースを出荷しました。v0.3.xサイクルではWindowsとmacOSでexit node対応が追加され、ピアはネットワーク内の他ノードを経由してインターネットトラフィックをルーティングできるようになりました。inviteとaliasの伝播もNostr上で同期されるようになったため、ユーザーは帯域外の調整なしにネットワークアクセスを共有できます。これらのリリースには、self-hosted deployment向けUmbrelパッケージング、記憶した公開endpointを使うNAT punch-through、自動のstale exit node cleanup、公開されたprotocol specificationも含まれます。プロジェクトはself-healing default routesとunderlay repairによりmacOSのroute処理も安定化させ、Tauri経由のAndroid buildも追加しました。ビルドはmacOS（Apple SiliconとIntel）、Linux（AppImageと.deb）、Windows、Android向けに利用できます。
+
+### NymchatがMarmotを巻き戻し、強化版NIP-17グループチャットを出荷
+
+[Nymchat](https://github.com/Spl0itable/NYM)はMLS対応チャットクライアントで、[v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261)から[v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274)まで14リリースを出荷しました。最も大きな変化はプロトコル方針の転換です。[v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261)ではMarmot MLS group chatsが追加されましたが、[v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268)では[Marmot](/ja/topics/marmot/)のmulti-device対応がまだ未完成で、デバイス間のgroup chat state同期に問題が出たため、[NIP-17](/ja/topics/nip-17/)へ戻しました。v3.58.271では、すべてのメッセージに対してローテーションするephemeral keysを使う強化版NIP-17グループチャットが導入され、タイミング攻撃や相関攻撃を防ぐ設計になっています。同週には、設定を細かく制御できるfriend system（[v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)）、暗号化されたアプリ設定内でのMLS group chat message同期、複数のrelay接続修正も入りました。
+
+### nak v0.19.5がBlossom multi-serverとoutbox publishingを追加
+
+[nak](https://github.com/fiatjaf/nak)はfiatjafによるコマンドラインNostrツールキットで、[v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5)を出荷しました。`blossom`コマンドは複数の`--server`フラグを受け取れるようになり、複数の[Blossom](/ja/topics/blossom/)サーバーへ1回でアップロードできます。新しい`key`コマンドは、部分的な鍵を左側ゼロ埋めで展開します。`event`コマンドにはoutbox model経由でイベントを公開する`--outbox`フラグが追加され、`fetch`はイベントが返らなかった場合にerror codeで終了するようになりました。
+
+## 開発中
+
+### White Noiseがthumbhashプレビューとpush registration bridgeを追加
+
+[White Noise](https://github.com/marmot-protocol/whitenoise)は[Marmot](/ja/topics/marmot/)プロトコル上に構築されたプライベートメッセンジャーで、今週5件のPRをマージしました。[PR #549](https://github.com/marmot-protocol/whitenoise/pull/549)は画像プレビューのblurhashをthumbhashへ置き換えます。thumbhashは、元画像のアスペクト比と色分布を保ちながら、より小さいペイロードサイズで（典型的には30バイト未満、blurhashの約50から100バイトに対して）より鮮明なプレースホルダー画像を生成する新しいアルゴリズムです。古いcontent向けにはblurhashがfallbackとして残されています。[PR #548](https://github.com/marmot-protocol/whitenoise/pull/548)はwhitenoise-rsを更新し、[MIP-05](/ja/topics/mip-05/) push registration bridgeを追加して、[先週のpush notification仕様作業](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications)をクライアントへ接続します。[PR #493](https://github.com/marmot-protocol/whitenoise/pull/493)はチャットメッセージにcursor-based paginationを追加し、従来の読み込み戦略をスクロール駆動の方式へ置き換えました。
+
+### Route96が動的label設定とzero-egress cleanupを追加
+
+[Route96](https://github.com/v0l/route96)はv0lによる[Blossom](/ja/topics/blossom/)メディアサーバーで、今週3件のPRをマージしました。[PR #80](https://github.com/v0l/route96/pull/80)はadmin API経由の動的label model設定を追加し、オペレーターがサーバー再起動なしにcontent分類モデルを差し替えられるようにします。[PR #82](https://github.com/v0l/route96/pull/82)はadmin UIへlabel設定フィールドを追加し、[PR #79](https://github.com/v0l/route96/pull/79)は一度もダウンロードされていないファイルを自動削除するzero-egress file cleanup policyを追加して、オペレーターのストレージコストを抑えます。
+
+### Snortがセキュリティ強化とDVM payment invoicesを出荷
+
+[Snort](https://github.com/v0l/snort)はwebクライアントで、今週は包括的なセキュリティ監査を伴う2リリースを出荷しました。修正にはSchnorr署名検証、[NIP-46](/ja/topics/nip-46/) relay message forgery保護（侵害されたrelay経由で攻撃者が署名要求を注入するのを防ぐ）、PIN暗号化改善、NIP-26 delegation trustの削除が含まれます。性能面の改善は、WASM内でのバッチSchnorr検証、lazy-loaded routes、事前コンパイル済み翻訳、イベントごとの二重検証の排除から来ています。[PR #618](https://github.com/v0l/snort/pull/618)は[NIP-90](/en/topics/nip-90/)（Data Vending Machine）のkind `7000`支払い要求invoice表示を追加し、DVMが支払い要件を返したときにSnortがLightning invoiceをフィード内へ直接描画できるようにします。
+
+### DamusがLMDB compactionを改善
+
+[Damus](https://github.com/damus-io/damus)はiOSクライアントで、[PR #3719](https://github.com/damus-io/damus/pull/3719)をマージし、スケジュールに基づく自動LMDB compactionを追加しました。これによりローカルデータベースが時間とともに無制限に肥大化するのを防ぎます。[PR #3663](https://github.com/damus-io/damus/pull/3663)はBlurOverlayViewを、壊れて見えるのではなく保護的に見えるよう改善しています。
+
+### Captain's Logがtag indexingとnote syncを追加
+
+[Captain's Log](https://github.com/nodetec/captains-log)（Comet）はNodetecによるNostrネイティブな長文執筆ツールで、今週4件のPRをマージしました。[PR #156](https://github.com/nodetec/captains-log/pull/156)はノート横断のtag indexingとsync対応を追加し、[PR #157](https://github.com/nodetec/captains-log/pull/157)はnote syncとtag処理をリファクタリングし、[PR #159](https://github.com/nodetec/captains-log/pull/159)はゴミ箱に入れたノートの同期を修正して、削除済みノートがデバイス間でも削除されたまま保たれるようにします。
+
+### Relatr v0.2.xがNostrネイティブvalidator marketplaceとともにplugin systemを再設計
+
+[Relatr](https://github.com/ContextVM/relatr)は、social graph distanceと設定可能なvalidatorsからtrust rankingを計算する[Web of Trust](/ja/topics/web-of-trust/) scoring engineで、完全なplugin system再設計を伴うv0.2.x系列を出荷しました。validatorsは現在、マルチステップのhostオーケストレーション能力（Nostrクエリ、social graph lookup、NIP-05解決）を支えるためにforkされた、移植性の高い関数型式言語Eloで書かれています。pluginsはkind `765`のNostr eventsとして公開されるため、配布自体がrelayネットワークにネイティブです。新しい[plugin marketplace](https://relatr.net)により、オペレーターはブラウザからvalidatorsを発見、インストール、重み付けでき、ローカルでのauthoringとpublishingにはCLIの`relo`が使えます。アーキテクチャはsandbox化されており、pluginsはhostが明示的に提供した能力しか呼び出せないため、悪意あるvalidatorが定義されたスコープを抜け出すことはできません。Relatrインスタンスは今やwebsiteから管理でき、どのpluginsがscoring algorithmを構成しているか、各重みがいくつかまで完全に見通せます。
+
+### Shopstrがモバイルナビゲーションとアクセス制御を改善
+
+[Shopstr](https://github.com/shopstr-eng/shopstr)はBitcoinでの売買向けNostrネイティブなマーケットプレイスで、今週はメインアプリとコンパニオンプロジェクトの[Milk Market](https://github.com/shopstr-eng/milk-market)にまたがって158コミットを積みました。修正には、モバイルcommunityレイアウト改善、ナビゲーション時のmenu自動クローズ、dropdownのauto-closeが含まれます。保護されたルートはサインインなしで直接URLからアクセスできなくなり、slug matchingロジックも複数の完全一致を正しく扱うようになりました。
+
+### Polleramaがnotifications、movie search、rating UIを追加
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls)はNostr上に構築されたpolling、survey、social ratingアプリで、thread notifications、movie search機能、rating UIの刷新を追加しました。このリリースではfeed読み込み問題の修正と依存関係バージョン更新も行われています。
+
+### PurserがMarmot暗号化を使うNostrネイティブpayment daemonを構築
+
+[Purser](https://github.com/EthnTuttle/purser)はZaprite代替として設計されたNostrネイティブpayment daemonで、今週はコアアーキテクチャ構築のために9件のPRをマージしました。このプロジェクトは、加盟店と顧客の暗号化メッセージングに、MDK経由の[Marmot](/ja/topics/marmot/) MLSを使い、payment providerとしてStrikeとSquareを採用しています。今週はconfigとcatalog読み込み、message schema validation、MDK communication layer、StrikeおよびSquare provider実装、polling engine、anti-spam rate limiting、pending payment永続化、order processing pipelineが入りました。チームがlocal modeでmock MLSを取り除き実際の暗号化へ切り替えたため、99件すべてのtestsは現在、実際のmdk-core MLS操作を通しています。
+
+### VectorがDM attachmentsをリファクタリングし、profile editingを追加
+
+[Vector](https://github.com/VectorPrivacy/Vector)はTauriで構築されたプライバシー重視のNostrメッセンジャーで、[PR #55](https://github.com/VectorPrivacy/Vector/pull/55)をマージしてfrontendをリファクタリングしました。DM attachmentの復号と保存はvector-coreライブラリへ移され、アプリはprofile editingにも対応しました。upload cancelフラグはTauriSendCallbackまで正しく配線され、未使用だったattachment preview callbacksも整理されています。
+
+## プロトコルと仕様の動き
+
+### NIPアップデート
+
+[NIPsリポジトリ](https://github.com/nostr-protocol/nips)への最近の変更です。
+
+**マージ済み：**
+
+- **[NIP-58](/ja/topics/nip-58/)（Badges）: Profile Badgesはkind 10008へ、Badge Setsはkind 30008へ移行**（[PR #2276](https://github.com/nostr-protocol/nips/pull/2276)）：Profile Badgesをkind `30008`からkind `10008`へ移行し（replaceable event、pubkeyごとに1つ）、Badge Sets向けにkind `30008`を導入します。従来、Profile BadgesはBadge定義と同じkind（`30008`）を使っていたため、`d`タグで識別されるparameterized replaceable eventsになっていました。新しいkind `10008`は単純なreplaceable eventで、pubkeyごとに1つ、`d`タグは不要です。クライアントはparameterized replaceable eventsを走査する代わりに、ユーザーごとに単一のreplaceable eventを問い合わせればよくなります。Amethyst v1.07.3はすでにこの移行を出荷済みです。
+
+- **[NIP-34](/ja/topics/nip-34/)（Git Stuff）: git関連follow listsを追加**（[PR #2130](https://github.com/nostr-protocol/nips/pull/2130)）：NIP-34のrepositoryおよびissue追跡向けfollow list慣例を追加します。ユーザーは、追跡したいrepositories（kind `30617`）への`a`タグ参照を含む、`git-repos`や`git-issues`のような`d`タグ付きのkind `30000` follow setsを公開します。クライアントはこれらのfollow setsを購読して、kind `3`のcontact listsがpubkeys向けに機能するのと同様に、ユーザーのフィードへrepository activityを表示できます。
+
+**オープンPRとディスカッション：**
+
+- **NIP-AC: WebRTC上のP2P Voice and Video Calls**（[PR #2301](https://github.com/nostr-protocol/nips/pull/2301)）：元のNIP-100（0xChatが実装）を3点で拡張します。すなわち、メタデータ漏えいをなくすために[NIP-59](/ja/topics/nip-59/) gift wrapsで包んだ[NIP-44](/ja/topics/nip-44/)暗号化へ移行すること、voiceとvideo callのセットアップ（offer、answer、ICE candidates）向けに明示されたWebRTCワークフローを定義すること、そして各ピアが他の全ピアへ直接WebRTC接続を張るmesh group callモデルを採ることです。この仕様はNIP-100との後方互換性はありません。Amethystはすでにこれに沿った実装を進めており、call state machine test suite（[PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)）とstale call offer処理（[PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)）が今週入りました。
+
+- **[NIP-340](/en/topics/nip-340/)（FROST Quorum）**（[PR #2299](https://github.com/nostr-protocol/nips/pull/2299)）：Nostr上での[FROST](/ja/topics/frost/)（Flexible Round-Optimized Schnorr Threshold）threshold signing向け慣例を提案します。FROSTでは署名者グループが共同で1つのNostr identityを制御し、完全な秘密鍵を再構成せずに、t-of-nメンバーのいずれかでイベント署名できます。このNIPは、[FROSTR project](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11)のIgloo signer作業を土台に、署名ラウンドの調整、key sharesの配布、threshold-signed eventsの公開方法を定義します。
+
+- **[NIP-5D](/en/topics/nip-5d/)（Nostr Web Applets）**（[PR #2303](https://github.com/nostr-protocol/nips/pull/2303)）：iframe内で動作するsandboxed web applications（「napplets」）が、ホストアプリケーション（「shell」）と通信するための`postMessage`プロトコルを定義します。shellは、構造化メッセージAPIを通じてnappletへNostr署名、relay access、ユーザー文脈を提供し、iframe sandboxは鍵への直接アクセスを防ぎます。これは[NIP-5A](/en/topics/nip-5a/)の静的webサイトホスティングモデルを、Nostr eventsを読んだり書いたりできる対話的アプリケーションへ拡張するものです。このNIPは、動作するruntime実装を伴って活発に開発中です。
+
+- **[NIP-5C](/en/topics/nip-5c/)（Scrolls）**（[PR #2281](https://github.com/nostr-protocol/nips/pull/2281)）：以前のNIP-A5提案から改名されたものです。Nostr上でWebAssemblyプログラムを公開し、発見するための慣例を定義します。WASM binariesはNostr eventsとして保存され、クライアントはそれらをダウンロードしてsandboxed runtimeで実行できます。[demo app](https://nprogram.netlify.app/)ではscrollsがブラウザ内で実行される様子が示されており、任意のクライアントが取得して実行できるexample programsがNostr eventsとして公開されています。
+
+- **[NIP-85](/ja/topics/nip-85/)（Trusted Assertions）: Clarifications**（[PR #2304](https://github.com/nostr-protocol/nips/pull/2304)）：サービスプロバイダーごとに複数鍵や複数relayが存在する場合の仕様文言を引き締め、複数のpubkeysやrelay endpointsにまたがって運用するプロバイダーからのassertionsをクライアントがどう扱うべきかを明確にします。
+
+- **[NIP-24](/ja/topics/nip-24/)（Extra Metadata Fields）: replaceable events向け`published_at`**（[PR #2300](https://github.com/nostr-protocol/nips/pull/2300)）：[NIP-23](/en/topics/nip-23/)（Long-form Content）由来の`published_at`タグを、すべてのreplaceable eventsとaddressable eventsへ一般化します。このタグは表示専用です。`published_at`が`created_at`と等しければ、その時刻に「created」と表示し、異なる場合（イベントが更新された場合）は代わりに「updated」と表示できます。これにより、kind `0`プロフィールに「joined at」日付を表示したり、他のreplaceable eventsでも更新をまたいで元の公開時刻を保てるようになります。補完的な[NIP-51](/ja/topics/nip-51/)提案（[PR #2302](https://github.com/nostr-protocol/nips/pull/2302)）は、同じタグをlist eventsにも追加します。
+
+- **[NIP-59](/ja/topics/nip-59/)（Gift Wrap）: Ephemeral gift wrap kind**（[PR #2245](https://github.com/nostr-protocol/nips/pull/2245)）：既存のkind `1059` gift wrapに対応するephemeral版としてkind `21059`を追加します。ephemeral events（kinds `20000`から`29999`）は[NIP-01](/ja/topics/nip-01/)の意味論に従い、relayは保存を期待されず、配信後に破棄してかまいません。これによりアプリケーションは、通常の[NIP-17](/ja/topics/nip-17/) DMsと同じ3層暗号化モデルを保ったまま、relay上から配信後に消えるgift-wrapped messagesを送れるようになり、高頻度メッセージングのストレージ要件を下げられます。
+
+### OpenSatsが第16回Nostr grantsを発表
+
+[OpenSats](https://opensats.org)は4月8日に[第16回Nostr grants](https://opensats.org/blog/sixteenth-wave-of-nostr-grants)を発表し、初回助成4件と更新1件を採択しました。[Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp)には、contributorのRobert Nagyが[Quartz](/ja/topics/quartz/)とCommonsモジュール上にスタンドアロンのデスクトップアプリを構築するための資金が提供されます。これにより、Androidクライアントの機能群が、永続的なrelay接続を持つマウス中心のインターフェースへ持ち込まれます。[Nostr Mail](https://github.com/nogringo/nostr-mail)には、kind `1301` eventsを[NIP-59](/ja/topics/nip-59/) gift wrapsで包んで使う、Nostr上の完全なメールシステム構築向け資金が提供されます。FlutterクライアントとGmail/Outlook互換のSMTP bridge serversも含まれます。[Nostrord](https://github.com/Nostrord/nostrord)には、Discord風のグループメッセージング、モデレーション、スレッドを備えたKotlin Multiplatformの[NIP-29](/en/topics/nip-29/) relay-based group client向け資金が提供されます。[Nurunuru](https://github.com/tami1A84/null--nostr)には、LINEの馴染みあるインターフェースを手本にし、オンボーディング向けにpasskeyベースの生体認証ログインを備えた、日本語圏向けNostrクライアントのネイティブiOS版構築資金が提供されます。HAMSTRには助成更新が行われました（初回採択は[第11回](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)）。
+
+## NIPディープダイブ: NIP-17（Private Direct Messages）
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md)は、Nostrにおける現在のプライベートダイレクトメッセージ標準を定義します。これは、relay上で送信者、受信者、タイムスタンプがすべて見えてしまい、暗号構成も弱かった旧来の[NIP-04](/ja/topics/nip-04/)（Encrypted Direct Messages）方式を置き換えるものです。NIP-17は、暗号化に[NIP-44](/ja/topics/nip-44/)（Encrypted Payloads）を、メタデータ保護に[NIP-59](/ja/topics/nip-59/)（Gift Wrap）を組み合わせ、relayからは誰と誰が会話しているかが見えない3層システムを作ります。
+
+このプロトコルは、3つのevent kindsを入れ子にして使います。最も内側の層は実際のメッセージで、署名されていないkind `14`イベントです。
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+kind `14`イベントは意図的に署名されていません（`sig`は空です）。仕様はこれを否認可能性を与えるものとして説明しますが、実際の保護は限定的です。rumorを包むkind `13`のsealは、送信者の実鍵で署名されています。受信者はメッセージ内容を明かさなくても、その署名済みsealを第三者に見せることで、送信者が自分と通信した事実を証明できます。ゼロ知識証明を使えば、受信者は自分の秘密鍵を明かさずに、メッセージ内容そのものまで証明できます。署名のないrumorは、署名入り封筒に入った無署名の手紙のようなものです。封筒の署名が送信者と内容を結び付けます。真の否認可能性には、SignalのHMACのような対称認証が必要ですが、それはメッセージ自体が自己認証可能でなければならないNostrの分散relayモデルとは両立しません。NIP-17の本当の強みは、否認可能性ではなく、メタデータのプライバシーと内容の秘匿性です。
+
+この無署名メッセージは次にkind `13`のsealで包まれ、実際の送信者によって署名され、受信者向けに[NIP-44](/ja/topics/nip-44/)で暗号化されます。
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+sealにはtagsがないため、復号できても受信者は分かりません。sealは送信者の実鍵で署名されており、受信者はsealの`pubkey`が内側のkind `14`の`pubkey`と一致することを確認することでメッセージを認証できます。
+
+そのsealはさらにkind `1059`のgift wrapで包まれ、ランダムな使い捨て鍵で署名され、受信者宛てに送られます。
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+gift wrapの`pubkey`は、このメッセージ専用に生成されたランダム鍵で、`created_at`は最大2日前までランダム化されています。relayが実際に見る最外層はこれです。未知のpubkeyから受信者宛てに送られたメッセージで、タイムスタンプも実際の送信時刻を反映しません。このランダム化タイムスタンプは、保存済みイベントを後から分析する攻撃への対策になりますが、relayへ能動的に接続している攻撃者はgift wrapが最初に現れた時点を観測できるため、この防御は後からrelayデータを問い合わせる受動的観測者に対してのみ有効です。pubkeyがランダムでタイムスタンプも偽装されているため、relayは実際の送信者を特定できません。受信者がメッセージを読むには、自分の鍵とランダムpubkeyを使ってgift wrapを復号し、中のsealを取り出し、次に自分の鍵とsealに入っている送信者pubkeyでsealを復号し、その内側にあるkind `14`メッセージを見つけます。
+
+NIP-17はforward secrecyを提供しません。すべてのメッセージは静的なNostr keypairを使って暗号化されます（NIP-44で送信者鍵と受信者鍵から導出した鍵を使用）。秘密鍵が侵害されると、その鍵宛てに暗号化された過去と未来のすべてのメッセージが復号可能になります。これは意図的なトレードオフです。暗号化はnsecだけに依存するため、ユーザーがnsecをバックアップしていれば、gift wrapsをまだ保持している任意のrelayからメッセージ履歴全体を復元できます。[Marmot](/ja/topics/marmot/)で使われるMLSのようなプロトコルは、鍵素材をローテーションすることでforward secrecyを提供しますが、その代償としてstate同期が必要になり、鍵ローテーション後の過去メッセージ履歴復元は不可能になります。
+
+NIP-17は暗号化ファイルメッセージ向けのkind `15`も定義しており、受信者がBlossomサーバーへアップロード前にAES-GCMで暗号化された添付ファイルを復号できるよう、`file-type`、`encryption-algorithm`、`decryption-key`、`decryption-nonce`タグを追加します。Kind `10050`は、送信者がgift wrapsをどこへ届けるべきか分かるよう、ユーザーが希望するDM relay listを公開するのに使われます。メッセージ内の`pubkey`と`p` tagsの集合が1つのチャットルームを定義し、参加者の追加や削除はクリーンな履歴を持つ新しいルームを作ります。
+
+実装は主要クライアントの多くをカバーしています。[nospeak](https://github.com/psic4t/nospeak)はすべての1対1メッセージングにNIP-17を使っています。[Flotilla](https://gitea.coracle.social/coracle/flotilla)はproof-of-work DMsにNIP-17を使っています。[Amethyst](https://github.com/vitorpamplona/amethyst)、[Primal](https://github.com/PrimalHQ/primal-android-app)、[Nostur](https://github.com/nostur-com/nostur-ios-public)、[Damus](https://github.com/damus-io/damus)、[noStrudel](https://github.com/hzrd149/nostrudel)、[Coracle](https://github.com/coracle-social/coracle)は、いずれも主要DMプロトコルとしてNIP-17を実装しています。gift wrapへ`expiration`タグを設定することで、仕様はdisappearing messagesにも対応します。
+
+## NIPディープダイブ: NIP-46（Nostr Remote Signing）
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)は、ユーザーの秘密鍵をクライアントアプリケーションから分離するためのプロトコルを定義します。webアプリへnsecを貼り付ける代わりに、ユーザーは秘密鍵を保持し、Nostr relays経由の署名要求へ応答するremote signer（「bunker」とも呼ばれます）を動かします。クライアントが秘密鍵を見ることはありません。これにより攻撃面は小さくなります。侵害されたクライアントでも署名要求は送れますが、鍵そのものを引き抜くことはできません。
+
+このプロトコルは、要求と応答の両方にkind `24133`を使い、[NIP-44](/ja/topics/nip-44/)（Encrypted Payloads）で暗号化します。クライアントはセッション用の使い捨て`client-keypair`を生成し、互いのpubkeysをタグ付けしたNIP-44暗号化メッセージを通じてremote signerと通信します。以下は、クライアントからremote signerへ送る署名要求の例です。
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+暗号化された`content`には、JSON-RPC風の構造が入っています。
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+remote signerはこの要求を復号し、ユーザーへ承認を提示し（または設定済み権限に基づいて自動承認し）、ユーザーの秘密鍵でイベントへ署名し、その署名済みイベントを応答として返します。
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+接続はどちら側からでも開始できます。remote signerは、自分のpubkeyとrelay情報を含む`bunker://` URLを提供します。クライアントは、自分のclient pubkey、relays、接続検証用secretを含む`nostrconnect://` URLを提供します。`secret`パラメータは接続なりすましを防ぎます。帯域外でURLを受け取った当事者だけがhandshakeを完了できます。
+
+定義されているメソッドは8つです。セッション確立用の`connect`、イベント署名用の`sign_event`、ユーザーのpubkey取得用の`get_public_key`、keepalive用の`ping`、旧来暗号化用の`nip04_encrypt`と`nip04_decrypt`、現行暗号化用の`nip44_encrypt`と`nip44_decrypt`、そしてrelay管理用の`switch_relays`です。relay migrationはremote signerが処理するため、セッションを壊さずに接続先relayを時間とともに移せます。
+
+クライアントは接続時にpermission systemを通じて具体的な能力を要求します。`nip44_encrypt,sign_event:1,sign_event:14`のようなpermission文字列は、NIP-44暗号化アクセスと、kind `1`およびkind `14`イベントに限定した署名アクセスを要求します。remote signerはこれらの権限を受け入れることも、拒否することも、変更することもできます。つまり、ノートの閲覧と投稿だけを行うwebクライアントには`sign_event:1`だけが与えられ、DMクライアントには`sign_event:14`と`nip44_encrypt`も与えられる、といった運用が可能です。
+
+[Amber](https://github.com/greenart7c3/Amber)はAndroidでNIP-46を実装しており、今週の[v6.0.0-pre1](#amber-v600-pre1が接続ごとのnip-46署名鍵を追加)ではクライアント間の分離のため、接続ごとの署名鍵が追加されました。[nsec.app](https://github.com/nicktee/nsecapp)（旧Nostr Connect）はwebベースのbunkerを提供します。[nostr-tools](https://github.com/nbd-wtf/nostr-tools)にはJavaScriptクライアント向けの`BunkerSigner`が含まれており、[先週のPR #530](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing)では手動relay管理向けに`skipSwitchRelays`が追加されました。このプロトコルはauth challengeもサポートします。remote signerが追加認証（パスワード、生体認証、ハードウェアトークン）を必要とする場合、クライアントがブラウザで開いて完了させる`auth_url`を返します。
+
+---
+
+今週は以上です。何か作っているものがある、あるいは共有したいニュースがありますか。NostrでDMを送るか、[nostrcompass.org](https://nostrcompass.org)を見てください。

--- a/content/ko/newsletters/2026-04-08-newsletter.md
+++ b/content/ko/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Nostr Compass에 다시 오신 것을 환영합니다. Nostr를 안내하는 주간 뉴스레터입니다.
+
+**이번 주:** [Amethyst](https://github.com/vitorpamplona/amethyst)가 Arti Tor 통합과 재설계된 Shorts UI가 포함된 [v1.08.0](#amethyst-ships-arti-tor-merges-pure-kotlin-mls-and-marmot)을 출시했고, [Quartz](/ko/topics/quartz/) 라이브러리에 [MLS](/ko/topics/mls/)와 [Marmot](/ko/topics/marmot/)의 순수 Kotlin 구현을 병합했습니다. [Nostur](https://github.com/nostur-com/nostur-ios-public)는 동영상 녹화, 애니메이션 GIF 프로필, 비공개 답글이 포함된 [v1.27.0](#nostur-v1270-adds-video-recording-and-private-replies)을 출시했습니다. [Shosho](https://github.com/r0d8lsh0p/shosho-releases)는 Shows(OBS와 연결되는 맞춤형 라이브 스트림 정보)와 TikTok 스타일의 세로 동영상 캐러셀이 포함된 [v0.15.0](#shosho-v0150-launches-shows-and-vertical-video-carousel)을 공개했습니다. [Nymchat](https://github.com/Spl0itable/NYM)는 회전하는 일회용 키를 사용하는 향상된 [NIP-17](/ko/topics/nip-17/) 그룹 채팅과 함께 [Marmot 되돌리기 릴리스](#nymchat-reverts-marmot-ships-enhanced-nip-17-group-chats)를 내놓았습니다. [Nostr VPN](https://github.com/mmalmi/nostr-vpn)은 여섯 개 릴리스에 걸쳐 [exit node 지원과 Umbrel 패키징](#nostr-vpn-ships-exit-node-support-and-umbrel-packaging)을 추가했습니다. [Amber](https://github.com/greenart7c3/Amber)는 연결별 [NIP-46](/ko/topics/nip-46/) 서명 키와 Zapstore 인앱 업데이트가 포함된 [v6.0.0-pre1](#amber-v600-pre1-adds-per-connection-nip-46-signing-keys)로 올라섰습니다. [Notedeck](https://github.com/damus-io/notedeck)는 Zapstore를 통한 APK 자체 업데이트가 포함된 [v0.10.0-beta](#notedeck-v0100-beta-ships-zapstore-self-update)에 도달했고, [NIP-58](/ko/topics/nip-58/) (Badges)은 [kind 마이그레이션](#nip-updates)을 받았습니다. 이번 주 NIP 심층 분석은 [NIP-17](/ko/topics/nip-17/) (Private Direct Messages)과 [NIP-46](/ko/topics/nip-46/) (Nostr Remote Signing)을 다룹니다.
+
+## Top Stories
+
+### Amethyst ships Arti Tor, merges pure Kotlin MLS and Marmot
+
+vitorpamplona가 유지 관리하는 Android 클라이언트 [Amethyst](https://github.com/vitorpamplona/amethyst)는 [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3)부터 [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0)까지 네 개의 릴리스를 배포했고, 아직 릴리스되지 않은 대규모 작업 묶음을 [Quartz](/ko/topics/quartz/) 라이브러리(공유 Kotlin Multiplatform Nostr 모듈)에 병합했습니다. 핵심 릴리스는 v1.08.0 "Arti Tor"로, 앱의 Tor 연결을 C 기반 Tor 라이브러리에서 Tor Project의 Rust 구현인 [Arti](https://gitlab.torproject.org/tpo/core/arti)로 옮깁니다. 이 전환은 이전 C Tor 바인딩에서 발생하던 무작위 충돌을 해결합니다. Arti는 메모리 안전성과 async I/O를 위해 Rust로 처음부터 다시 작성된 Tor Project의 장기적인 C 코드베이스 대체물입니다.
+
+v1.07.3 릴리스는 Shorts UI를 재설계해 페이지 단위 디자인을 사진, 쇼츠, 긴 동영상을 위한 edge-to-edge 피드로 바꿨습니다. 같은 릴리스는 badges를 kind `10008`로, bookmarks를 kind `10003`으로 옮겨 이번 주 [병합된](#nip-updates) [NIP-58](/ko/topics/nip-58/) kind 마이그레이션과 맞췄습니다. v1.07.4는 Nostr Wallet Connect secret 처리 문제를 수정했고, v1.07.5는 이미지 업로드 충돌을 수정했습니다.
+
+아직 태그된 릴리스에는 포함되지 않았지만 main에는 이미 들어간 작업으로, 팀은 [MLS](/ko/topics/mls/)와 [Marmot](/ko/topics/marmot/) 프로토콜 모두의 전체 Kotlin 구현을 작성해 네이티브 C/Rust 라이브러리 바인딩이 더 이상 필요 없게 만들었습니다. [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147)은 핵심 Marmot MLS 그룹 메시징 계층을 추가하고, [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149)는 그룹 채팅 UI를 추가하며, [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146)은 구독 관리자와 함께 수신 및 발신 메시지 프로세서를 추가합니다. [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141)은 MLS 그룹 상태 영속화와 KeyPackage rotation 관리를 추가하고, [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150)은 향상된 GroupInfo signing과 함께 전체 MLS 테스트 스위트를 추가하며, [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158)은 KeyPackage publication status 추적을 더합니다. [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166)은 Nostr 암호화 연산을 위한 순수 Kotlin secp256k1 구현을 추가해 네이티브 C 라이브러리 의존성을 대체합니다. Kotlin MLS 구현까지 더해지면서 [Quartz](/ko/topics/quartz/)는 네이티브 바인딩 없이도 Nostr signing과 Marmot 그룹 메시징을 수행할 수 있게 되었고, 이는 iOS를 포함한 Kotlin Multiplatform 타깃으로 나아갈 길을 엽니다.
+
+팀은 또한 [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls) 지원도 구축하고 있습니다. [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)은 NIP-AC call state machine에 대한 전체 테스트 스위트를 추가하고, [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)는 앱 재시작 후 오래된 call offer가 다시 트리거되는 일을 막습니다.
+
+### Nostur v1.27.0 adds video recording and private replies
+
+iOS Nostr 클라이언트 [Nostur](https://github.com/nostur-com/nostur-ios-public)는 4월 2일 [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0)을 출시했습니다. 이 릴리스는 업로드 전 잘라내기가 가능한 인앱 동영상 녹화를 추가해, 사용자가 짧은 영상을 촬영하고 길이를 조정한 뒤 클라이언트를 벗어나지 않고 게시할 수 있게 합니다. 애니메이션 GIF 지원은 프로필 사진과 배너 사진까지 확장되며, animated WebP 렌더링도 추가됐습니다. 새로운 Shortcuts 통합을 통해 사용자는 Apple Shortcuts 자동화에서 Nostr 게시물을 보낼 수 있습니다. 이번 릴리스는 또한 비공개 답글을 추가했고, Nostur와 다른 클라이언트 사이의 메시지 전달에 영향을 주던 DM 호환성 문제도 수정했습니다.
+
+### Shosho v0.15.0 launches Shows and vertical video carousel
+
+Nostr 라이브 스트리밍 앱 [Shosho](https://github.com/r0d8lsh0p/shosho-releases)는 4월 7일 [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0)과 [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1)을 출시했습니다. 핵심 기능은 Shows입니다. 스트리머는 라이브를 시작하기 전에 맞춤형 쇼 정보를 설정하고, 자신의 쇼를 OBS나 다른 외부 인코더에 연결할 수 있습니다. 이렇게 하면 "무엇을 스트리밍하는가"라는 메타데이터를 실제 라이브 시작 행위와 분리할 수 있어, 방송 전에 제목, 설명, 상품을 미리 준비할 수 있습니다. 같은 릴리스는 라이브, 클립, 리플레이를 전체 화면 피드에서 스와이프해 넘기는 TikTok 스타일의 세로 동영상 캐러셀과, 프로필 페이지에서 바로 동영상 클립 게시와 상품 추가를 할 수 있는 Quick Add도 포함합니다. v0.15.1은 키보드가 라이브 스트림 채팅 입력창을 가리던 버그를 수정합니다.
+
+## Shipping This Week
+
+### Notedeck v0.10.0-beta ships Zapstore self-update
+
+Damus 팀의 데스크톱 및 모바일 클라이언트 [Notedeck](https://github.com/damus-io/notedeck)는 APK 자체 업데이트를 시험하기 위한 테스트 프리릴리스로 [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1)과 [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2)를 배포했습니다. [PR #1417](https://github.com/damus-io/notedeck/pull/1417)은 Android에서 Nostr/Zapstore 업데이터를 통한 APK 자체 업데이트를 추가하며, 이는 [뉴스레터 #14의 Nostr 네이티브 업데이트 탐색 작업](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr)을 바탕으로 합니다. 이 업데이트 흐름은 relay에 게시된 Nostr 이벤트를 통해 새 릴리스를 발견하고, 개발자가 호스팅하는 위치(GitHub releases, Blossom CDN, 그 밖의 소스)에서 APK를 다운로드한 뒤, 서명된 Nostr 이벤트와 SHA-256 해시를 대조해 검증하고 설치합니다. [PR #1438](https://github.com/damus-io/notedeck/pull/1438)은 Login과 CreateAccount 버튼이 즉시 뒤로 이동해 버리던 welcome screen 버그를 수정하고, [PR #1424](https://github.com/damus-io/notedeck/pull/1424)은 Agentium AI session view의 텍스트 overflow를 수정합니다.
+
+### Amber v6.0.0-pre1 adds per-connection NIP-46 signing keys
+
+[Amber](https://github.com/greenart7c3/Amber)는 [NIP-55](/ko/topics/nip-55/) (Android Signer Application) signer 앱으로, 4월 4일 [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1)을 출시했습니다. 가장 중요한 변화는 [NIP-46](/ko/topics/nip-46/) (Nostr Remote Signing) bunker 프로토콜을 위한 연결별 서명 키입니다. Amber는 이제 모든 bunker 연결에 단일 키페어를 쓰는 대신, 연결된 각 클라이언트마다 별도의 키를 생성합니다. 한 클라이언트 연결이 손상되더라도 공격자는 다른 클라이언트에 대해 signer를 사칭할 수 없습니다.
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377)은 Zapstore를 통한 인앱 업데이트 확인 및 설치를 추가해, [Notedeck](#notedeck-v0100-beta-ships-zapstore-self-update)과 함께 Nostr 네이티브 앱 배포를 채택합니다. [PR #375](https://github.com/greenart7c3/Amber/pull/375)는 AndroidKeyStore 실패 시 충돌 대신 사용자에게 경고를 표시하도록 처리하고, [PR #371](https://github.com/greenart7c3/Amber/pull/371)은 무제한 저장소 증가를 막기 위해 크기 제한과 콘텐츠 잘라내기가 포함된 데이터베이스 정리를 추가합니다. 이 프리릴리스에는 [지난주 v5.0.x 주기에서 다룬](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504) [NIP-42](/ko/topics/nip-42/) relay auth 화이트리스트와 mnemonic recovery phrase 로그인도 포함되어 있습니다.
+
+### Nostria ships native mobile app
+
+SondreB가 유지 관리하는 크로스 플랫폼 Nostr 클라이언트 [Nostria](https://github.com/nostria-app/nostria)는 Android용 네이티브 모바일 앱을 출시했고, [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11)부터 [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18)까지 여덟 개의 릴리스를 배포했습니다. 가장 중요한 새 기능은 [Amber](https://github.com/greenart7c3/Amber)와 Aegis 같은 signer를 위한 네이티브 로컬 signer 지원입니다. Linux, macOS, Windows용 [데스크톱 설치 파일](https://www.nostria.app/download)도 함께 제공됩니다. [PR #610](https://github.com/nostria-app/nostria/pull/610)은 적응형 런타임 제한과 preview URL 정리를 통해 피드 메모리 압박을 줄입니다. v3.1.14는 [Web of Trust](/ko/topics/web-of-trust/) provider인 Brainstorm과의 통합을 수정합니다. v3.1.15는 음악 관련 개선에 집중합니다. 새 Android 앱은 [Zapstore](https://zapstore.dev/apps/app.nostria)에서 받을 수 있습니다.
+
+### diVine 1.0.8 ships resumable uploads and DMs
+
+짧은 형식의 동영상 클라이언트 [diVine](https://github.com/divinevideo/divine-mobile)는 87개의 병합된 PR과 함께 [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8)을 출시했습니다. resumable upload를 통해 제작자는 불안정한 연결에서 업로드가 끊겨도 처음부터 다시 시작하지 않고 청크 단위로 이어서 올릴 수 있습니다. 이 릴리스는 동영상 품질 및 bitrate 설정, double-tap 좋아요, DM 개선도 추가합니다. [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722)는 데스크톱 동영상 캡처를 위한 macOS 카메라 플러그인을 추가하고, [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820)은 알림 시스템을 enrichment와 grouping이 포함된 BLoC 아키텍처로 옮깁니다. 팀은 또한 AI 생성 스티커와 카테고리 아트를 OpenMoji SVG로 교체했습니다([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 adds sensitive note blurring and NIP-42 auth
+
+개인 암호화 노트 및 파일 저장 앱 [Manent](https://github.com/dtonon/manent)는 4월 2일 [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0)을 출시했습니다. 이제 사용자는 노트를 민감한 항목으로 표시해 목록 보기에서 흐리게 처리할 수 있어, 가볍게 스크롤할 때 사적인 내용을 가릴 수 있습니다. 이번 릴리스는 또한 [NIP-42](/ko/topics/nip-42/) (Authentication of Clients to Relays) 지원을 추가해, 이벤트를 받기 전에 인증을 요구하는 relay에 Manent가 인증할 수 있게 합니다. Manent는 모든 데이터를 사용자의 키페어를 사용해 Nostr relay에 암호화 저장하므로, NIP-42 지원은 저장에 활용할 수 있는 relay 집합을 넓혀 줍니다.
+
+### Wisp v0.17.0 through v0.17.3 add live stream zaps and wallet backup
+
+Android Nostr 클라이언트 [Wisp](https://github.com/barrydeen/wisp)는 [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta)부터 [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta)까지 여섯 개의 릴리스를 배포했고, 44개의 PR을 병합했습니다. v0.17.0은 지갑 백업 안전 프롬프트와 zap UX 개선을 추가합니다. [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta)은 플랫폼 전반에서 라이브 스트림 채팅 가시성과 라이브 스트림 zap 기능을 더합니다. [PR #423](https://github.com/barrydeen/wisp/pull/423)은 프로필 자동 검색, zap 성공 애니메이션, 사용자 상태 개선을 추가합니다. [PR #426](https://github.com/barrydeen/wisp/pull/426)은 큰 태그 목록이 있는 이벤트에서 `computeId`가 out-of-memory로 충돌하던 문제를 수정합니다. v0.16.x 릴리스는 emoji shortcode 자동완성, 그룹 채팅 UI 개선, 모든 알림 경로에 걸친 차단 사용자 필터링을 추가했습니다.
+
+### Mostro ships deep links, Nostr exchange rates, and a duplicate payment fix
+
+Nostr 위에 구축된 P2P Bitcoin 거래소 [Mostro](https://github.com/MostroP2P/mostro)는 이번 주 서버 데몬과 모바일 클라이언트 양쪽에서 업데이트가 있었습니다. 서버 측에서는 [PR #692](https://github.com/MostroP2P/mostro/pull/692)가 오래된 주문 쓰기로 인해 중복 결제가 발생하는 문제를 막아, 판매자가 같은 거래에 대해 두 번 지급받을 수 있는 버그를 차단합니다. [PR #693](https://github.com/MostroP2P/mostro/pull/693)은 전체 주문 덮어쓰기 대신 dev_fee 쓰기에 표적화된 업데이트를 사용합니다.
+
+Flutter 클라이언트 [Mostro Mobile](https://github.com/MostroP2P/mobile)은 4월 3일 [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3)을 출시했습니다. 이 릴리스는 서로 다른 Mostro 인스턴스에서 오는 딥 링크를 처리해, 사용자가 올바른 거래 서버로 연결되는 링크를 탭할 수 있게 합니다. [PR #498](https://github.com/MostroP2P/mobile/pull/498)은 백그라운드 알림 파이프라인에서 admin 및 dispute DM을 감지하고, 앱은 이제 HTTP/cache fallback과 함께 Nostr에서 환율을 가져옵니다. [PR #560](https://github.com/MostroP2P/mobile/pull/560)은 특정 네트워크 조건에서 앱이 relay에 도달하지 못하게 하던 relay 연결 차단 버그를 수정합니다.
+
+### Unfiltered v1.0.12 adds hashtags and comments
+
+이미지 중심 콘텐츠에 초점을 맞춘 Nostr 클라이언트 [Unfiltered](https://github.com/dmcarrington/unfiltered)는 [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12)를 출시했습니다. [PR #69](https://github.com/dmcarrington/unfiltered/pull/69)는 hashtag 지원을 추가하고, [PR #72](https://github.com/dmcarrington/unfiltered/pull/72)는 게시물에 댓글을 작성하고 표시하는 기능을 추가합니다. [PR #71](https://github.com/dmcarrington/unfiltered/pull/71)은 게시물당 여러 이미지를 다룰 때의 내비게이션 문제를 수정합니다.
+
+### Primal Android ships wallet multi-account sharing and remote signer auto-reconnect
+
+Android Nostr 클라이언트 [Primal](https://github.com/PrimalHQ/primal-android-app)은 4월 7일 릴리스를 배포했습니다. 이번 업데이트는 지갑 다중 계정 공유와 Dev Tools의 지갑 삭제가 포함된 overflow menu를 추가합니다. remote signer는 이제 연결이 끊기면 자동으로 다시 연결되며, 지갑 서비스도 자체 auto-reconnect 로직을 갖게 됐습니다. 수정 사항에는 poll zap 투표가 더 이상 Top Zaps로 나타나지 않는 문제, 빈 poll option 충돌 방지, 지갑이 없을 때 wallet balance 숨김, NWC 응답에서 WalletException 타입을 에러 코드에 매핑하는 작업이 포함됩니다.
+
+### Titan v0.1.0 launches native nsite:// browser with Bitcoin name registration
+
+Nostr 웹을 위한 네이티브 데스크톱 브라우저 [Titan](https://github.com/btcjt/titan)은 4월 7일 [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0)을 출시했습니다. Titan은 Bitcoin에 등록된 사람이 읽을 수 있는 이름을 조회해 `nsite://` URL을 해석하고, 사이트의 콘텐츠 이벤트를 얻기 위해 Nostr relay를 질의하며, [Blossom](/ko/topics/blossom/) 서버에서 가져온 페이지를 렌더링합니다. 결과적으로 DNS도, TLS 인증서도, 호스팅 제공자도 없는 웹 브라우징 경험이 만들어집니다. 이름은 Bitcoin 거래와 연결된 [웹 인터페이스](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register)를 통해 등록됩니다. 초기 릴리스는 macOS `.dmg`(ARM, Intel용 Rosetta 2 지원)로 배포되며, Nix 개발 환경 지원도 포함합니다.
+
+### Bikel v1.5.0 ships native foreground service for de-Googled phones
+
+주행 기록을 Nostr를 통해 공공 인프라 데이터로 바꾸는 탈중앙화 사이클링 트래커 [Bikel](https://github.com/Mnpezz/bikel)은 4월 4일 [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0)을 출시했습니다. 이 릴리스는 GMS 의존 Expo TaskManager에서 커스텀 네이티브 foreground service로 전환해, LineageOS, GrapheneOS, 그 밖의 de-Googled Android 변형에서 안정적인 백그라운드 주행 추적을 보장합니다. Bikel Bot은 Cashu nutzaps를 통한 자율 eCash 수집이 가능한 dual-pocket 아키텍처를 갖추게 됐습니다. v1.4.3과 v1.4.2는 비표준 Android 환경에서의 백그라운드 추적 동기화를 수정하고, 앱은 OSM 자전거 거치대 지도 포인트 토글도 추가합니다.
+
+### Sprout adds NIP-01, NIP-23, and NIP-33 support
+
+내장 Nostr relay를 갖춘 Block의 커뮤니케이션 플랫폼 [Sprout](https://github.com/block/sprout)은 4월 6일 [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7)을 출시했습니다. 이번 주 팀은 [NIP-23](/en/topics/nip-23/) (Long-form Content) kind `30023` article, `d` 태그 기반 교체를 사용하는 [NIP-33](/en/topics/nip-33/) parameterized replaceable event, 그리고 [NIP-01](/ko/topics/nip-01/)/[NIP-02](/en/topics/nip-02/) kind `1` text note와 kind `3` follow list 지원을 추가했습니다. 이번 릴리스는 54개 테마를 갖춘 적응형 IDE 테마 시스템, workflow 및 agent run history UX 개선, members sidebar 정리도 포함합니다.
+
+### mesh-llm v0.56.0 ships distributed config protocol
+
+노드 신원에 Nostr 키페어를 사용하는 분산 LLM 추론 시스템 [mesh-llm](https://github.com/michaelneale/mesh-llm)은 4월 7일 [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0)을 출시했습니다. 이 릴리스는 ownership semantics가 포함된 분산 config 프로토콜, 메모리 사용량을 줄이기 위한 비대칭 KV cache 양자화(Q8_0 keys와 Q4 values), identity keystore를 위한 OS keychain 저장, 메시지 queue를 이용한 부드러운 chat streaming, fullscreen layout과 flash attention 기반 KV cache splitting 수정 사항을 추가합니다.
+
+### Nostr VPN ships exit node support and Umbrel packaging
+
+신호에는 Nostr relay를 사용하고 암호화 터널에는 WireGuard를 사용하는 P2P VPN [Nostr VPN](https://github.com/mmalmi/nostr-vpn)은 이번 주 [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0)부터 [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6)까지 여섯 개의 릴리스를 배포했습니다. v0.3.x 주기는 Windows와 macOS에서 exit node 지원을 추가해, 피어가 네트워크 안의 다른 노드를 통해 인터넷 트래픽을 라우팅할 수 있게 합니다. invite와 alias 전파도 이제 Nostr를 통해 동기화되므로, 사용자는 별도의 바깥 채널 조율 없이 네트워크 접근 권한을 공유할 수 있습니다. 이번 릴리스들은 self-hosted 배포를 위한 Umbrel 패키징, 기억된 public endpoint를 이용한 NAT punch-through, 오래된 exit node 자동 정리, 공개된 프로토콜 사양도 추가합니다. 프로젝트는 또한 self-healing default route와 underlay repair를 통해 macOS route 처리를 안정화했고, Tauri 기반 Android 빌드도 추가했습니다. 빌드는 macOS(Apple Silicon 및 Intel), Linux(AppImage 및 .deb), Windows, Android에서 제공됩니다.
+
+### Nymchat reverts Marmot, ships enhanced NIP-17 group chats
+
+MLS 지원 채팅 클라이언트 [Nymchat](https://github.com/Spl0itable/NYM)은 [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261)부터 [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274)까지 14개의 릴리스를 배포했습니다. 가장 중요한 변화는 프로토콜 방향 전환입니다. [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261)은 Marmot MLS 그룹 채팅을 추가했지만, [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268)은 Marmot의 다중 장치 지원이 아직 완성되지 않아 장치 간 그룹 채팅 상태 동기화에 문제가 생기면서 다시 [NIP-17](/ko/topics/nip-17/)으로 되돌렸습니다. v3.58.271은 모든 메시지에 대해 회전하는 일회용 키를 사용하는 향상된 NIP-17 그룹 채팅을 도입해, timing 및 correlation 공격을 막도록 설계됐습니다. 이번 주에는 세밀한 설정 제어가 가능한 친구 시스템([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), 암호화된 앱 설정 속 MLS 그룹 채팅 메시지 동기화, 여러 relay 연결성 수정도 포함됐습니다.
+
+### nak v0.19.5 adds Blossom multi-server and outbox publishing
+
+fiatjaf의 커맨드라인 Nostr 도구킷 [nak](https://github.com/fiatjaf/nak)은 [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5)를 출시했습니다. `blossom` 명령은 이제 여러 [Blossom](/ko/topics/blossom/) 서버에 한 번에 업로드할 수 있도록 다중 `--server` 플래그를 받습니다. 새 `key` 명령은 부분 키를 왼쪽에 0을 채워 확장합니다. `event` 명령은 outbox model을 통해 이벤트를 게시하는 `--outbox` 플래그를 얻었고, `fetch`는 이벤트가 반환되지 않을 때 에러 코드와 함께 종료합니다.
+
+## In Development
+
+### White Noise adds thumbhash previews and push registration bridge
+
+[Marmot](/ko/topics/marmot/) 프로토콜 위에 구축된 개인 메신저 [White Noise](https://github.com/marmot-protocol/whitenoise)는 다섯 개의 PR을 병합했습니다. [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549)는 blurhash 이미지 미리보기를 더 작은 payload 크기로 더 선명한 placeholder 이미지를 생성하는 최신 알고리즘 thumbhash로 교체합니다(보통 blurhash의 약 50-100 bytes에 비해 30 bytes 이하). 이 알고리즘은 원본의 종횡비와 색 분포를 유지합니다. 오래된 콘텐츠를 위해 blurhash는 fallback으로 남겨 둡니다. [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548)은 whitenoise-rs를 업데이트하고 [MIP-05](/ko/topics/mip-05/) push registration bridge를 추가해, [지난주 다룬 push notification spec 작업](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications)을 클라이언트와 연결합니다. [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493)은 채팅 메시지에 cursor 기반 pagination을 추가해, 이전 로딩 전략을 스크롤 기반 접근으로 교체합니다.
+
+### Route96 adds dynamic label configuration and zero-egress cleanup
+
+v0l의 [Blossom](/ko/topics/blossom/) 미디어 서버 [Route96](https://github.com/v0l/route96)는 세 개의 PR을 병합했습니다. [PR #80](https://github.com/v0l/route96/pull/80)은 admin API를 통한 동적 label model 설정을 추가해, 운영자가 서버를 재시작하지 않고도 콘텐츠 분류 모델을 교체할 수 있게 합니다. [PR #82](https://github.com/v0l/route96/pull/82)는 admin UI에 label configuration 필드를 추가합니다. [PR #79](https://github.com/v0l/route96/pull/79)는 한 번도 다운로드되지 않은 파일을 자동으로 제거하는 zero-egress file cleanup 정책을 추가해, 운영자의 저장 비용을 낮춥니다.
+
+### Snort ships security hardening and DVM payment invoices
+
+웹 클라이언트 [Snort](https://github.com/v0l/snort)는 이번 주 포괄적인 보안 감사와 함께 두 개의 릴리스를 배포했습니다. 수정 사항에는 Schnorr signature 검증, [NIP-46](/ko/topics/nip-46/) relay message forgery 방지(손상된 relay를 통해 공격자가 signing request를 주입하는 것을 막음), PIN 암호화 개선, NIP-26 delegation 신뢰 제거가 포함됩니다. 성능 개선은 WASM에서의 batched Schnorr verification, lazy-loaded route, 사전 컴파일된 번역, 이벤트당 이중 검증 제거에서 나옵니다. [PR #618](https://github.com/v0l/snort/pull/618)은 [NIP-90](/en/topics/nip-90/) (Data Vending Machine) kind `7000` payment-required invoice 표시를 추가해, DVM이 결제 요구와 함께 응답할 때 Snort가 Lightning invoice를 피드에 직접 렌더링하게 합니다.
+
+### Damus improves LMDB compaction
+
+iOS 클라이언트 [Damus](https://github.com/damus-io/damus)는 [PR #3719](https://github.com/damus-io/damus/pull/3719)를 병합해 일정에 따라 자동 LMDB compaction을 수행하도록 했고, 로컬 데이터베이스가 시간이 지나며 무제한으로 커지는 일을 막습니다. [PR #3663](https://github.com/damus-io/damus/pull/3663)는 BlurOverlayView가 고장난 것처럼 보이지 않고 보호 기능처럼 보이도록 개선합니다.
+
+### Captain's Log adds tag indexing and note sync
+
+Nodetec의 Nostr 네이티브 장문 글쓰기 도구 [Captain's Log](https://github.com/nodetec/captains-log) (Comet)는 이번 주 네 개의 PR을 병합했습니다. [PR #156](https://github.com/nodetec/captains-log/pull/156)은 노트 전반에 걸친 태그 인덱싱과 sync 지원을 추가하고, [PR #157](https://github.com/nodetec/captains-log/pull/157)은 노트 sync와 태그 처리를 리팩터링하며, [PR #159](https://github.com/nodetec/captains-log/pull/159)은 휴지통으로 보낸 노트 sync를 수정해 삭제된 노트가 장치 간에도 삭제 상태를 유지하게 합니다.
+
+### Relatr v0.2.x redesigns plugin system with Nostr-native validator marketplace
+
+[Relatr](https://github.com/ContextVM/relatr)는 [Web of Trust](/ko/topics/web-of-trust/) 점수 엔진으로, 사회적 그래프 거리와 설정 가능한 validator를 바탕으로 신뢰 순위를 계산합니다. 이번 주 v0.2.x 계열을 배포하며 플러그인 시스템을 전면 재설계했습니다. validator는 이제 다단계 host orchestration capability(Nostr query, social graph lookup, NIP-05 resolution)를 지원하도록 포크된 휴대용 함수형 표현 언어 Elo로 작성됩니다. 플러그인은 kind `765` Nostr 이벤트로 게시되므로, 배포 자체가 relay 네트워크에 네이티브하게 올라갑니다. 새 [plugin marketplace](https://relatr.net)는 운영자가 브라우저에서 validator를 발견하고, 설치하고, 가중치를 설정할 수 있게 하며, 로컬 작성과 게시를 위한 CLI(`relo`)도 제공합니다. 이 아키텍처는 sandboxed되어 있어, 플러그인은 host가 명시적으로 제공한 capability만 호출할 수 있으므로 악성 validator가 정의된 범위를 벗어날 수 없습니다. 이제 Relatr 인스턴스는 웹사이트에서 관리할 수 있고, 어떤 플러그인이 점수 알고리즘을 구성하는지와 각 가중치를 완전히 볼 수 있습니다.
+
+### Shopstr improves mobile navigation and access control
+
+Bitcoin으로 사고파는 Nostr 네이티브 마켓플레이스 [Shopstr](https://github.com/shopstr-eng/shopstr)는 이번 주 메인 앱과 동반 프로젝트 [Milk Market](https://github.com/shopstr-eng/milk-market) 전반에 걸쳐 158개의 커밋을 푸시했습니다. 수정 사항에는 모바일 community 레이아웃 개선, 내비게이션 시 메뉴 자동 닫기 동작, dropdown 자동 닫기가 포함됩니다. 보호된 route는 이제 로그인하지 않고 직접 URL로 접근할 수 없으며, slug 매칭 로직은 여러 개의 정확 일치 항목도 올바르게 처리합니다.
+
+### Pollerama adds notifications, movie search, and rating UI
+
+Nostr 기반 polling, survey, social rating 앱 [Pollerama](https://github.com/formstr-hq/nostr-polls)는 thread 알림, 영화 검색 기능, rating UI 전면 개편을 추가했습니다. 이번 릴리스는 피드 로딩 문제를 수정하고 의존성 버전도 올립니다.
+
+### Purser builds Nostr-native payment daemon with Marmot encryption
+
+[Purser](https://github.com/EthnTuttle/purser)는 Zaprite 대체를 목표로 하는 Nostr 네이티브 payment daemon으로, 이번 주 아홉 개의 PR을 병합하며 핵심 아키텍처를 구축했습니다. 이 프로젝트는 판매자와 고객 간 암호화 메시징을 위해 MDK를 통한 [Marmot](/ko/topics/marmot/) MLS를 사용하고, 결제 제공자로 Strike와 Square를 사용합니다. 이번 주에는 config와 catalog 로딩, message schema 검증, MDK communication layer, Strike 및 Square provider 구현, polling engine, anti-spam rate limiting, pending payment 영속화, order processing pipeline이 들어왔습니다. 팀이 local mode에서 mock MLS를 제거하고 실제 암호화를 사용하도록 바꾸면서, 이제 99개 테스트 전체가 실제 mdk-core MLS 동작을 실행합니다.
+
+### Vector refactors DM attachments and adds profile editing
+
+Tauri로 구축된 privacy 중심 Nostr 메신저 [Vector](https://github.com/VectorPrivacy/Vector)는 프론트엔드를 리팩터링하는 [PR #55](https://github.com/VectorPrivacy/Vector/pull/55)를 병합했습니다. DM 첨부파일 복호화와 저장은 vector-core 라이브러리로 이동했고, 앱은 이제 프로필 편집도 지원합니다. 업로드 취소 플래그는 TauriSendCallback을 통해 제대로 연결됐고, 사용되지 않던 첨부파일 미리보기 callback도 정리됐습니다.
+
+## Protocol and Spec Work
+
+### NIP Updates
+
+[NIPs 저장소](https://github.com/nostr-protocol/nips)의 최근 변경 사항:
+
+**Merged:**
+
+- **[NIP-58](/ko/topics/nip-58/) (Badges): Profile Badges move to kind 10008, Badge Sets to kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Profile Badges를 kind `30008`에서 kind `10008`로 옮기고(pubkey당 하나의 replaceable event), Badge Sets를 위한 kind `30008`을 도입합니다. 이전에는 Profile Badges가 Badge 정의와 같은 kind(`30008`)를 사용해 `d` 태그로 키가 정해지는 parameterized replaceable event였습니다. 새 kind `10008`은 단순한 replaceable event로, pubkey당 하나이며 `d` 태그가 필요 없습니다. 클라이언트는 이제 사용자당 하나의 replaceable event만 질의하면 되고, parameterized replaceable event를 스캔할 필요가 없습니다. Amethyst v1.07.3은 이미 이 마이그레이션을 포함하고 있습니다.
+
+- **[NIP-34](/ko/topics/nip-34/) (Git Stuff): Add git-related follow lists** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): NIP-34 저장소 및 issue 추적을 위한 follow list 규약을 추가합니다. 사용자는 `git-repos`나 `git-issues` 같은 `d` 태그를 가진 kind `30000` follow set을 게시하고, 안에는 추적하려는 저장소(kind `30617`)를 가리키는 `a` 태그 참조를 담습니다. 클라이언트는 이 follow set을 구독해, kind `3` contact list가 pubkey에 대해 동작하는 것과 비슷하게 사용자의 피드에 저장소 활동을 보여줄 수 있습니다.
+
+**Open PRs and Discussions:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): 원래의 NIP-100(0xChat이 구현함)을 세 가지 방식으로 확장합니다. 첫째, 메타데이터 누출을 없애기 위해 [NIP-59](/ko/topics/nip-59/) gift wrap으로 감싼 [NIP-44](/ko/topics/nip-44/) 암호화로 이동합니다. 둘째, 음성 및 영상 통화 설정을 위한 WebRTC 워크플로(offer, answer, ICE candidate)를 명시합니다. 셋째, 각 피어가 다른 모든 피어와 직접 WebRTC 연결을 맺는 mesh 그룹 통화 모델을 정의합니다. 이 사양은 NIP-100과 하위 호환되지 않습니다. Amethyst는 이미 이에 맞춰 개발 중이며, call state machine 테스트 스위트([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143))와 오래된 call offer 처리([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164))가 이번 주에 반영됐습니다.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Nostr에서 [FROST](/ko/topics/frost/) (Flexible Round-Optimized Schnorr) threshold signing을 위한 규약을 제안합니다. FROST는 signer 집단이 Nostr 신원을 공동으로 제어하게 해 주며, 전체 개인 키를 재구성하지 않고도 t-of-n 구성원만으로 이벤트에 서명할 수 있게 합니다. 이 NIP는 [FROSTR 프로젝트](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11)의 Igloo signer 작업을 바탕으로, 서명 라운드 조정, 키 share 배포, threshold-signed event 게시 방법을 정의합니다.
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): iframe 안에서 실행되는 sandboxed 웹 애플리케이션("napplets")이 호스팅 애플리케이션("shell")과 통신하기 위한 `postMessage` 프로토콜을 정의합니다. shell은 구조화된 message API를 통해 napplet에 Nostr signing, relay access, 사용자 컨텍스트를 제공합니다. 반면 iframe sandbox는 키에 직접 접근하는 일을 막습니다. 이는 [NIP-5A](/en/topics/nip-5a/)의 정적 웹사이트 호스팅 모델을, Nostr 이벤트를 읽고 쓸 수 있는 상호작용 애플리케이션 쪽으로 확장합니다. 이 NIP는 동작하는 runtime 구현과 함께 활발히 개발 중입니다.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): 이전 NIP-A5 제안에서 이름이 바뀌었습니다. Nostr에서 WebAssembly 프로그램을 게시하고 발견하기 위한 규약을 정의합니다. WASM 바이너리는 Nostr 이벤트로 저장되고, 클라이언트는 이를 다운로드해 sandboxed runtime에서 실행할 수 있습니다. [데모 앱](https://nprogram.netlify.app/)은 브라우저 안에서 실행되는 scrolls를 보여 주며, 어떤 클라이언트든 가져와 실행할 수 있는 예제 프로그램이 Nostr 이벤트로 게시돼 있습니다.
+
+- **[NIP-85](/ko/topics/nip-85/) (Trusted Assertions): Clarifications** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): 서비스 제공자당 여러 키와 relay를 다루는 사양 문구를 더 엄격하게 다듬어, 제공자가 여러 pubkey나 relay endpoint에 걸쳐 동작할 때 클라이언트가 assertion을 어떻게 처리해야 하는지 분명히 합니다.
+
+- **[NIP-24](/ko/topics/nip-24/) (Extra Metadata Fields): published_at for replaceable events** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): [NIP-23](/en/topics/nip-23/) (Long-form Content)의 `published_at` 태그를 모든 replaceable 및 addressable event로 일반화합니다. 이 태그는 표시 전용입니다. `published_at`이 `created_at`과 같으면 클라이언트는 해당 시점을 "created"로 표시하고, 값이 다르면(이벤트가 업데이트되었기 때문) "updated"로 표시할 수 있습니다. 이를 통해 kind `0` 프로필은 "joined at" 날짜를 표시할 수 있고, 다른 replaceable event도 업데이트를 거쳐도 원래의 게시 시점을 유지할 수 있습니다. 보완 제안으로 [NIP-51](/ko/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302))은 동일한 태그를 list event에도 추가합니다.
+
+- **[NIP-59](/ko/topics/nip-59/) (Gift Wrap): Ephemeral gift wrap kind** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): 기존 kind `1059` gift wrap의 ephemeral 대응물로 kind `21059`를 추가합니다. Ephemeral event(kinds `20000`-`29999`)는 [NIP-01](/ko/topics/nip-01/) semantics를 따르며, relay는 이를 저장할 것으로 기대되지 않고 전달 후 폐기할 수 있습니다. 이를 통해 애플리케이션은 일반 [NIP-17](/ko/topics/nip-17/) DM과 같은 3계층 암호화 모델을 유지하면서도, relay에서 전달 후 사라지는 gift-wrapped 메시지를 보낼 수 있어 대용량 메시징의 저장 요구를 줄일 수 있습니다.
+
+### OpenSats announces sixteenth wave of Nostr grants
+
+[OpenSats](https://opensats.org)는 4월 8일 [열여섯 번째 Nostr grants 물결](https://opensats.org/blog/sixteenth-wave-of-nostr-grants)을 발표하며, 신규 4건과 갱신 1건을 지원했습니다. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp)는 기여자 Robert Nagy가 [Quartz](/ko/topics/quartz/)와 Commons 모듈 위에 독립형 데스크톱 앱을 구축하도록 자금을 받았고, 이를 통해 Android 클라이언트의 기능 세트를 지속적인 relay 연결을 갖춘 마우스 중심 인터페이스로 가져가게 됩니다. [Nostr Mail](https://github.com/nogringo/nostr-mail)는 [NIP-59](/ko/topics/nip-59/) gift wrap에 싸인 kind `1301` 이벤트를 사용해 Nostr 위에서 전체 이메일 시스템을 구축하기 위한 지원을 받았으며, Flutter 클라이언트와 Gmail/Outlook 호환용 SMTP bridge 서버도 포함됩니다. [Nostrord](https://github.com/Nostrord/nostrord)는 Discord 스타일의 그룹 메시징, moderation, thread를 갖춘 Kotlin Multiplatform [NIP-29](/en/topics/nip-29/) relay 기반 그룹 클라이언트를 위한 지원을 받았습니다. [Nurunuru](https://github.com/tami1A84/null--nostr)는 LINE과 유사한 친숙한 인터페이스를 모델로 한 일본어 중심 Nostr 클라이언트의 네이티브 iOS 버전을 만들기 위한 자금을 받았고, 온보딩에는 passkey 기반 biometric login이 포함됩니다. HAMSTR는 [열한 번째 물결](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)에서 처음 지원된 뒤 이번에 갱신 지원을 받았습니다.
+
+## NIP Deep Dive: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md)은 Nostr에서 private direct message를 위한 현재 표준을 정의합니다. 이 사양은 이전 [NIP-04](/ko/topics/nip-04/) (Encrypted Direct Messages) 방식을 대체합니다. NIP-04는 발신자, 수신자, 타임스탬프가 모두 relay에 노출되는 메타데이터 누출 문제가 있었고, 더 약한 암호화 구성을 사용했습니다. NIP-17은 암호화를 위해 [NIP-44](/ko/topics/nip-44/) (Encrypted Payloads)를 사용하고, 메타데이터 보호를 위해 [NIP-59](/ko/topics/nip-59/) (Gift Wrap)를 결합해, relay가 누가 누구와 대화하는지 볼 수 없는 3계층 시스템을 만듭니다.
+
+이 프로토콜은 서로 안에 쌓인 세 가지 event kind를 사용합니다. 가장 안쪽 계층은 실제 메시지인 서명되지 않은 kind `14` 이벤트입니다.
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+kind `14` 이벤트는 의도적으로 서명되지 않았습니다(`sig`가 비어 있음). 사양은 이를 부인 가능성을 제공하는 것으로 설명하지만, 실제 보호 수준은 제한적입니다. rumor를 감싸는 kind `13` seal은 발신자의 실제 키로 서명됩니다. 수신자는 메시지 내용을 공개하지 않더라도, 서명된 seal을 제3자에게 보여 주며 발신자가 자신과 통신했다는 사실을 증명할 수 있습니다. 영지식 증명을 사용하면 수신자는 자신의 개인 키를 드러내지 않고도 정확한 메시지 내용까지 증명할 수 있습니다. 서명되지 않은 rumor는 서명된 봉투 안에 들어 있는 서명 없는 편지와 비슷합니다. 봉투의 서명이 발신자를 내용물과 연결합니다. 진정한 부인 가능성은 Signal의 HMAC 같은 대칭 인증이 필요하지만, 메시지가 self-authenticating이어야 하는 Nostr의 탈중앙 relay 모델과는 맞지 않습니다. NIP-17의 진짜 강점은 부인 가능성이 아니라 메타데이터 프라이버시와 콘텐츠 기밀성입니다.
+
+이 서명되지 않은 메시지는 kind `13` seal에 감싸지며, 이 seal은 실제 발신자가 서명하고 [NIP-44](/ko/topics/nip-44/)로 수신자에게 암호화됩니다.
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+seal에는 태그가 없으므로, 설령 복호화되더라도 수신자를 드러내지 않습니다. seal은 발신자의 실제 키로 서명되므로, 수신자는 seal의 `pubkey`가 내부 kind `14`의 `pubkey`와 일치하는지 확인해 메시지를 인증할 수 있습니다.
+
+그다음 이 seal은 임의의 일회용 키로 서명되고 수신자 앞으로 지정된 kind `1059` gift wrap에 다시 감싸집니다.
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+gift wrap의 `pubkey`는 이 메시지만을 위해 생성된 임의의 키이며, `created_at`은 최대 이틀 전까지 무작위화됩니다. relay가 실제로 보는 최외곽 계층은 이것입니다. 정체를 알 수 없는 pubkey에서 수신자 앞으로 온 메시지이지만, 타임스탬프는 실제 발송 시점을 반영하지 않습니다. 이 무작위 타임스탬프는 저장된 이벤트를 나중에 분석하는 공격에는 방어가 되지만, relay에 능동적으로 연결된 적대자는 gift wrap이 처음 나타난 시점을 여전히 관찰할 수 있으므로 이 방어는 나중에 relay 데이터를 조회하는 수동 관찰자에게만 제한적으로 유효합니다. pubkey는 임의이고 타임스탬프는 가짜이므로, relay는 실제 발신자를 판별할 수 없습니다. 메시지를 읽으려면 수신자가 자신의 키와 임의 pubkey를 사용해 gift wrap을 복호화하고, 그 안에서 seal을 찾은 뒤, 자신의 키와 seal 안의 발신자 pubkey를 사용해 seal을 복호화해, 마지막으로 안쪽의 kind `14` 메시지를 찾아야 합니다.
+
+NIP-17은 forward secrecy를 제공하지 않습니다. 모든 메시지는 정적인 Nostr 키페어를 사용해 암호화됩니다(NIP-44는 발신자와 수신자 키로부터 키를 도출합니다). 개인 키가 손상되면, 그 키로 암호화된 과거와 미래의 모든 메시지를 복호화할 수 있습니다. 이는 의도된 절충입니다. 암호화가 nsec에만 의존하기 때문에, 사용자가 자신의 nsec를 백업해 두면 gift wrap을 여전히 저장하고 있는 어떤 relay에서든 전체 메시지 기록을 복구할 수 있습니다. [Marmot](/ko/topics/marmot/)에 사용되는 MLS 같은 프로토콜은 회전하는 키 재료를 통해 forward secrecy를 제공하지만, 그 대가로 상태 동기화가 필요하고 키 회전 이후에는 과거 메시지를 복구할 수 없게 됩니다.
+
+NIP-17은 또한 암호화된 파일 메시지를 위한 kind `15`도 정의합니다. 이 kind는 `file-type`, `encryption-algorithm`, `decryption-key`, `decryption-nonce` 태그를 추가해, 수신자가 Blossom 서버에 업로드되기 전에 AES-GCM으로 암호화된 첨부 파일을 복호화할 수 있게 합니다. kind `10050`은 사용자가 선호하는 DM relay 목록을 게시하는 데 사용되며, 발신자는 gift wrap을 어디로 전달해야 하는지 알 수 있습니다. 메시지 안의 `pubkey`와 `p` 태그 집합이 채팅방을 정의하며, 참가자를 추가하거나 제거하면 깔끔한 이력이 분리된 새 방이 만들어집니다.
+
+구현은 주요 클라이언트 대부분을 아우릅니다. [nospeak](https://github.com/psic4t/nospeak)는 모든 일대일 메시징에 NIP-17을 사용합니다. [Flotilla](https://gitea.coracle.social/coracle/flotilla)는 proof-of-work DM에 NIP-17을 사용합니다. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel), [Coracle](https://github.com/coracle-social/coracle)은 모두 NIP-17을 기본 DM 프로토콜로 구현하고 있습니다. 이 사양은 또한 gift wrap에 `expiration` 태그를 설정해 사라지는 메시지도 지원합니다.
+
+## NIP Deep Dive: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)은 사용자의 개인 키를 클라이언트 애플리케이션과 분리하는 프로토콜을 정의합니다. 사용자가 웹 앱에 nsec를 붙여 넣는 대신, 개인 키를 보관하는 remote signer("bunker"라고도 부름)를 실행하고, 이 signer가 Nostr relay를 통해 서명 요청에 응답합니다. 클라이언트는 개인 키를 절대 보지 못합니다. 이렇게 하면 공격 표면이 줄어듭니다. 손상된 클라이언트가 서명을 요청할 수는 있어도 키 자체를 빼내 갈 수는 없습니다.
+
+이 프로토콜은 요청과 응답 모두에 kind `24133`을 사용하며, [NIP-44](/ko/topics/nip-44/) (Encrypted Payloads)로 암호화됩니다. 클라이언트는 세션용 일회성 `client-keypair`를 생성하고, 서로의 pubkey로 태그된 NIP-44 암호화 메시지를 통해 remote signer와 통신합니다. 아래는 클라이언트가 remote signer에 보내는 서명 요청 예시입니다.
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+암호화된 `content`는 JSON-RPC와 유사한 구조를 담고 있습니다.
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+remote signer는 요청을 복호화하고, 사용자에게 승인을 요청하거나(또는 설정된 권한에 따라 자동 승인하거나), 사용자의 개인 키로 이벤트에 서명한 뒤, 응답으로 서명된 이벤트를 반환합니다.
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+연결은 양쪽 어느 쪽에서든 시작할 수 있습니다. remote signer는 자신의 pubkey와 relay 정보를 담은 `bunker://` URL을 제공합니다. 클라이언트는 자신의 client pubkey, relay, 연결 검증용 secret이 포함된 `nostrconnect://` URL을 제공합니다. `secret` 파라미터는 연결 스푸핑을 막습니다. 바깥 채널로 URL을 전달받은 당사자만 핸드셰이크를 완료할 수 있습니다.
+
+정의된 메서드는 여덟 가지입니다. 세션을 설정하는 `connect`, 이벤트에 서명하는 `sign_event`, 사용자의 pubkey를 알아내는 `get_public_key`, keepalive용 `ping`, 레거시 암호화를 위한 `nip04_encrypt`/`nip04_decrypt`, 현재 암호화를 위한 `nip44_encrypt`/`nip44_decrypt`, relay 관리를 위한 `switch_relays`입니다. relay 마이그레이션은 remote signer가 처리하므로, 시간이 지나 새 relay로 연결을 옮겨도 세션은 끊기지 않습니다.
+
+클라이언트는 permission 시스템을 통해 연결 시점에 필요한 capability를 요청합니다. `nip44_encrypt,sign_event:1,sign_event:14` 같은 permission 문자열은 NIP-44 암호화 접근과 kind `1`, kind `14` 이벤트에 대한 서명 접근만 요청합니다. remote signer는 이 권한을 수락, 거부, 수정할 수 있습니다. 이는 읽기와 노트 게시를 하는 웹 클라이언트가 `sign_event:1` 권한만 받을 수 있고, DM 클라이언트는 여기에 `sign_event:14`와 `nip44_encrypt` 권한까지 추가로 받을 수 있음을 뜻합니다.
+
+[Amber](https://github.com/greenart7c3/Amber)는 Android에서 NIP-46을 구현하고 있으며, 이번 주의 [v6.0.0-pre1](#amber-v600-pre1-adds-per-connection-nip-46-signing-keys)은 클라이언트 간 격리를 위해 연결별 서명 키를 추가합니다. [nsec.app](https://github.com/nicktee/nsecapp) (이전 이름은 Nostr Connect)은 웹 기반 bunker를 제공합니다. [nostr-tools](https://github.com/nbd-wtf/nostr-tools)는 JavaScript 클라이언트를 위한 `BunkerSigner`를 포함하고 있으며, [지난주 PR #530](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing)은 수동 relay 관리를 위한 `skipSwitchRelays`를 추가했습니다. 이 프로토콜은 auth challenge도 지원합니다. remote signer가 추가 인증(비밀번호, biometric, hardware token)을 요구할 때는, 클라이언트가 브라우저에서 열어 사용자가 완료할 수 있는 `auth_url`로 응답합니다.
+
+---
+
+이번 주는 여기까지입니다. 만들고 있는 것이 있거나 공유할 소식이 있다면 Nostr에서 DM을 보내 주세요. 아니면 [nostrcompass.org](https://nostrcompass.org)에서 저희를 찾아오셔도 됩니다.

--- a/content/nl/newsletters/2026-04-08-newsletter.md
+++ b/content/nl/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Welkom terug bij Nostr Compass, je wekelijkse gids voor Nostr.
+
+**Deze week:** [Amethyst](https://github.com/vitorpamplona/amethyst) brengt [v1.08.0](#amethyst-brengt-arti-tor-en-merget-pure-kotlin-mls-en-marmot) uit met Arti Tor-integratie en een herontworpen Shorts-UI, terwijl pure Kotlin-implementaties van [MLS](/nl/topics/mls/) en [Marmot](/nl/topics/marmot/) in de [Quartz](/nl/topics/quartz/)-bibliotheek worden gemerged. [Nostur](https://github.com/nostur-com/nostur-ios-public) brengt [v1.27.0](#nostur-v1270-voegt-video-opname-en-prive-antwoorden-toe) uit met video-opname, geanimeerde GIF-profielen en private replies. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) lanceert [v0.15.0](#shosho-v0150-lanceert-shows-en-verticale-video-carousel) met Shows (aangepaste live-streaminfo gekoppeld aan OBS) en een verticale videocarrousel in TikTok-stijl. [Nymchat](https://github.com/Spl0itable/NYM) [draait Marmot terug en brengt verbeterde NIP-17-groepschats uit](#nymchat-draait-marmot-terug-en-brengt-verbeterde-nip-17-groepschats-uit) met roterende ephemeral keys. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) brengt [ondersteuning voor exit nodes en Umbrel-packaging](#nostr-vpn-brengt-ondersteuning-voor-exit-nodes-en-umbrel-packaging-uit) uit in zes releases. [Amber](https://github.com/greenart7c3/Amber) springt naar [v6.0.0-pre1](#amber-v600-pre1-voegt-nip-46-signing-keys-per-verbinding-toe) met [NIP-46](/nl/topics/nip-46/) signing keys per verbinding en in-app updates via Zapstore. [Notedeck](https://github.com/damus-io/notedeck) bereikt [v0.10.0-beta](#notedeck-v0100-beta-brengt-zapstore-self-update-uit) met APK self-update via Zapstore, en [NIP-58](/nl/topics/nip-58/) (Badges) krijgt een [kind-migratie](#nip-updates). Twee NIP-deep-dives behandelen [NIP-17](/nl/topics/nip-17/) (Private Direct Messages) en [NIP-46](/nl/topics/nip-46/) (Nostr Remote Signing).
+
+## Nieuws
+
+### Amethyst brengt Arti Tor en merget pure Kotlin MLS en Marmot
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), de Android-client onderhouden door vitorpamplona, bracht vier releases uit van [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) tot en met [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) en merge'de een grote reeks nog niet uitgebrachte wijzigingen in de [Quartz](/nl/topics/quartz/)-bibliotheek (de gedeelde Kotlin Multiplatform Nostr-module). De hoofdrelease is v1.08.0 "Arti Tor", die de Tor-connectiviteit van de app migreert van de op C gebaseerde Tor-bibliotheek naar [Arti](https://gitlab.torproject.org/tpo/core/arti), de Rust-implementatie van het Tor Project. Die migratie pakt willekeurige crashes aan die optraden onder de eerdere C Tor-bindings. Arti is de langetermijnvervanger van het Tor Project voor de C-codebase, vanaf nul geschreven in Rust voor memory safety en async I/O.
+
+De v1.07.3-release herontwierp de Shorts-UI en verving het gepagineerde ontwerp door rand-tot-rand-feeds voor afbeeldingen, shorts en lange video's. Diezelfde release migreerde badges naar kind `10008` en bookmarks naar kind `10003`, in lijn met de [NIP-58](/nl/topics/nip-58/) kind-migratie die [deze week werd gemerged](#nip-updates). v1.07.4 repareerde een probleem met de secret-afhandeling van Nostr Wallet Connect, en v1.07.5 repareerde een crash bij image-upload.
+
+Op main, maar nog niet in een getagde release, schreef het team een volledige Kotlin-implementatie van zowel [MLS](/nl/topics/mls/) als het [Marmot](/nl/topics/marmot/)-protocol, waardoor native C/Rust-library bindings niet langer nodig zijn. [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) voegt de kernlaag voor Marmot MLS-groepsberichten toe, [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) voegt de groepschat-UI toe, [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) voegt inkomende en uitgaande berichtprocessors met een subscription manager toe, [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) voegt persistente MLS-groepsstatus en KeyPackage-rotatiebeheer toe, [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) voegt een volledige MLS-testsuite met verbeterde GroupInfo-signing toe, en [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) voegt tracking van de publicatiestatus van KeyPackages toe. [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) voegt een pure Kotlin secp256k1-implementatie toe voor Nostr-cryptografische operaties, als vervanging van de native C-library dependency. In combinatie met de Kotlin MLS-implementatie kan [Quartz](/nl/topics/quartz/) Nostr-signing en Marmot-groepsberichten draaien zonder native bindings, wat de deur opent naar Kotlin Multiplatform-targets waaronder iOS.
+
+Het team bouwt ook ondersteuning voor [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls): [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) voegt een volledige testsuite toe voor de NIP-AC call state machine, en [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) voorkomt dat verouderde call offers opnieuw worden getriggerd nadat de app opnieuw is gestart.
+
+### Nostur v1.27.0 voegt video-opname en private replies toe
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), de iOS Nostr-client, bracht [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) uit op 2 april. De release voegt video-opname in de app toe met trim-before-upload, zodat gebruikers korte clips kunnen opnemen, op lengte kunnen knippen en publiceren zonder de client te verlaten. Ondersteuning voor geanimeerde GIF's strekt zich nu uit tot profiel- en bannerfoto's, en er is ook geanimeerde WebP-rendering toegevoegd. Een nieuwe Shortcuts-integratie laat gebruikers Nostr-posts versturen vanuit Apple Shortcuts-automatiseringen. De release voegt ook private replies toe en repareert DM-compatibiliteitsproblemen die de berichtbezorging tussen Nostur en andere clients beïnvloedden.
+
+### Shosho v0.15.0 lanceert Shows en verticale video-carousel
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), de Nostr-livestreamingapp, bracht [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) en [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) uit op 7 april. De hoofdfunctie is Shows: streamers kunnen aangepaste show-informatie instellen voordat ze live gaan en hun show koppelen aan OBS of een andere externe encoder. Daarmee wordt de metadata van "wat stream ik" losgekoppeld van het daadwerkelijk live gaan, zodat streamers titels, beschrijvingen en producten kunnen voorbereiden voordat de uitzending begint. Diezelfde release voegt een verticale videocarrousel in TikTok-stijl toe om door lives, clips en replays te swipen in een fullscreen-feed, plus Quick Add om videoclips te publiceren en producten direct vanaf een profielpagina toe te voegen. v0.15.1 repareert een bug waarbij het toetsenbord het chatinvoerveld van de livestream verborg.
+
+## Releases
+
+### Notedeck v0.10.0-beta brengt Zapstore self-update uit
+
+[Notedeck](https://github.com/damus-io/notedeck), de desktop- en mobiele client van het Damus-team, bracht [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) en [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) uit als test-prereleases voor APK self-update. [PR #1417](https://github.com/damus-io/notedeck/pull/1417) voegt APK self-update toe via de Nostr/Zapstore-updater op Android, voortbouwend op het [Nostr-native update-discoverywerk uit Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr). De updateflow ontdekt nieuwe releases via Nostr-events die naar relays zijn gepubliceerd, downloadt vervolgens de APK van waar de ontwikkelaar die host (GitHub releases, Blossom CDN of andere bronnen), verifieert de SHA-256-hash tegen het ondertekende Nostr-event en installeert die daarna. [PR #1438](https://github.com/damus-io/notedeck/pull/1438) repareert een bug op het welkomstscherm waarbij Login- en CreateAccount-knoppen direct terug navigeerden, en [PR #1424](https://github.com/damus-io/notedeck/pull/1424) repareert tekstoverflow in de Agentium AI-sessieweergave.
+
+### Amber v6.0.0-pre1 voegt NIP-46 signing keys per verbinding toe
+
+[Amber](https://github.com/greenart7c3/Amber), de [NIP-55](/nl/topics/nip-55/) (Android Signer Application) signer-app, bracht [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) uit op 4 april. De belangrijkste wijziging is signing keys per verbinding voor het [NIP-46](/nl/topics/nip-46/) (Nostr Remote Signing) bunker-protocol. In plaats van één keypair te gebruiken voor alle bunker-verbindingen genereert Amber nu een aparte sleutel voor elke verbonden client. Als één clientverbinding gecompromitteerd raakt, kan de aanvaller zich niet voordoen als de signer tegenover andere clients.
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377) voegt in-app controle op updates en installatie via Zapstore toe, waarmee Amber zich naast [Notedeck](#notedeck-v0100-beta-brengt-zapstore-self-update-uit) schaart in Nostr-native appdistributie. [PR #375](https://github.com/greenart7c3/Amber/pull/375) handelt AndroidKeyStore-fouten netjes af door gebruikers een waarschuwing te tonen in plaats van te crashen, en [PR #371](https://github.com/greenart7c3/Amber/pull/371) voegt database-opruiming toe met groottelimieten en truncatie van content om onbegrensde opslaggroei te voorkomen. De pre-release bevat ook de [NIP-42](/nl/topics/nip-42/) relay-auth-whitelist en login via mnemonic recovery phrase uit de [v5.0.x-cyclus die vorige week werd behandeld](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria brengt native mobiele app uit
+
+[Nostria](https://github.com/nostria-app/nostria), de cross-platform Nostr-client onderhouden door SondreB, bracht een native mobiele app voor Android uit met acht releases van [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) tot en met [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). De belangrijkste nieuwe mogelijkheid is native ondersteuning voor local signers zoals [Amber](https://github.com/greenart7c3/Amber) en Aegis. [Desktop-installers](https://www.nostria.app/download) voor Linux, macOS en Windows zijn ook beschikbaar. [PR #610](https://github.com/nostria-app/nostria/pull/610) verlaagt de geheugendruk van de feed met adaptieve runtime-limieten en opschoning van preview-URL's. v3.1.14 repareert de integratie met Brainstorm, een [Web of Trust](/nl/topics/web-of-trust/)-provider. v3.1.15 richt zich op muziekverbeteringen. De nieuwe Android-app is beschikbaar op [Zapstore](https://zapstore.dev/apps/app.nostria).
+
+### diVine 1.0.8 brengt hervatbare uploads en DM's uit
+
+[diVine](https://github.com/divinevideo/divine-mobile), de short-form videocliënt, bracht [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) uit met 87 gemergede PR's. Hervatbare uploads laten makers onderbroken uploads chunk voor chunk voortzetten in plaats van opnieuw vanaf nul te beginnen op een instabiele verbinding. De release voegt instellingen voor videokwaliteit en bitrate toe, double-tap om te liken en verbeteringen aan DM's. [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) voegt een macOS-camera-plugin toe voor desktop-video-opname, en [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migreert het notificatiesysteem naar een BLoC-architectuur met enrichment en grouping. Het team verving ook AI-generated stickers en category art door OpenMoji SVG's ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 voegt vervaging van gevoelige notities en NIP-42-auth toe
+
+[Manent](https://github.com/dtonon/manent), de private app voor versleutelde notities en bestandsopslag, bracht [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) uit op 2 april. Gebruikers kunnen notities nu als gevoelig markeren om ze in de lijstweergave te vervagen, zodat private content verborgen blijft tijdens vluchtig scrollen. De release voegt ook ondersteuning voor [NIP-42](/nl/topics/nip-42/) (Authentication of Clients to Relays) toe, waardoor Manent zich kan authenticeren bij relays die dat vereisen voordat ze events accepteren. Manent slaat alle data versleuteld op Nostr-relays op met het keypair van de gebruiker, dus NIP-42-ondersteuning vergroot het aantal relays dat het voor opslag kan gebruiken.
+
+### Wisp v0.17.0 tot en met v0.17.3 voegen livestream-zaps en walletbackup toe
+
+[Wisp](https://github.com/barrydeen/wisp), de Android Nostr-client, bracht zes releases uit van [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) tot en met [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) met 44 gemergede PR's. De v0.17.0-release voegt veiligheidsmeldingen voor walletbackups en zap-UX-verbeteringen toe. [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) voegt zichtbaarheid van livestreamchat over platforms heen en functionaliteit voor livestream-zaps toe. [PR #423](https://github.com/barrydeen/wisp/pull/423) voegt automatisch zoeken naar profielen, een zap-success-animatie en verbeteringen aan de gebruikersstatus toe. [PR #426](https://github.com/barrydeen/wisp/pull/426) repareert een out-of-memory-crash in `computeId` voor events met grote taglijsten. De v0.16.x-releases voegden emoji-shortcode-autocomplete, verbeteringen aan de groepschat-UI en filtering van geblokkeerde gebruikers toe over alle notificatiepaden heen.
+
+### Mostro brengt deep links, Nostr-wisselkoersen en een fix voor dubbele betalingen uit
+
+[Mostro](https://github.com/MostroP2P/mostro), de peer-to-peer Bitcoin-beurs gebouwd op Nostr, zag deze week updates in zowel zijn serverdaemon als mobiele client. Aan serverzijde voorkomt [PR #692](https://github.com/MostroP2P/mostro/pull/692) dat verouderde orderwrites dubbele betalingen veroorzaken, een bug die ertoe kon leiden dat een verkoper twee keer voor dezelfde trade werd betaald. [PR #693](https://github.com/MostroP2P/mostro/pull/693) gebruikt gerichte updates voor dev_fee-writes in plaats van volledige order-overschrijvingen.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), de Flutter-client, bracht [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) uit op 3 april. De release handelt deep links van verschillende Mostro-instanties af, zodat gebruikers op links kunnen tikken die naar de juiste exchange-server routeren. [PR #498](https://github.com/MostroP2P/mobile/pull/498) detecteert admin- en dispute-DM's in de achtergrondnotificatiepipeline, en de app haalt wisselkoersen nu op via Nostr met een HTTP/cache-fallback. [PR #560](https://github.com/MostroP2P/mobile/pull/560) repareert een relay-connection blocking bug waardoor de app onder bepaalde netwerkcondities relays niet kon bereiken.
+
+### Unfiltered v1.0.12 voegt hashtags en comments toe
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), een Nostr-client gericht op beeldrijke content, bracht [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12) uit. [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) voegt hashtag-ondersteuning toe en [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) voegt de mogelijkheid toe om comments op posts te schrijven en te tonen. [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) repareert navigatieproblemen bij posts met meerdere afbeeldingen.
+
+### Primal Android brengt walletdeling voor meerdere accounts en auto-reconnect voor remote signer uit
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), de Android Nostr-client, bracht op 7 april een release uit. De update voegt walletdeling voor meerdere accounts toe en een overflow-menu met walletverwijdering in Dev Tools. De remote signer reconnect nu automatisch bij verbroken verbindingen, en de walletservice kreeg zijn eigen auto-reconnectlogica. Fixes zorgen ervoor dat poll-zap-stemmen niet langer als Top Zaps verschijnen, lege pollopties geen crash meer veroorzaken, walletsaldo wordt verborgen wanneer er geen wallet bestaat, en WalletException-typen naar foutcodes in NWC-antwoorden worden gemapt.
+
+### Titan v0.1.0 lanceert native nsite://-browser met Bitcoin-naamsregistratie
+
+[Titan](https://github.com/btcjt/titan), een native desktopbrowser voor het Nostr-web, bracht [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) uit op 7 april. Titan resolveert `nsite://`-URL's door mensleesbare namen op te zoeken die op Bitcoin zijn geregistreerd, Nostr-relays te bevragen voor de contentevents van de site en pagina's te renderen die van [Blossom](/nl/topics/blossom/)-servers zijn opgehaald. Het resultaat is een webbrowse-ervaring zonder DNS, zonder TLS-certificaten en zonder hostingproviders. Namen worden geregistreerd via een [webinterface](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) die gekoppeld is aan Bitcoin-transacties. De eerste release wordt geleverd als een macOS `.dmg` (ARM, met Rosetta 2-ondersteuning voor Intel) en bevat ondersteuning voor een Nix-ontwikkelomgeving.
+
+### Bikel v1.5.0 brengt een native foreground service uit voor de-Googled telefoons
+
+[Bikel](https://github.com/Mnpezz/bikel), een gedecentraliseerde fietstracker die ritten omzet in publieke infrastructuurdata via Nostr, bracht [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) uit op 4 april. De release migreert van de van GMS afhankelijke Expo TaskManager naar een aangepaste native foreground service, wat betrouwbare achtergrondtracking van ritten garandeert op LineageOS, GrapheneOS en andere de-Googled Android-varianten. De Bikel Bot kreeg een dual-pocket-architectuur met autonome eCash-collectie via Cashu nutzaps. v1.4.3 en v1.4.2 repareren sync van achtergrondtracking voor niet-standaard Android-omgevingen, en de app voegt OSM bike rack map point toggles toe.
+
+### Sprout voegt NIP-01, NIP-23 en NIP-33-ondersteuning toe
+
+[Sprout](https://github.com/block/sprout), een communicatieplatform van Block met een ingebouwde Nostr-relay, bracht [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) uit op 6 april. Deze week voegde het team ondersteuning toe voor [NIP-23](/en/topics/nip-23/) (Long-form Content) kind `30023`-artikelen, [NIP-33](/en/topics/nip-33/) parameterized replaceable events met vervanging op basis van `d`-tags, en [NIP-01](/nl/topics/nip-01/)/[NIP-02](/en/topics/nip-02/) kind `1` text notes en kind `3` follow lists. De release voegt ook een adaptief IDE-themasysteem met 54 thema's toe, UX-polish voor workflow- en agent-run history, en een opgeschoonde ledenzijbalk.
+
+### mesh-llm v0.56.0 brengt distributed config protocol uit
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), een gedistribueerd LLM-inferentiesysteem dat Nostr-keypairs gebruikt voor node-identiteit, bracht [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) uit op 7 april. De release voegt een distributed config protocol toe met ownership-semantiek, asymmetrische KV-cache-kwantisatie (Q8_0-sleutels met Q4-waarden) voor lager geheugengebruik, OS keychain-opslag voor identity keystores, vloeiende chatstreaming met message queuing, en fixes voor fullscreen-layout en KV-cache-splitting met flash attention.
+
+### Nostr VPN brengt ondersteuning voor exit nodes en Umbrel-packaging uit
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), een peer-to-peer VPN die Nostr-relays gebruikt voor signalering en WireGuard voor versleutelde tunnels, bracht deze week zes releases uit van [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) tot en met [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6). De v0.3.x-cyclus voegt ondersteuning voor exit nodes op Windows en macOS toe, waardoor peers internetverkeer via andere nodes in het netwerk kunnen routeren. Invite- en alias-propagatie synchroniseren nu over Nostr, zodat gebruikers netwerktoegang kunnen delen zonder coördinatie buiten het protocol om. De releases voegen Umbrel-packaging voor self-hosted deployment toe, NAT punch-through met onthouden publieke endpoints, automatische opschoning van verouderde exit nodes en een gepubliceerde protocolspecificatie. Het project stabiliseerde ook de route-afhandeling op macOS met zelfherstellende default routes en underlay-reparatie, en voegde een Android-build via Tauri toe. Builds zijn beschikbaar voor macOS (Apple Silicon en Intel), Linux (AppImage en .deb), Windows en Android.
+
+### Nymchat draait Marmot terug en brengt verbeterde NIP-17-groepschats uit
+
+[Nymchat](https://github.com/Spl0itable/NYM), de MLS-capabele chatclient, bracht 14 releases uit van [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) tot en met [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274). De belangrijkste wijziging is een protocoldraai: [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) voegde Marmot MLS-groepschats toe, maar [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) keerde terug naar [NIP-17](/nl/topics/nip-17/) omdat de ondersteuning van Marmot voor meerdere apparaten nog niet af is, wat problemen veroorzaakte met de synchronisatie van groepschatstatus tussen apparaten. v3.58.271 introduceert verbeterde NIP-17-groepschats met roterende ephemeral keys voor alle berichten, ontworpen om timing- en correlatieaanvallen te voorkomen. De week bracht ook een friendsysteem met fijnmazige controle over instellingen ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), synchronisatie van MLS-groepschatberichten in versleutelde appinstellingen en meerdere fixes voor relayconnectiviteit.
+
+### nak v0.19.5 voegt Blossom multi-server en outbox-publicatie toe
+
+[nak](https://github.com/fiatjaf/nak), fiatjaf's command-line Nostr-toolkit, bracht [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5) uit. Het `blossom`-commando accepteert nu meerdere `--server`-flags om in één keer naar verschillende [Blossom](/nl/topics/blossom/)-servers te uploaden. Een nieuw `key`-commando breidt partiële sleutels uit door links nullen toe te voegen. Het `event`-commando krijgt een `--outbox`-flag om events via het outbox-model te publiceren, en `fetch` stopt nu met een foutcode wanneer geen event wordt teruggegeven.
+
+## In ontwikkeling
+
+### White Noise voegt thumbhash-previews en push registration bridge toe
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), de private messenger gebouwd op het [Marmot](/nl/topics/marmot/)-protocol, merge'de vijf PR's. [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) vervangt blurhash-image previews door thumbhash, een nieuwer algoritme dat scherpere placeholderafbeeldingen produceert met een kleinere payload (doorgaans minder dan 30 bytes tegenover blurhash met ongeveer 50-100 bytes), terwijl de aspectverhouding en kleurverdeling van de oorspronkelijke afbeelding behouden blijven. Blurhash blijft als fallback bestaan voor oudere content. [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) werkt whitenoise-rs bij en voegt de [MIP-05](/nl/topics/mip-05/) push registration bridge toe, waarmee het [werk aan de pushnotificatiespecificatie van vorige week](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications) met de client wordt verbonden. [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) voegt cursor-based pagination toe voor chatberichten, als vervanging van de eerdere laadstrategie door een scrollgestuurde aanpak.
+
+### Route96 voegt dynamische labelconfiguratie en zero-egress-opruiming toe
+
+[Route96](https://github.com/v0l/route96), de [Blossom](/nl/topics/blossom/)-mediaserver van v0l, merge'de drie PR's. [PR #80](https://github.com/v0l/route96/pull/80) voegt dynamische configuratie van labelmodellen via de admin-API toe, waardoor operators contentclassificatiemodellen kunnen wisselen zonder de server opnieuw te starten. [PR #82](https://github.com/v0l/route96/pull/82) voegt labelconfiguratievelden toe aan de admin-UI. [PR #79](https://github.com/v0l/route96/pull/79) voegt een zero-egress-opruimbeleid toe dat bestanden die nooit zijn gedownload automatisch verwijdert, zodat opslagkosten voor operators laag blijven.
+
+### Snort brengt beveiligingsverharding en DVM-betaalfacturen uit
+
+[Snort](https://github.com/v0l/snort), de webclient, bracht deze week twee releases uit samen met een uitgebreide beveiligingsaudit. Fixes omvatten Schnorr-signatuurverificatie, bescherming tegen relay message forgery in [NIP-46](/nl/topics/nip-46/) (waardoor aanvallers geen signing requests kunnen injecteren via gecompromitteerde relays), verbeteringen aan PIN-versleuteling en verwijdering van vertrouwen op NIP-26-delegatie. Prestatieverbeteringen komen van gebatchte Schnorr-verificatie in WASM, lazy-loaded routes, vooraf gecompileerde vertalingen en het weghalen van dubbele verificatie per event. [PR #618](https://github.com/v0l/snort/pull/618) voegt weergave van payment-required invoices toe voor [NIP-90](/en/topics/nip-90/) (Data Vending Machine) kind `7000`, zodat Snort de Lightning-factuur direct in de feed rendert wanneer een DVM met een betaalverzoek reageert.
+
+### Damus verbetert LMDB-compaction
+
+[Damus](https://github.com/damus-io/damus), de iOS-client, merge'de [PR #3719](https://github.com/damus-io/damus/pull/3719), die automatische LMDB-compaction volgens een schema toevoegt en voorkomt dat de lokale database na verloop van tijd onbegrensd groeit. [PR #3663](https://github.com/damus-io/damus/pull/3663) verbetert de BlurOverlayView zodat die beschermend oogt in plaats van kapot.
+
+### Captain's Log voegt tag-indexering en note-sync toe
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), de Nostr-native long-form schrijftool van Nodetec, merge'de deze week vier PR's. [PR #156](https://github.com/nodetec/captains-log/pull/156) voegt tag-indexering en sync-ondersteuning over notes heen toe, [PR #157](https://github.com/nodetec/captains-log/pull/157) refactort note-sync en tag-afhandeling, en [PR #159](https://github.com/nodetec/captains-log/pull/159) repareert sync van verwijderde notes zodat gewiste notes op alle apparaten verwijderd blijven.
+
+### Relatr v0.2.x herontwerpt plug-insysteem met Nostr-native validator-marktplaats
+
+[Relatr](https://github.com/ContextVM/relatr), een [Web of Trust](/nl/topics/web-of-trust/)-scoringengine die vertrouwensranglijsten berekent op basis van sociale-graafafstand en configureerbare validators, bracht de v0.2.x-familie uit met een complete herziening van het plug-insysteem. Validators worden nu geschreven in Elo, een draagbare functionele expressietaal die is geforkt om host-georkestreerde capabilities in meerdere stappen te ondersteunen (Nostr-queries, social graph-lookups, NIP-05-resolutie). Plug-ins worden gepubliceerd als kind `765` Nostr-events, waardoor distributie native wordt aan het relaynetwerk. Een nieuwe [plugin marketplace](https://relatr.net) laat operators validators ontdekken, installeren en wegen vanuit de browser, met een CLI (`relo`) voor lokaal authoren en publiceren. De architectuur is gesandboxed: plug-ins kunnen alleen capabilities aanroepen die de host expliciet beschikbaar stelt, zodat een kwaadaardige validator niet buiten zijn gedefinieerde scope kan ontsnappen. Relatr-instanties kunnen nu vanaf de website worden beheerd, met volledige zichtbaarheid in welke plug-ins het scoringsalgoritme vormen en welke individuele gewichten ze hebben.
+
+### Shopstr verbetert mobiele navigatie en toegangscontrole
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), de Nostr-native marktplaats voor kopen en verkopen met Bitcoin, pushte deze week 158 commits over de hoofdapp en het begeleidende [Milk Market](https://github.com/shopstr-eng/milk-market)-project. Fixes omvatten verbeteringen aan de mobiele communitylayout, gedrag waarbij menu's bij navigatie sluiten en het automatisch sluiten van dropdowns. Beschermde routes zijn niet langer via een directe URL bereikbaar zonder in te loggen, en de slug-matchinglogica behandelt meerdere exacte matches nu correct.
+
+### Pollerama voegt notificaties, filmzoekfunctie en rating-UI toe
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), een polling-, survey- en social rating-app gebouwd op Nostr, voegde thread-notificaties, een filmzoekfunctie en een herziening van de rating-UI toe. De release repareert ook problemen met het laden van de feed en verhoogt dependency-versies.
+
+### Purser bouwt Nostr-native betaaldemon met Marmot-versleuteling
+
+[Purser](https://github.com/EthnTuttle/purser), een Nostr-native betaaldemon ontworpen als vervanger voor Zaprite, merge'de deze week negen PR's die de kernarchitectuur uitbouwen. Het project gebruikt [Marmot](/nl/topics/marmot/) MLS via MDK voor versleutelde merchant-customer messaging, met Strike en Square als payment providers. Deze week landden config- en catalog-loading, validatie van berichtschema's, de MDK-communicatielaag, implementaties voor Strike en Square, een polling-engine, anti-spam-rate limiting, persistentie van pending payments en de orderverwerkingspipeline. Alle 99 tests oefenen nu echte mdk-core MLS-operaties uit nadat het team mock MLS verwijderde ten gunste van echte versleuteling in local mode.
+
+### Vector refactort DM-bijlagen en voegt profielbewerking toe
+
+[Vector](https://github.com/VectorPrivacy/Vector), de privacygerichte Nostr-messenger gebouwd met Tauri, merge'de [PR #55](https://github.com/VectorPrivacy/Vector/pull/55), die de frontend refactort. Het decrypten en opslaan van DM-bijlagen is verplaatst naar de vector-core-library, en de app ondersteunt nu profielbewerking. De upload-cancel-flag is correct doorverbonden via TauriSendCallback, en ongebruikte callbacks voor attachment previews zijn opgeschoond.
+
+## Protocol- en specificatiewerk
+
+### NIP-Updates
+
+Recente wijzigingen in het [NIPs-repository](https://github.com/nostr-protocol/nips):
+
+**Gemerged:**
+
+- **[NIP-58](/nl/topics/nip-58/) (Badges): Profile Badges verhuizen naar kind 10008, Badge Sets naar kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Migreert Profile Badges van kind `30008` naar kind `10008` (een replaceable event, één per pubkey) en introduceert kind `30008` voor Badge Sets. Eerder gebruikten Profile Badges hetzelfde kind (`30008`) als badge-definities, waardoor ze parameterized replaceable events waren met een `d`-tag als sleutel. Het nieuwe kind `10008` is een eenvoudig replaceable event: één per pubkey, zonder `d`-tag. Clients vragen nu per gebruiker één enkel replaceable event op in plaats van parameterized replaceable events te scannen. Amethyst v1.07.3 wordt al met deze migratie geleverd.
+
+- **[NIP-34](/nl/topics/nip-34/) (Git Stuff): Add git-related follow lists** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): Voegt conventies voor follow lists toe voor NIP-34 repository- en issue-tracking. Gebruikers publiceren kind `30000` follow sets met `d`-tags zoals `git-repos` of `git-issues` die `a`-tagverwijzingen bevatten naar repositories (kind `30617`) die zij willen volgen. Clients kunnen zich op deze follow sets abonneren om repository-activiteit in de feed van een gebruiker te tonen, vergelijkbaar met hoe kind `3` contactlijsten werken voor pubkeys.
+
+**Open PR's en discussies:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): Breidt de oorspronkelijke NIP-100 (geïmplementeerd door 0xChat) uit met drie wijzigingen: migratie naar [NIP-44](/nl/topics/nip-44/)-versleuteling verpakt in [NIP-59](/nl/topics/nip-59/) gift wraps om metadata-lekken te elimineren, een gespecificeerde WebRTC-workflow voor de setup van voice- en videocalls (offer, answer, ICE candidates), en een mesh-model voor groepscalls waarin elke peer een directe WebRTC-verbinding opzet met elke andere peer. De specificatie is niet backwards-compatible met NIP-100. Amethyst bouwt er al tegenaan, met een testsuite voor de call state machine ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) en afhandeling van verouderde call offers ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)) die deze week landden.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Stelt conventies voor voor threshold-signing op Nostr met [FROST](/nl/topics/frost/) (Flexible Round-Optimized Schnorr Threshold). FROST laat een groep signers gezamenlijk een Nostr-identiteit beheren waarbij elke t-of-n-combinatie events kan signeren zonder de volledige private key te reconstrueren. Het NIP definieert hoe signing-rondes worden gecoördineerd, key shares worden verdeeld en threshold-signed events worden gepubliceerd, voortbouwend op het Igloo-signerwerk uit het [FROSTR-project](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Definieert een `postMessage`-protocol voor gesandboxte webapplicaties ("napplets") die in iframes draaien om te communiceren met een hostapplicatie ("shell"). De shell voorziet de napplet via een gestructureerde message-API van Nostr-signing, relaytoegang en gebruikerscontext, terwijl de iframe-sandbox directe sleuteltoegang verhindert. Dit breidt het model voor hosting van statische websites uit [NIP-5A](/en/topics/nip-5a/) uit richting interactieve applicaties die Nostr-events kunnen lezen en schrijven. Het NIP is actief in ontwikkeling met een werkende runtime-implementatie.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): Is hernoemd vanuit het eerdere voorstel NIP-A5. Het definieert conventies voor het publiceren en ontdekken van WebAssembly-programma's op Nostr. WASM-binaries worden als Nostr-events opgeslagen, en clients kunnen ze downloaden en uitvoeren in een gesandboxte runtime. Een [demo-app](https://nprogram.netlify.app/) laat scrolls in de browser draaien, met voorbeeldprogramma's die als Nostr-events zijn gepubliceerd en door elke client kunnen worden opgehaald en uitgevoerd.
+
+- **[NIP-85](/nl/topics/nip-85/) (Trusted Assertions): Clarifications** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): Verscherpt de specificatietaal rond meerdere sleutels en relays per serviceprovider en verduidelijkt hoe clients assertions van providers moeten afhandelen die over meerdere pubkeys of relay-endpoints opereren.
+
+- **[NIP-24](/nl/topics/nip-24/) (Extra Metadata Fields): published_at voor replaceable events** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): Generaliseert de `published_at`-tag uit [NIP-23](/en/topics/nip-23/) (Long-form Content) naar alle replaceable en addressable events. De tag is uitsluitend bedoeld voor weergave: als `published_at` gelijk is aan `created_at`, tonen clients het event als "gemaakt" op dat moment; als ze verschillen (omdat het event is bijgewerkt), kunnen clients in plaats daarvan "bijgewerkt" tonen. Dit laat kind `0`-profielen "joined at"-data tonen en laat andere replaceable events hun oorspronkelijke publicatietijdstip behouden over updates heen. Een aanvullend voorstel voor [NIP-51](/nl/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) voegt dezelfde tag toe aan list-events.
+
+- **[NIP-59](/nl/topics/nip-59/) (Gift Wrap): Ephemeral gift wrap kind** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): Voegt kind `21059` toe als ephemeral tegenhanger van de bestaande kind `1059` gift wrap. Ephemeral events (kinds `20000`-`29999`) volgen de semantiek van [NIP-01](/nl/topics/nip-01/): relays hoeven ze niet op te slaan en mogen ze na bezorging weggooien. Daarmee kunnen applicaties gift-wrapped berichten versturen die van relays verdwijnen zodra ze zijn afgeleverd, wat de opslagbehoefte voor berichtenverkeer met hoog volume vermindert terwijl hetzelfde drielagige versleutelingsmodel als gewone [NIP-17](/nl/topics/nip-17/) DM's behouden blijft.
+
+### OpenSats kondigt zestiende golf Nostr-subsidies aan
+
+[OpenSats](https://opensats.org) kondigde op 8 april zijn [zestiende golf Nostr-subsidies](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) aan, met financiering voor vier eerste subsidies en één verlenging. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) ontvangt financiering voor bijdrager Robert Nagy om een zelfstandige desktopapp te bouwen bovenop de [Quartz](/nl/topics/quartz/) en Commons-modules, waarmee de feature-set van de Android-client naar muisgestuurde interfaces met persistente relayverbindingen wordt gebracht. [Nostr Mail](https://github.com/nogringo/nostr-mail) ontvangt financiering om een volledig e-mailsysteem op Nostr te bouwen met kind `1301`-events verpakt in [NIP-59](/nl/topics/nip-59/) gift wraps, met een Flutter-client en SMTP-bridgeservers voor compatibiliteit met Gmail en Outlook. [Nostrord](https://github.com/Nostrord/nostrord) ontvangt financiering voor een Kotlin Multiplatform [NIP-29](/en/topics/nip-29/) relay-based groepsclient met Discord-achtige groepsberichten, moderatie en threads. [Nurunuru](https://github.com/tami1A84/null--nostr) ontvangt financiering om een native iOS-versie te bouwen van de op Japan gerichte Nostr-client gemodelleerd naar de vertrouwde interface van LINE, met op passkeys gebaseerde biometrische login voor onboarding. HAMSTR kreeg een verlenging van zijn subsidie (voor het eerst gefinancierd in de [elfde golf](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)).
+
+## NIP Deep Dive: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) definieert de huidige standaard voor private direct messages op Nostr. Het vervangt het oudere schema van [NIP-04](/nl/topics/nip-04/) (Encrypted Direct Messages), dat metadata lekte (afzender, ontvanger en tijdstempels waren allemaal zichtbaar op relays) en een zwakkere versleutelingsconstructie gebruikte. NIP-17 combineert [NIP-44](/nl/topics/nip-44/) (Encrypted Payloads) voor versleuteling met [NIP-59](/nl/topics/nip-59/) (Gift Wrap) voor bescherming van metadata, en creëert zo een systeem met drie lagen waarin relays niet kunnen zien wie met wie praat.
+
+Het protocol gebruikt drie event kinds die in elkaar zijn genest. De binnenste laag is het daadwerkelijke bericht, een ongetekend kind `14`-event:
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+Het kind `14`-event is bewust ongetekend (lege `sig`). De specificatie beschrijft dit als het bieden van ontkenbaarheid, maar in de praktijk is die bescherming beperkt. De kind `13` seal die het rumor-bericht inpakt, is ondertekend met de echte sleutel van de afzender. Een ontvanger kan die ondertekende seal aan een derde partij tonen en daarmee bewijzen dat de afzender met hen heeft gecommuniceerd, zelfs zonder de inhoud van het bericht prijs te geven. Met zero-knowledge proofs kan een ontvanger zelfs de exacte inhoud van het bericht bewijzen zonder zijn eigen private key prijs te geven. Het ongetekende rumor is als een ongetekende brief in een ondertekende envelop: de handtekening op de envelop koppelt de afzender aan de inhoud. Echte ontkenbaarheid zou symmetrische authenticatie vereisen (zoals de HMACs van Signal), wat onverenigbaar is met het gedecentraliseerde relaymodel van Nostr waarin berichten zelfauthenticerend moeten zijn. De echte sterke punten van NIP-17 zijn metadata-privacy en geheimhouding van content, niet ontkenbaarheid.
+
+Dit ongetekende bericht wordt vervolgens verpakt in een kind `13` seal, die door de werkelijke afzender wordt ondertekend en met [NIP-44](/nl/topics/nip-44/) voor de ontvanger wordt versleuteld:
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+De seal heeft geen tags, dus zelfs na decryptie zou die de ontvanger niet onthullen. De seal is ondertekend met de echte sleutel van de afzender, waardoor de ontvanger het bericht kan authenticeren door te controleren dat de `pubkey` van de seal overeenkomt met de `pubkey` van het binnenste kind `14`.
+
+De seal wordt daarna verpakt in een kind `1059` gift wrap, ondertekend met een willekeurige wegwerpsleutel en geadresseerd aan de ontvanger:
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+De `pubkey` van de gift wrap is een willekeurige sleutel die alleen voor dit bericht wordt gegenereerd, en de `created_at` wordt tot twee dagen in het verleden gerandomiseerd. Dit is de buitenste laag die relays daadwerkelijk zien: een bericht van een onbekende pubkey aan de ontvanger, met een tijdstempel die niet weerspiegelt wanneer het bericht echt is verzonden. De gerandomiseerde tijdstempel beschermt tegen analyse achteraf van opgeslagen events, maar een aanvaller die actief met relays is verbonden kan nog steeds zien wanneer de gift wrap voor het eerst verscheen, waardoor deze verdediging beperkt blijft tot passieve waarnemers die relaydata later opvragen. Omdat de pubkey willekeurig is en de tijdstempel nep, kunnen relays de echte afzender niet bepalen. Om het bericht te lezen decrypt de ontvanger de gift wrap met zijn eigen sleutel en de willekeurige pubkey, vindt daarbinnen de seal, decrypt vervolgens de seal met zijn eigen sleutel en de pubkey van de afzender uit de seal, en vindt daarbinnen het kind `14`-bericht.
+
+NIP-17 biedt geen forward secrecy. Alle berichten worden versleuteld met het statische Nostr-keypair (via de sleutelafleiding van NIP-44 uit de sleutels van afzender en ontvanger). Als een private key gecompromitteerd raakt, kan elk vroeger en toekomstig bericht dat naar die sleutel is versleuteld worden gedecrypt. Dat is een bewuste afruil: omdat versleuteling alleen van de nsec afhangt, kan een gebruiker die zijn nsec back-upt de volledige berichtgeschiedenis herstellen van elke relay die de gift wraps nog bewaart. Protocollen zoals MLS (gebruikt door [Marmot](/nl/topics/marmot/)) bieden forward secrecy via roterend sleutelmateriaal, maar ten koste van statussynchronisatie en met als gevolg dat historische berichten na sleutelrotatie niet meer kunnen worden hersteld.
+
+NIP-17 definieert ook kind `15` voor versleutelde bestandsberichten, met `file-type`-, `encryption-algorithm`-, `decryption-key`- en `decryption-nonce`-tags zodat de ontvanger een bijgevoegd bestand kan decrypten dat met AES-GCM is versleuteld voordat het naar een Blossom-server werd geüpload. Kind `10050` wordt gebruikt om de voorkeurslijst van DM-relays van een gebruiker te publiceren, zodat afzenders weten waar zij gift wraps moeten afleveren. De set van `pubkey` + `p`-tags in een bericht definieert een chatroom; een deelnemer toevoegen of verwijderen maakt een nieuwe room met een schone geschiedenis.
+
+Implementaties dekken de meeste grote clients. [nospeak](https://github.com/psic4t/nospeak) gebruikt NIP-17 voor alle één-op-één-berichten. [Flotilla](https://gitea.coracle.social/coracle/flotilla) gebruikt NIP-17 voor zijn proof-of-work-DM's. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel) en [Coracle](https://github.com/coracle-social/coracle) implementeren allemaal NIP-17 als hun primaire DM-protocol. De specificatie ondersteunt ook verdwijnende berichten door een `expiration`-tag in de gift wrap te zetten.
+
+## NIP Deep Dive: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) definieert een protocol om de private key van de gebruiker te scheiden van de clientapplicatie. In plaats van een nsec in een webapp te plakken draait de gebruiker een remote signer (ook wel een "bunker" genoemd) die de private key vasthoudt en op signing requests via Nostr-relays reageert. De client ziet de private key nooit. Dat verkleint het aanvalsoppervlak: een gecompromitteerde client kan signatures aanvragen, maar kan de sleutel zelf niet extraheren.
+
+Het protocol gebruikt kind `24133` voor zowel verzoeken als antwoorden, versleuteld met [NIP-44](/nl/topics/nip-44/) (Encrypted Payloads). Een client genereert voor de sessie een wegwerp-`client-keypair` en communiceert met de remote signer via met NIP-44 versleutelde berichten die met elkaars pubkeys zijn getagd. Hieronder staat een signing request van een client aan een remote signer:
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+De versleutelde `content` bevat een JSON-RPC-achtige structuur:
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+De remote signer decrypt het verzoek, presenteert het aan de gebruiker ter goedkeuring (of keurt het automatisch goed op basis van geconfigureerde permissies), ondertekent het event met de private key van de gebruiker en retourneert het ondertekende event in een antwoord:
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Verbindingen kunnen vanaf beide kanten worden gestart. Een remote signer levert een `bunker://`-URL met zijn pubkey en relayinformatie. Een client levert een `nostrconnect://`-URL met zijn client pubkey, relays en een secret voor verificatie van de verbinding. De `secret`-parameter voorkomt connection spoofing: alleen de partij die de URL out-of-band heeft ontvangen kan de handshake voltooien.
+
+Acht methoden zijn gedefinieerd: `connect` voor het opzetten van de sessie, `sign_event` voor het signeren van events, `get_public_key` om de pubkey van de gebruiker op te vragen, `ping` voor keepalive, `nip04_encrypt`/`nip04_decrypt` voor legacy-versleuteling, `nip44_encrypt`/`nip44_decrypt` voor huidige versleuteling, en `switch_relays` voor relaybeheer. Relaymigratie wordt afgehandeld door de remote signer, die de verbinding in de loop van de tijd naar nieuwe relays kan verplaatsen zonder de sessie te breken.
+
+Clients vragen tijdens het verbinden specifieke capabilities aan via een permissiesysteem. Een permissiestring als `nip44_encrypt,sign_event:1,sign_event:14` vraagt toegang tot NIP-44-versleuteling en signingtoegang voor alleen kind `1`- en kind `14`-events. De remote signer kan deze permissies accepteren, weigeren of aanpassen. Dat betekent dat een webclient voor het lezen en posten van notes misschien alleen permissie `sign_event:1` krijgt, terwijl een DM-client ook `sign_event:14` en `nip44_encrypt` kan krijgen.
+
+[Amber](https://github.com/greenart7c3/Amber) implementeert NIP-46 op Android, en de [v6.0.0-pre1](#amber-v600-pre1-voegt-nip-46-signing-keys-per-verbinding-toe) van deze week voegt signing keys per verbinding toe voor isolatie tussen clients. [nsec.app](https://github.com/nicktee/nsecapp) (voorheen Nostr Connect) levert een webgebaseerde bunker. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) bevat `BunkerSigner` voor JavaScript-clients, en [de PR #530 van vorige week](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) voegde `skipSwitchRelays` toe voor handmatig relaybeheer. Het protocol ondersteunt ook auth challenges: wanneer een remote signer extra authenticatie nodig heeft (wachtwoord, biometrie of hardwaretoken), reageert die met een `auth_url` die de client in een browser opent zodat de gebruiker die kan voltooien.
+
+---
+
+Dat is het voor deze week. Bouw je iets of heb je nieuws om te delen? Stuur ons een DM op Nostr of vind ons op [nostrcompass.org](https://nostrcompass.org).

--- a/content/pt/newsletters/2026-04-08-newsletter.md
+++ b/content/pt/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+Bem-vindo de volta ao Nostr Compass, seu guia semanal sobre o Nostr.
+
+**Esta semana:** [Amethyst](https://github.com/vitorpamplona/amethyst) lança a [v1.08.0](#amethyst-lanca-arti-tor-e-incorpora-mls-e-marmot-em-kotlin-puro) com integração Arti Tor e uma UI de Shorts redesenhada, enquanto incorpora implementações em Kotlin puro de [MLS](/pt/topics/mls/) e [Marmot](/pt/topics/marmot/) à sua biblioteca [Quartz](/pt/topics/quartz/). [Nostur](https://github.com/nostur-com/nostur-ios-public) lança a [v1.27.0](#nostur-v1270-adiciona-gravacao-de-video-e-respostas-privadas) com gravação de vídeo, perfis com GIF animado e respostas privadas. [Shosho](https://github.com/r0d8lsh0p/shosho-releases) lança a [v0.15.0](#shosho-v0150-lanca-shows-e-carrossel-vertical-de-video) com Shows (informações personalizadas de live conectadas ao OBS) e um carrossel vertical de vídeos no estilo TikTok. [Nymchat](https://github.com/Spl0itable/NYM) [reverte Marmot e lança chats de grupo NIP-17 aprimorados](#nymchat-reverte-marmot-e-lanca-chats-de-grupo-nip-17-aprimorados) com chaves efêmeras rotativas. [Nostr VPN](https://github.com/mmalmi/nostr-vpn) lança [suporte a exit nodes e empacotamento para Umbrel](#nostr-vpn-lanca-suporte-a-exit-nodes-e-empacotamento-para-umbrel) ao longo de seis releases. [Amber](https://github.com/greenart7c3/Amber) salta para a [v6.0.0-pre1](#amber-v600-pre1-adiciona-chaves-de-assinatura-nip-46-por-conexao) com chaves de assinatura [NIP-46](/pt/topics/nip-46/) por conexão e atualizações in-app via Zapstore. [Notedeck](https://github.com/damus-io/notedeck) chega à [v0.10.0-beta](#notedeck-v0100-beta-lanca-self-update-via-zapstore) com self-update de APK via Zapstore, e [NIP-58](/pt/topics/nip-58/) (Badges) recebe uma [migração de kind](#atualizacoes-de-nips). Dois deep dives de NIP cobrem [NIP-17](/pt/topics/nip-17/) (Private Direct Messages) e [NIP-46](/pt/topics/nip-46/) (Nostr Remote Signing).
+
+## Notícias
+
+### Amethyst lança Arti Tor e incorpora MLS e Marmot em Kotlin puro
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), o cliente Android mantido por vitorpamplona, lançou quatro releases da [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) até a [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) e incorporou um grande lote de trabalho ainda não lançado à sua biblioteca [Quartz](/pt/topics/quartz/) (o módulo Nostr compartilhado em Kotlin Multiplatform). O release principal é a v1.08.0 "Arti Tor", que migra a conectividade Tor do app da biblioteca Tor baseada em C para [Arti](https://gitlab.torproject.org/tpo/core/arti), a implementação em Rust do Tor Project. A migração resolve crashes aleatórios que aconteciam com os bindings anteriores de Tor em C. Arti é o substituto de longo prazo do Tor Project para a codebase em C, escrito do zero em Rust para memory safety e async I/O.
+
+O release v1.07.3 redesenhou a UI de Shorts, substituindo o design paginado por feeds edge-to-edge para fotos, shorts e vídeos longos. O mesmo release migrou badges para kind `10008` e bookmarks para kind `10003`, alinhando-se à migração de kind de [NIP-58](/pt/topics/nip-58/) [mergeada nesta semana](#atualizacoes-de-nips). A v1.07.4 corrigiu um problema no tratamento de secret do Nostr Wallet Connect, e a v1.07.5 corrigiu um crash no upload de imagens.
+
+Na branch main, mas ainda sem release com tag, a equipe escreveu uma implementação completa em Kotlin tanto de [MLS](/pt/topics/mls/) quanto do protocolo [Marmot](/pt/topics/marmot/), eliminando a necessidade de bindings nativos de bibliotecas C/Rust. O [PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) adiciona a camada central de mensagens de grupo Marmot MLS, o [PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) adiciona a UI de chat em grupo, o [PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) adiciona processadores de mensagens de entrada e saída com um subscription manager, o [PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) adiciona persistência do estado de grupo MLS e gerenciamento de rotação de KeyPackage, o [PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) adiciona uma suíte completa de testes de MLS com assinatura de GroupInfo aprimorada, e o [PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) adiciona rastreamento do status de publicação de KeyPackage. O [PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) adiciona uma implementação secp256k1 em Kotlin puro para operações criptográficas de Nostr, substituindo a dependência da biblioteca nativa em C. Combinado com a implementação de MLS em Kotlin, [Quartz](/pt/topics/quartz/) pode executar assinatura Nostr e mensagens de grupo Marmot sem nenhum binding nativo, o que abre caminho para targets Kotlin Multiplatform incluindo iOS.
+
+A equipe também está construindo suporte a [NIP-AC](/en/topics/nip-ac/) (P2P Voice and Video Calls): o [PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) adiciona uma suíte completa de testes para a máquina de estados de chamadas do NIP-AC, e o [PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) impede que ofertas de chamada antigas sejam disparadas novamente após reiniciar o app.
+
+### Nostur v1.27.0 adiciona gravação de vídeo e respostas privadas
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public), o cliente Nostr para iOS, lançou a [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0) em 2 de abril. O release adiciona gravação de vídeo dentro do app com corte antes do upload, para que usuários possam capturar clipes curtos, ajustá-los ao tamanho desejado e publicar sem sair do cliente. O suporte a GIF animado se estende a fotos de perfil e de banner, com renderização de WebP animado adicionada também. Uma nova integração com Shortcuts permite que usuários enviem posts Nostr a partir de automações do Apple Shortcuts. O release também adiciona respostas privadas e corrige problemas de compatibilidade de DM que afetavam a entrega de mensagens entre Nostur e outros clientes.
+
+### Shosho v0.15.0 lança Shows e carrossel vertical de vídeo
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases), o app de live streaming Nostr, lançou a [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) e a [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1) em 7 de abril. O recurso principal é Shows: streamers podem configurar informações personalizadas do show antes de entrar ao vivo e conectar seu show ao OBS ou a qualquer encoder externo. Isso separa os metadados de "o que estou transmitindo" do ato de entrar ao vivo, de modo que streamers possam preparar títulos, descrições e produtos antes de começar a transmitir. O mesmo release adiciona um carrossel vertical de vídeo no estilo TikTok para navegar por lives, clipes e replays em um feed de tela cheia, além de Quick Add para publicar clipes de vídeo e adicionar produtos diretamente de uma página de perfil. A v0.15.1 corrige um bug em que o teclado escondia o campo de entrada do chat da live.
+
+## Lançamentos
+
+### Notedeck v0.10.0-beta lança self-update via Zapstore
+
+[Notedeck](https://github.com/damus-io/notedeck), o cliente desktop e mobile da equipe Damus, lançou a [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) e a [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2) como prereleases de teste para self-update de APK. O [PR #1417](https://github.com/damus-io/notedeck/pull/1417) adiciona self-update de APK via o atualizador Nostr/Zapstore no Android, expandindo o [trabalho de descoberta de atualizações nativa do Nostr da Newsletter #14](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr). O fluxo de atualização descobre novos releases por meio de eventos Nostr publicados em relays, depois baixa o APK de onde quer que o desenvolvedor o hospede (GitHub releases, Blossom CDN ou outras fontes), verifica o hash SHA-256 contra o evento Nostr assinado e faz a instalação. O [PR #1438](https://github.com/damus-io/notedeck/pull/1438) corrige um bug na tela de boas-vindas em que os botões Login e CreateAccount navegavam imediatamente de volta, e o [PR #1424](https://github.com/damus-io/notedeck/pull/1424) corrige overflow de texto na visualização de sessão do Agentium AI.
+
+### Amber v6.0.0-pre1 adiciona chaves de assinatura NIP-46 por conexão
+
+[Amber](https://github.com/greenart7c3/Amber), o app assinador [NIP-55](/pt/topics/nip-55/) (Android Signer Application), lançou a [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1) em 4 de abril. A mudança mais importante é o uso de chaves de assinatura por conexão para o protocolo bunker [NIP-46](/pt/topics/nip-46/) (Nostr Remote Signing). Em vez de usar um único par de chaves para todas as conexões bunker, o Amber agora gera uma chave distinta para cada cliente conectado. Se a conexão de um cliente for comprometida, o invasor não pode se passar pelo signer para outros clientes.
+
+O [PR #377](https://github.com/greenart7c3/Amber/pull/377) adiciona verificação e instalação de atualizações in-app via Zapstore, juntando-se ao [Notedeck](#notedeck-v0100-beta-lanca-self-update-via-zapstore) na adoção de distribuição de apps nativa do Nostr. O [PR #375](https://github.com/greenart7c3/Amber/pull/375) trata falhas de AndroidKeyStore de forma segura ao exibir um aviso aos usuários em vez de causar crash, e o [PR #371](https://github.com/greenart7c3/Amber/pull/371) adiciona limpeza de banco de dados com limites de tamanho e truncamento de conteúdo para impedir crescimento ilimitado de armazenamento. O pre-release também carrega a whitelist de relay auth [NIP-42](/pt/topics/nip-42/) e o login por frase de recuperação mnemônica do [ciclo v5.0.x coberto na semana passada](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504).
+
+### Nostria lança app mobile nativo
+
+[Nostria](https://github.com/nostria-app/nostria), o cliente Nostr multiplataforma mantido por SondreB, lançou um app mobile nativo para Android com oito releases da [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) até a [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18). A nova capacidade mais importante é o suporte nativo a signer local para signers como [Amber](https://github.com/greenart7c3/Amber) e Aegis. Também estão disponíveis [instaladores desktop](https://www.nostria.app/download) para Linux, macOS e Windows. O [PR #610](https://github.com/nostria-app/nostria/pull/610) reduz a pressão de memória do feed com limites adaptativos em runtime e limpeza de preview URLs. A v3.1.14 corrige a integração com Brainstorm, um provedor de [Web of Trust](/pt/topics/web-of-trust/). A v3.1.15 se concentra em melhorias de música. O novo app Android está disponível no [Zapstore](https://zapstore.dev/apps/app.nostria).
+
+### diVine 1.0.8 lança uploads retomáveis e DMs
+
+[diVine](https://github.com/divinevideo/divine-mobile), o cliente de vídeo short-form, lançou a [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8) com 87 PRs mergeados. Uploads retomáveis permitem que criadores continuem uploads interrompidos chunk por chunk em vez de reiniciar do zero em uma conexão instável. O release adiciona configurações de qualidade de vídeo e bitrate, double-tap para curtir e melhorias em DMs. O [PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) adiciona um plugin de câmera para macOS para captura de vídeo no desktop, e o [PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) migra o sistema de notificações para uma arquitetura BLoC com enriquecimento e agrupamento. A equipe também substituiu stickers e artes de categoria gerados por AI por SVGs do OpenMoji ([PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844), [PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)).
+
+### Manent v1.3.0 adiciona desfoque de notas sensíveis e auth NIP-42
+
+[Manent](https://github.com/dtonon/manent), o app privado de notas criptografadas e armazenamento de arquivos, lançou a [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0) em 2 de abril. Usuários agora podem marcar notas como sensíveis para desfocá-las na visualização em lista, mantendo conteúdo privado oculto durante rolagens casuais. O release também adiciona suporte a [NIP-42](/pt/topics/nip-42/) (Authentication of Clients to Relays), permitindo que o Manent se autentique em relays que exigem isso antes de aceitar eventos. O Manent armazena todos os dados criptografados em relays Nostr usando o par de chaves do usuário, então o suporte a NIP-42 amplia o conjunto de relays que ele pode usar para armazenamento.
+
+### Wisp v0.17.0 até v0.17.3 adicionam zaps em live stream e backup de carteira
+
+[Wisp](https://github.com/barrydeen/wisp), o cliente Nostr para Android, lançou seis releases da [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) até a [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) com 44 PRs mergeados. O release v0.17.0 adiciona prompts de segurança para backup de carteira e melhorias na UX de zap. A [v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) adiciona visibilidade de chat de live stream entre plataformas e funcionalidade de zap em live stream. O [PR #423](https://github.com/barrydeen/wisp/pull/423) adiciona auto-search de perfis, uma animação de sucesso de zap e melhorias de status do usuário. O [PR #426](https://github.com/barrydeen/wisp/pull/426) corrige um crash por falta de memória em `computeId` para eventos com listas grandes de tags. Os releases v0.16.x adicionaram autocomplete de shortcode de emoji, melhorias na UI de chat em grupo e filtragem de usuários bloqueados em todos os caminhos de notificação.
+
+### Mostro lança deep links, taxas de câmbio do Nostr e uma correção para pagamento duplicado
+
+[Mostro](https://github.com/MostroP2P/mostro), a exchange peer-to-peer de Bitcoin construída sobre Nostr, teve atualizações tanto em seu daemon de servidor quanto em seu cliente mobile nesta semana. No lado do servidor, o [PR #692](https://github.com/MostroP2P/mostro/pull/692) impede que escritas antigas de ordens causem pagamentos duplicados, um bug que poderia fazer com que um vendedor recebesse duas vezes pela mesma negociação. O [PR #693](https://github.com/MostroP2P/mostro/pull/693) usa atualizações direcionadas para escritas de dev_fee em vez de sobrescrever a ordem inteira.
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile), o cliente Flutter, lançou a [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3) em 3 de abril. O release trata deep links de diferentes instâncias do Mostro, para que usuários possam tocar em links que os encaminham ao servidor de exchange correto. O [PR #498](https://github.com/MostroP2P/mobile/pull/498) detecta DMs de admin e de disputa no pipeline de notificações em background, e o app agora busca taxas de câmbio via Nostr com fallback HTTP/cache. O [PR #560](https://github.com/MostroP2P/mobile/pull/560) corrige um bug de bloqueio de conexão com relay que impedia o app de alcançar relays em certas condições de rede.
+
+### Unfiltered v1.0.12 adiciona hashtags e comentários
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered), um cliente Nostr focado em conteúdo orientado por imagem, lançou a [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12). O [PR #69](https://github.com/dmcarrington/unfiltered/pull/69) adiciona suporte a hashtag e o [PR #72](https://github.com/dmcarrington/unfiltered/pull/72) adiciona a capacidade de escrever e exibir comentários em posts. O [PR #71](https://github.com/dmcarrington/unfiltered/pull/71) corrige problemas de navegação com múltiplas imagens por post.
+
+### Primal Android lança compartilhamento multi-conta de carteira e auto-reconnect do remote signer
+
+[Primal](https://github.com/PrimalHQ/primal-android-app), o cliente Nostr para Android, lançou um release em 7 de abril. A atualização adiciona compartilhamento multi-conta de carteira e menu overflow com deleção de carteira em Dev Tools. O remote signer agora faz auto-reconnect quando a conexão cai, e o serviço de carteira ganhou sua própria lógica de auto-reconnect. As correções incluem votos de zap em enquetes que não aparecem mais como Top Zaps, prevenção de crash com opção de enquete vazia, ocultação do saldo da carteira quando não existe carteira, e mapeamento do tipo WalletException para códigos de erro em respostas NWC.
+
+### Titan v0.1.0 lança navegador nativo nsite:// com registro de nomes no Bitcoin
+
+[Titan](https://github.com/btcjt/titan), um navegador desktop nativo para a web do Nostr, lançou a [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0) em 7 de abril. O Titan resolve URLs `nsite://` consultando nomes legíveis por humanos registrados no Bitcoin, consultando relays Nostr pelos eventos de conteúdo do site e renderizando páginas buscadas em servidores [Blossom](/pt/topics/blossom/). O resultado é uma experiência de navegação web sem DNS, sem certificados TLS e sem provedores de hospedagem. Os nomes são registrados por meio de uma [interface web](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register) vinculada a transações de Bitcoin. O release inicial sai como um `.dmg` para macOS (ARM, com suporte a Rosetta 2 para Intel) e inclui suporte a ambiente de desenvolvimento Nix.
+
+### Bikel v1.5.0 lança serviço foreground nativo para telefones sem Google
+
+[Bikel](https://github.com/Mnpezz/bikel), um rastreador de ciclismo descentralizado que transforma trajetos em dados de infraestrutura pública usando Nostr, lançou a [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0) em 4 de abril. O release migra do Expo TaskManager dependente de GMS para um serviço foreground nativo customizado, garantindo rastreamento confiável de percursos em background em LineageOS, GrapheneOS e outras variantes Android sem Google. O Bikel Bot ganhou uma arquitetura dual-pocket com coleta autônoma de eCash via Cashu nutzaps. As v1.4.3 e v1.4.2 corrigem sincronização do rastreamento em background para ambientes Android não padrão, e o app adiciona toggles para pontos de mapa de bicicletários no OSM.
+
+### Sprout adiciona suporte a NIP-01, NIP-23 e NIP-33
+
+[Sprout](https://github.com/block/sprout), uma plataforma de comunicação da Block com um relay Nostr embutido, lançou a [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7) em 6 de abril. Nesta semana a equipe adicionou suporte a artigos kind `30023` de [NIP-23](/en/topics/nip-23/) (Long-form Content), eventos parameterized replaceable [NIP-33](/en/topics/nip-33/) com substituição identificada por tag `d`, e notas de texto kind `1` e listas de follows kind `3` de [NIP-01](/pt/topics/nip-01/)/[NIP-02](/en/topics/nip-02/). O release também adiciona um sistema adaptativo de tema de IDE com 54 temas, polimento na UX do histórico de workflows e execuções de agentes, e uma limpeza da barra lateral de membros.
+
+### mesh-llm v0.56.0 lança protocolo distribuído de configuração
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm), um sistema distribuído de inferência de LLM que usa pares de chaves Nostr para identidade de nó, lançou a [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0) em 7 de abril. O release adiciona um protocolo distribuído de configuração com semântica de ownership, quantização assimétrica de cache KV (chaves Q8_0 com valores Q4) para reduzir uso de memória, armazenamento em keychain do SO para keystores de identidade, streaming suave de chat com fila de mensagens, e correções para layout em tela cheia e divisão de cache KV com flash attention.
+
+### Nostr VPN lança suporte a exit nodes e empacotamento para Umbrel
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn), uma VPN peer-to-peer que usa relays Nostr para sinalização e WireGuard para túneis criptografados, lançou seis releases da [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) até a [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) nesta semana. O ciclo v0.3.x adiciona suporte a exit node no Windows e macOS, permitindo que peers roteiem tráfego de internet por outros nós da rede. A propagação de invites e aliases agora sincroniza sobre Nostr, para que usuários possam compartilhar acesso à rede sem coordenação fora de banda. Os releases adicionam empacotamento para Umbrel para deployment self-hosted, NAT punch-through usando endpoints públicos memorizados, limpeza automática de exit nodes obsoletos e uma especificação de protocolo publicada. O projeto também estabilizou o tratamento de rotas no macOS com rotas padrão auto-recuperáveis e reparo de underlay, e adicionou uma build Android via Tauri. Há builds disponíveis para macOS (Apple Silicon e Intel), Linux (AppImage e .deb), Windows e Android.
+
+### Nymchat reverte Marmot e lança chats de grupo NIP-17 aprimorados
+
+[Nymchat](https://github.com/Spl0itable/NYM), o cliente de chat com suporte a MLS, lançou 14 releases da [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) até a [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274). A mudança mais significativa é uma guinada de protocolo: a [v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) adicionou chats de grupo Marmot MLS, mas a [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) reverteu de volta para [NIP-17](/pt/topics/nip-17/) porque o suporte multi-device do Marmot ainda não está concluído, o que causava problemas na sincronização do estado do chat de grupo entre dispositivos. A v3.58.271 introduz chats de grupo NIP-17 aprimorados com chaves efêmeras rotativas para todas as mensagens, projetadas para impedir ataques de timing e correlação. A semana também trouxe um sistema de friends com controle granular de settings ([v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)), sincronização de mensagens de chat em grupo MLS em settings criptografadas do app, e múltiplas correções de conectividade com relay.
+
+### nak v0.19.5 adiciona multi-server Blossom e publicação por outbox
+
+[nak](https://github.com/fiatjaf/nak), o toolkit de linha de comando Nostr do fiatjaf, lançou a [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5). O comando `blossom` agora aceita múltiplas flags `--server` para fazer upload para vários servidores [Blossom](/pt/topics/blossom/) em uma só chamada. Um novo comando `key` expande chaves parciais preenchendo com zeroes à esquerda. O comando `event` ganha uma flag `--outbox` para publicar eventos pelo modelo outbox, e `fetch` agora sai com código de erro quando nenhum event é retornado.
+
+## Em desenvolvimento
+
+### White Noise adiciona previews com thumbhash e bridge de registro de push
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), o mensageiro privado construído sobre o protocolo [Marmot](/pt/topics/marmot/), mergeou cinco PRs. O [PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) substitui previews de imagem com blurhash por thumbhash, um algoritmo mais novo que produz imagens placeholder mais nítidas com payload menor (normalmente abaixo de 30 bytes contra cerca de 50-100 bytes do blurhash), preservando a proporção e a distribuição de cores da imagem original. Blurhash permanece como fallback para conteúdo mais antigo. O [PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) atualiza whitenoise-rs e adiciona a bridge de registro de push [MIP-05](/pt/topics/mip-05/), conectando ao cliente o [trabalho de spec de push notifications da semana passada](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications). O [PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) adiciona paginação baseada em cursor para mensagens de chat, substituindo a estratégia anterior de carregamento por uma abordagem guiada por scroll.
+
+### Route96 adiciona configuração dinâmica de labels e limpeza zero-egress
+
+[Route96](https://github.com/v0l/route96), o servidor de mídia [Blossom](/pt/topics/blossom/) do v0l, mergeou três PRs. O [PR #80](https://github.com/v0l/route96/pull/80) adiciona configuração dinâmica de modelo de labels via a admin API, permitindo que operadores troquem modelos de classificação de conteúdo sem reiniciar o servidor. O [PR #82](https://github.com/v0l/route96/pull/82) adiciona campos de configuração de labels à admin UI. O [PR #79](https://github.com/v0l/route96/pull/79) adiciona uma política de limpeza de arquivos zero-egress que remove automaticamente arquivos que nunca foram baixados, reduzindo custos de armazenamento para operadores.
+
+### Snort lança endurecimento de segurança e invoices de pagamento para DVM
+
+[Snort](https://github.com/v0l/snort), o cliente web, lançou dois releases nesta semana junto com uma auditoria de segurança abrangente. As correções incluem verificação de assinatura Schnorr, proteção contra falsificação de mensagens de relay em [NIP-46](/pt/topics/nip-46/) (impedindo que atacantes injetem requests de assinatura por relays comprometidos), melhorias na criptografia de PIN e remoção da confiança em delegação NIP-26. Os ganhos de desempenho vêm de verificação Schnorr em lote em WASM, rotas lazy-loaded, traduções pré-compiladas e eliminação da verificação dupla por event. O [PR #618](https://github.com/v0l/snort/pull/618) adiciona exibição de invoice exigindo pagamento para kind `7000` de [NIP-90](/en/topics/nip-90/) (Data Vending Machine), de modo que quando um DVM responde com uma exigência de pagamento, o Snort renderiza a invoice Lightning diretamente no feed.
+
+### Damus melhora compactação do LMDB
+
+[Damus](https://github.com/damus-io/damus), o cliente iOS, mergeou o [PR #3719](https://github.com/damus-io/damus/pull/3719) adicionando compactação automática do LMDB em um cronograma, evitando que o banco de dados local cresça sem limites ao longo do tempo. O [PR #3663](https://github.com/damus-io/damus/pull/3663) melhora o BlurOverlayView para que pareça protetor em vez de quebrado.
+
+### Captain's Log adiciona indexação de tags e sincronização de notas
+
+[Captain's Log](https://github.com/nodetec/captains-log) (Comet), a ferramenta Nostr-native de escrita long-form da Nodetec, mergeou quatro PRs nesta semana. O [PR #156](https://github.com/nodetec/captains-log/pull/156) adiciona indexação de tags e suporte a sync entre notas, o [PR #157](https://github.com/nodetec/captains-log/pull/157) refatora a sincronização de notas e o tratamento de tags, e o [PR #159](https://github.com/nodetec/captains-log/pull/159) corrige a sync de notas enviadas para a lixeira para que notas deletadas permaneçam deletadas entre dispositivos.
+
+### Relatr v0.2.x redesenha sistema de plugins com marketplace de validadores nativo do Nostr
+
+[Relatr](https://github.com/ContextVM/relatr), um motor de pontuação de [Web of Trust](/pt/topics/web-of-trust/) que calcula rankings de confiança com base na distância do grafo social e em validadores configuráveis, lançou a família v0.2.x com um redesenho completo do sistema de plugins. Validadores agora são escritos em Elo, uma linguagem funcional portátil de expressões bifurcada para suportar capacidades em múltiplas etapas orquestradas pelo host (consultas Nostr, buscas no grafo social, resolução NIP-05). Plugins são publicados como eventos Nostr kind `765`, tornando a distribuição nativa da rede de relays. Um novo [plugin marketplace](https://relatr.net) permite que operadores descubram, instalem e ponderem validadores a partir do navegador, com um CLI (`relo`) para autoria e publicação local. A arquitetura é sandboxed: plugins só podem invocar capacidades que o host fornece explicitamente, então um validador malicioso não pode escapar de seu escopo definido. Instâncias do Relatr agora podem ser gerenciadas a partir do site, com visibilidade total sobre quais plugins compõem o algoritmo de pontuação e seus pesos individuais.
+
+### Shopstr melhora navegação mobile e controle de acesso
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), o marketplace Nostr-native para compra e venda com Bitcoin, publicou 158 commits nesta semana entre seu app principal e o projeto complementar [Milk Market](https://github.com/shopstr-eng/milk-market). As correções incluem melhorias no layout mobile de comunidades, comportamento de fechar menus ao navegar e auto-close de dropdowns. Rotas protegidas não podem mais ser acessadas por URL direta sem login, e a lógica de correspondência de slug agora lida corretamente com múltiplas correspondências exatas.
+
+### Pollerama adiciona notificações, busca de filmes e UI de avaliação
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), um app de enquetes, surveys e rating social construído sobre Nostr, adicionou notificações de threads, um recurso de busca de filmes e uma reformulação da UI de avaliação. O release também corrige problemas de carregamento do feed e atualiza versões de dependências.
+
+### Purser constrói daemon de pagamentos Nostr-native com criptografia Marmot
+
+[Purser](https://github.com/EthnTuttle/purser), um daemon de pagamentos Nostr-native projetado como substituto do Zaprite, mergeou nove PRs nesta semana enquanto desenvolvia sua arquitetura central. O projeto usa MLS do [Marmot](/pt/topics/marmot/) via MDK para mensagens criptografadas entre merchant e customer, com Strike e Square como provedores de pagamento. Nesta semana entraram carregamento de config e catálogo, validação de schema de mensagens, a camada de comunicação MDK, implementações dos provedores Strike e Square, um polling engine, limitação anti-spam de taxa, persistência de pagamentos pendentes e o pipeline de processamento de pedidos. Todos os 99 testes agora exercitam operações reais de MLS do mdk-core depois que a equipe removeu MLS mockado em favor de criptografia real em modo local.
+
+### Vector refatora anexos de DM e adiciona edição de perfil
+
+[Vector](https://github.com/VectorPrivacy/Vector), o mensageiro Nostr focado em privacidade construído com Tauri, mergeou o [PR #55](https://github.com/VectorPrivacy/Vector/pull/55) refatorando o frontend. A decriptação e o salvamento de anexos de DM foram movidos para a biblioteca vector-core, e o app agora suporta edição de perfil. A flag de cancelamento de upload foi corretamente conectada via TauriSendCallback, e callbacks não usados de preview de anexos foram removidos.
+
+## Trabalho de Protocolo e Spec
+
+### Atualizações de NIPs
+
+Mudanças recentes no [repositório de NIPs](https://github.com/nostr-protocol/nips):
+
+**Mergeado:**
+
+- **[NIP-58](/pt/topics/nip-58/) (Badges): Profile Badges passam para kind 10008, Badge Sets para kind 30008** ([PR #2276](https://github.com/nostr-protocol/nips/pull/2276)): Migra Profile Badges de kind `30008` para kind `10008` (um event replaceable, um por pubkey) e introduz kind `30008` para Badge Sets. Antes, Profile Badges usavam o mesmo kind (`30008`) que as definições de Badge, tornando-os eventos parameterized replaceable identificados por uma tag `d`. O novo kind `10008` é um event replaceable simples: um por pubkey, sem necessidade de tag `d`. Clientes consultam um único event replaceable por usuário em vez de varrer eventos parameterized replaceable. O Amethyst v1.07.3 já sai com essa migração.
+
+- **[NIP-34](/pt/topics/nip-34/) (Git Stuff): adicionar follow lists relacionadas a git** ([PR #2130](https://github.com/nostr-protocol/nips/pull/2130)): Adiciona convenções de follow lists para tracking de repositórios e issues do NIP-34. Usuários publicam conjuntos de follows kind `30000` com tags `d` como `git-repos` ou `git-issues` contendo referências de tag `a` a repositórios (kind `30617`) que querem acompanhar. Clientes podem se inscrever nesses conjuntos de follows para mostrar atividade de repositório no feed de um usuário, de forma semelhante a como listas de contatos kind `3` funcionam para pubkeys.
+
+**PRs abertos e discussões:**
+
+- **NIP-AC: P2P Voice and Video Calls over WebRTC** ([PR #2301](https://github.com/nostr-protocol/nips/pull/2301)): Expande o NIP-100 original (implementado pelo 0xChat) com três mudanças: migração para criptografia [NIP-44](/pt/topics/nip-44/) encapsulada em gift wraps [NIP-59](/pt/topics/nip-59/) para eliminar vazamentos de metadados, um workflow WebRTC especificado para configuração de chamadas de voz e vídeo (offer, answer, ICE candidates), e um modelo mesh de chamadas em grupo em que cada peer estabelece uma conexão WebRTC direta com todos os demais peers. A spec não é backwards-compatible com o NIP-100. O Amethyst já está desenvolvendo contra ela, com uma suíte de testes para a máquina de estados de chamadas ([PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)) e tratamento de ofertas de chamada antigas ([PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)) entrando nesta semana.
+
+- **[NIP-340](/en/topics/nip-340/) (FROST Quorum)** ([PR #2299](https://github.com/nostr-protocol/nips/pull/2299)): Propõe convenções para assinatura threshold [FROST](/pt/topics/frost/) (Flexible Round-Optimized Schnorr Threshold) no Nostr. FROST permite que um grupo de signers controle coletivamente uma identidade Nostr em que qualquer conjunto t-of-n de membros pode assinar events sem reconstruir a chave privada completa. O NIP define como coordenar rodadas de assinatura, distribuir key shares e publicar events assinados por threshold, apoiando-se no trabalho do signer Igloo do [projeto FROSTR](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11).
+
+- **[NIP-5D](/en/topics/nip-5d/) (Nostr Web Applets)** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Define um protocolo `postMessage` para aplicações web sandboxed ("napplets") executadas em iframes se comunicarem com uma aplicação hospedeira ("shell"). O shell fornece ao napplet assinatura Nostr, acesso a relay e contexto do usuário por meio de uma API estruturada de mensagens, enquanto o sandbox do iframe impede acesso direto a chaves. Isso estende o modelo de hospedagem de sites estáticos de [NIP-5A](/en/topics/nip-5a/) em direção a aplicações interativas que podem ler e escrever events Nostr. O NIP está em desenvolvimento ativo com uma implementação runtime funcional.
+
+- **[NIP-5C](/en/topics/nip-5c/) (Scrolls)** ([PR #2281](https://github.com/nostr-protocol/nips/pull/2281)): Renomeado da proposta anterior NIP-A5. Define convenções para publicar e descobrir programas WebAssembly no Nostr. Binários WASM são armazenados como events Nostr, e clientes podem baixá-los e executá-los em um runtime sandboxed. Um [demo app](https://nprogram.netlify.app/) mostra scrolls executando no browser, com programas de exemplo publicados como events Nostr que qualquer cliente pode buscar e executar.
+
+- **[NIP-85](/pt/topics/nip-85/) (Trusted Assertions): esclarecimentos** ([PR #2304](https://github.com/nostr-protocol/nips/pull/2304)): Torna mais precisa a linguagem da spec sobre múltiplas chaves e relays por provedor de serviço, esclarecendo como clientes devem lidar com assertions de provedores que operam em várias pubkeys ou endpoints de relay.
+
+- **[NIP-24](/pt/topics/nip-24/) (Extra Metadata Fields): `published_at` para events replaceable** ([PR #2300](https://github.com/nostr-protocol/nips/pull/2300)): Generaliza a tag `published_at` de [NIP-23](/en/topics/nip-23/) (Long-form Content) para todos os events replaceable e addressable. A tag é apenas de exibição: se `published_at` for igual a `created_at`, clientes mostram o event como "created" naquele momento; se forem diferentes (porque o event foi atualizado), clientes podem mostrar "updated" no lugar. Isso permite que perfis kind `0` exibam datas de "joined at" e que outros events replaceable preservem seu timestamp original de publicação ao longo de atualizações. Uma proposta complementar de [NIP-51](/pt/topics/nip-51/) ([PR #2302](https://github.com/nostr-protocol/nips/pull/2302)) adiciona a mesma tag a list events.
+
+- **[NIP-59](/pt/topics/nip-59/) (Gift Wrap): kind efêmero de gift wrap** ([PR #2245](https://github.com/nostr-protocol/nips/pull/2245)): Adiciona kind `21059` como contraparte efêmera do gift wrap kind `1059` existente. Events efêmeros (kinds `20000`-`29999`) seguem a semântica de [NIP-01](/pt/topics/nip-01/): relays não são obrigados a armazená-los e podem descartá-los após a entrega. Isso permite que aplicações enviem mensagens em gift wrap que desaparecem dos relays depois de entregues, reduzindo exigências de armazenamento para mensagens de alto volume e mantendo o mesmo modelo de criptografia em três camadas das DMs regulares [NIP-17](/pt/topics/nip-17/).
+
+### OpenSats anuncia a décima sexta rodada de grants para Nostr
+
+[OpenSats](https://opensats.org) anunciou sua [décima sexta rodada de grants para Nostr](https://opensats.org/blog/sixteenth-wave-of-nostr-grants) em 8 de abril, financiando quatro grants inéditos e uma renovação. [Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) recebe financiamento para que o contribuidor Robert Nagy construa um app desktop standalone sobre os módulos [Quartz](/pt/topics/quartz/) e Commons, levando o conjunto de recursos do cliente Android para interfaces orientadas a mouse com conexões persistentes a relay. [Nostr Mail](https://github.com/nogringo/nostr-mail) recebe financiamento para construir um sistema completo de email sobre Nostr usando events kind `1301` encapsulados em gift wraps [NIP-59](/pt/topics/nip-59/), com um cliente Flutter e servidores bridge SMTP para compatibilidade com Gmail/Outlook. [Nostrord](https://github.com/Nostrord/nostrord) recebe financiamento para um cliente de grupos baseado em relay [NIP-29](/en/topics/nip-29/) em Kotlin Multiplatform com mensagens em grupo ao estilo Discord, moderação e threads. [Nurunuru](https://github.com/tami1A84/null--nostr) recebe financiamento para construir uma versão nativa iOS do cliente Nostr japonês, modelado sobre a interface familiar do LINE, com login biométrico baseado em passkey para onboarding. HAMSTR recebeu renovação de grant (financiado pela primeira vez na [décima primeira rodada](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)).
+
+## NIP Deep Dive: NIP-17 (Private Direct Messages)
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) define o padrão atual para mensagens diretas privadas no Nostr. Ele substitui o esquema mais antigo [NIP-04](/pt/topics/nip-04/) (Encrypted Direct Messages), que vazava metadados (remetente, destinatário e timestamps ficavam todos visíveis nos relays) e usava uma construção de criptografia mais fraca. O NIP-17 combina [NIP-44](/pt/topics/nip-44/) (Encrypted Payloads) para criptografia com [NIP-59](/pt/topics/nip-59/) (Gift Wrap) para proteção de metadados, criando um sistema em três camadas em que relays não conseguem ver quem está falando com quem.
+
+O protocolo usa três kinds de event empilhados um dentro do outro. A camada mais interna é a mensagem em si, um event kind `14` sem assinatura:
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+O event kind `14` é deliberadamente sem assinatura (`sig` vazio). A spec descreve isso como fornecendo negabilidade, mas na prática a proteção é limitada. O selo kind `13` que encapsula o rumor é assinado pela chave real do remetente. Um destinatário pode mostrar o selo assinado a um terceiro, provando que o remetente se comunicou com ele, mesmo sem revelar o conteúdo da mensagem. Com provas de conhecimento zero, um destinatário pode provar o conteúdo exato da mensagem sem revelar sua própria chave privada. O rumor sem assinatura é como uma carta não assinada dentro de um envelope assinado: a assinatura do envelope liga o remetente ao conteúdo. Negabilidade real exigiria autenticação simétrica (como os HMACs do Signal), o que é incompatível com o modelo descentralizado de relay do Nostr, no qual mensagens precisam ser autoautenticáveis. Os pontos fortes reais do NIP-17 são privacidade de metadados e sigilo de conteúdo, não negabilidade.
+
+Essa mensagem sem assinatura é então encapsulada em um selo kind `13`, que é assinado pelo remetente real e criptografado com [NIP-44](/pt/topics/nip-44/) para o destinatário:
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+O selo não tem tags, então mesmo que seja decriptado ele não revelaria o destinatário. O selo é assinado pela chave real do remetente, o que permite ao destinatário autenticar a mensagem verificando que a `pubkey` do selo corresponde à `pubkey` do kind `14` interno.
+
+O selo então é encapsulado em um gift wrap kind `1059`, assinado por uma chave aleatória descartável e endereçado ao destinatário:
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+A `pubkey` do gift wrap é uma chave aleatória gerada apenas para esta mensagem, e o `created_at` é randomizado em até dois dias no passado. Essa é a camada mais externa que os relays realmente veem: uma mensagem de uma pubkey desconhecida endereçada ao destinatário, com um timestamp que não reflete quando a mensagem foi de fato enviada. O timestamp randomizado protege contra análise posterior de events armazenados, mas um adversário conectado ativamente aos relays ainda pode observar quando o gift wrap apareceu pela primeira vez, então essa defesa é limitada a observadores passivos que consultam dados de relay mais tarde. Como a pubkey é aleatória e o timestamp é falso, os relays não conseguem determinar o remetente real. Para ler a mensagem, o destinatário decripta o gift wrap usando sua própria chave e a pubkey aleatória, encontra o selo dentro dele, decripta o selo usando sua própria chave e a pubkey do remetente obtida do selo, e encontra a mensagem kind `14` dentro.
+
+O NIP-17 não fornece forward secrecy. Todas as mensagens são criptografadas usando o par de chaves estático do Nostr (via derivação de chave do NIP-44 a partir das chaves do remetente e do destinatário). Se uma chave privada for comprometida, toda mensagem passada e futura criptografada para essa chave poderá ser decriptada. Esse é um tradeoff deliberado: como a criptografia depende apenas do nsec, um usuário que faz backup do seu nsec pode recuperar todo o histórico de mensagens a partir de qualquer relay que ainda armazene os gift wraps. Protocolos como MLS (usado por [Marmot](/pt/topics/marmot/)) fornecem forward secrecy por meio de material de chave rotativo, mas ao custo de exigir sincronização de estado e tornar impossível a recuperação histórica de mensagens após a rotação de chave.
+
+O NIP-17 também define kind `15` para mensagens com arquivos criptografados, adicionando tags `file-type`, `encryption-algorithm`, `decryption-key` e `decryption-nonce` para que o destinatário possa decriptar um arquivo anexado que foi criptografado com AES-GCM antes do upload para um servidor Blossom. O kind `10050` é usado para publicar a lista preferida de relays de DM do usuário, para que remetentes saibam onde entregar gift wraps. O conjunto de tags `pubkey` + `p` em uma mensagem define uma sala de chat; adicionar ou remover um participante cria uma nova sala com histórico limpo.
+
+As implementações cobrem a maior parte dos clientes principais. [nospeak](https://github.com/psic4t/nospeak) usa NIP-17 para todas as mensagens um a um. [Flotilla](https://gitea.coracle.social/coracle/flotilla) usa NIP-17 para suas DMs com proof-of-work. [Amethyst](https://github.com/vitorpamplona/amethyst), [Primal](https://github.com/PrimalHQ/primal-android-app), [Nostur](https://github.com/nostur-com/nostur-ios-public), [Damus](https://github.com/damus-io/damus), [noStrudel](https://github.com/hzrd149/nostrudel) e [Coracle](https://github.com/coracle-social/coracle) implementam NIP-17 como seu protocolo principal de DM. A spec também suporta mensagens que desaparecem ao definir uma tag `expiration` no gift wrap.
+
+## NIP Deep Dive: NIP-46 (Nostr Remote Signing)
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) define um protocolo para separar a chave privada do usuário da aplicação cliente. Em vez de colar um nsec em um app web, o usuário roda um signer remoto (também chamado de "bunker") que mantém a chave privada e responde a requests de assinatura por relays Nostr. O cliente nunca vê a chave privada. Isso reduz a superfície de ataque: um cliente comprometido pode solicitar assinaturas, mas não consegue extrair a chave em si.
+
+O protocolo usa kind `24133` tanto para requests quanto para responses, criptografados com [NIP-44](/pt/topics/nip-44/) (Encrypted Payloads). Um cliente gera um `client-keypair` descartável para a sessão e se comunica com o signer remoto por mensagens criptografadas em NIP-44 marcadas com as pubkeys um do outro. Aqui está um request de assinatura de um cliente para um signer remoto:
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+O `content` criptografado contém uma estrutura semelhante a JSON-RPC:
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+O signer remoto decripta o request, o apresenta ao usuário para aprovação (ou aprova automaticamente com base nas permissões configuradas), assina o event com a chave privada do usuário e devolve o event assinado em uma response:
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+Conexões podem ser iniciadas de qualquer lado. Um signer remoto fornece uma URL `bunker://` contendo sua pubkey e informações de relay. Um cliente fornece uma URL `nostrconnect://` com sua pubkey de cliente, relays e um secret para verificação da conexão. O parâmetro `secret` impede connection spoofing: apenas a parte que recebeu a URL fora de banda pode completar o handshake.
+
+Oito métodos são definidos: `connect` para estabelecer a sessão, `sign_event` para assinar events, `get_public_key` para obter a pubkey do usuário, `ping` para keepalive, `nip04_encrypt`/`nip04_decrypt` para criptografia legada, `nip44_encrypt`/`nip44_decrypt` para criptografia atual, e `switch_relays` para gerenciamento de relay. A migração de relay é tratada pelo signer remoto, que pode mover a conexão para novos relays ao longo do tempo sem quebrar a sessão.
+
+Clientes solicitam capacidades específicas no momento da conexão por meio de um sistema de permissões. Uma string de permissão como `nip44_encrypt,sign_event:1,sign_event:14` solicita acesso à criptografia NIP-44 e acesso de assinatura apenas para events kind `1` e kind `14`. O signer remoto pode aceitar, rejeitar ou modificar essas permissões. Isso significa que um cliente web para ler e publicar notas talvez receba apenas permissão `sign_event:1`, enquanto um cliente de DM pode também receber permissões `sign_event:14` e `nip44_encrypt`.
+
+[Amber](https://github.com/greenart7c3/Amber) implementa NIP-46 no Android, e sua [v6.0.0-pre1](#amber-v600-pre1-adiciona-chaves-de-assinatura-nip-46-por-conexao) nesta semana adiciona chaves de assinatura por conexão para isolamento entre clientes. [nsec.app](https://github.com/nicktee/nsecapp) (antigo Nostr Connect) fornece um bunker baseado na web. [nostr-tools](https://github.com/nbd-wtf/nostr-tools) inclui `BunkerSigner` para clientes JavaScript, e [o PR #530 da semana passada](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing) adicionou `skipSwitchRelays` para gerenciamento manual de relay. O protocolo também suporta auth challenges: quando um signer remoto precisa de autenticação adicional (senha, biometria ou token de hardware), ele responde com uma `auth_url` que o cliente abre no browser para que o usuário conclua o processo.
+
+---
+
+Isso é tudo por esta semana. Está construindo algo ou tem novidades para compartilhar? Envie uma DM para nós no Nostr ou nos encontre em [nostrcompass.org](https://nostrcompass.org).

--- a/content/zh/newsletters/2026-04-08-newsletter.md
+++ b/content/zh/newsletters/2026-04-08-newsletter.md
@@ -1,0 +1,297 @@
+---
+title: 'Nostr Compass #17'
+date: 2026-04-08
+translationOf: /en/newsletters/2026-04-08-newsletter.md
+translationDate: 2026-04-09
+draft: false
+type: newsletters
+---
+
+欢迎回到 Nostr Compass，您的每周 Nostr 指南。
+
+**本周：** [Amethyst](https://github.com/vitorpamplona/amethyst) 在 [v1.08.0](#amethyst-发布-arti-tor并合并纯-kotlin-版-mls-和-marmot) 中加入 Arti Tor 集成，并重新设计了 Shorts UI，同时还将纯 Kotlin 实现的 [MLS](/zh/topics/mls/) 和 [Marmot](/zh/topics/marmot/) 合并进其 [Quartz](/zh/topics/quartz/) 库。[Nostur](https://github.com/nostur-com/nostur-ios-public) 在 [v1.27.0](#nostur-v1270-增加视频录制和私密回复) 中加入视频录制、动画 GIF 资料图以及私密回复。[Shosho](https://github.com/r0d8lsh0p/shosho-releases) 在 [v0.15.0](#shosho-v0150-推出-shows-和竖屏视频轮播) 中推出 Shows（与 OBS 连接的自定义直播信息）以及类似 TikTok 的竖屏视频轮播。[Nymchat](https://github.com/Spl0itable/NYM) [回退 Marmot 并发布增强版 NIP-17 群聊](#nymchat-回退-marmot并发布增强版-nip-17-群聊)，使用轮换的临时密钥。[Nostr VPN](https://github.com/mmalmi/nostr-vpn) 在六个版本中发布了[出口节点支持和 Umbrel 打包](#nostr-vpn-发布出口节点支持和-umbrel-打包)。[Amber](https://github.com/greenart7c3/Amber) 跳升至 [v6.0.0-pre1](#amber-v600-pre1-增加按连接隔离的-nip-46-签名密钥)，加入按连接隔离的 [NIP-46](/zh/topics/nip-46/) 签名密钥和 Zapstore 应用内更新。[Notedeck](https://github.com/damus-io/notedeck) 达到 [v0.10.0-beta](#notedeck-v0100-beta-发布-zapstore-自更新)，支持通过 Zapstore 进行 APK 自更新，而 [NIP-58](/zh/topics/nip-58/)（Badges）则在本周发生了 [kind 迁移](#nip-更新)。本期的两篇 NIP 深度解析分别是 [NIP-17](/zh/topics/nip-17/)（Private Direct Messages）和 [NIP-46](/zh/topics/nip-46/)（Nostr Remote Signing）。
+
+## 头条
+
+### Amethyst 发布 Arti Tor，并合并纯 Kotlin 版 MLS 和 Marmot
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) 这个由 vitorpamplona 维护的 Android 客户端，发布了从 [v1.07.3](https://github.com/vitorpamplona/amethyst/releases/tag/v1.07.3) 到 [v1.08.0](https://github.com/vitorpamplona/amethyst/releases/tag/v1.08.0) 的四个版本，并将一大批尚未正式发布的工作合并进其 [Quartz](/zh/topics/quartz/) 库，也就是共享的 Kotlin Multiplatform Nostr 模块。最重要的发布是 v1.08.0 “Arti Tor”，它将应用的 Tor 连接从基于 C 的 Tor 库迁移到 [Arti](https://gitlab.torproject.org/tpo/core/arti)，也就是 Tor Project 的 Rust 实现。这次迁移解决了此前 C Tor 绑定下出现的随机崩溃问题。Arti 是 Tor Project 面向长期的 C 代码库替代方案，从零开始以 Rust 编写，以获得内存安全和 async I/O。
+
+v1.07.3 重新设计了 Shorts UI，用 edge-to-edge 信息流替代了原先的分页设计，用于图片、短视频和长视频的浏览。这个版本还将 badges 迁移到 kind `10008`，将 bookmarks 迁移到 kind `10003`，与本周[合并的 NIP-58](/zh/topics/nip-58/) kind 迁移保持一致。v1.07.4 修复了一个 Nostr Wallet Connect secret 处理问题，v1.07.5 则修复了图片上传崩溃。
+
+在主分支上但尚未进入正式 tag 版本的工作中，团队用 Kotlin 完整实现了 [MLS](/zh/topics/mls/) 和 [Marmot](/zh/topics/marmot/) 协议，不再需要依赖原生 C/Rust 库绑定。[PR #2147](https://github.com/vitorpamplona/amethyst/pull/2147) 增加了核心的 Marmot MLS 群消息层，[PR #2149](https://github.com/vitorpamplona/amethyst/pull/2149) 增加了群聊 UI，[PR #2146](https://github.com/vitorpamplona/amethyst/pull/2146) 增加了入站和出站消息处理器以及订阅管理器，[PR #2141](https://github.com/vitorpamplona/amethyst/pull/2141) 增加了 MLS 群状态持久化和 KeyPackage 轮换管理，[PR #2150](https://github.com/vitorpamplona/amethyst/pull/2150) 增加了完整的 MLS 测试套件并改进了 GroupInfo 签名，[PR #2158](https://github.com/vitorpamplona/amethyst/pull/2158) 增加了 KeyPackage 发布状态跟踪。[PR #2166](https://github.com/vitorpamplona/amethyst/pull/2166) 则为 Nostr 加密操作增加了纯 Kotlin 的 secp256k1 实现，替代原生 C 库依赖。结合 Kotlin 版 MLS 实现之后，[Quartz](/zh/topics/quartz/) 已经可以在没有任何原生绑定的情况下运行 Nostr 签名和 Marmot 群消息，这为包括 iOS 在内的 Kotlin Multiplatform 目标打开了空间。
+
+团队也在构建 [NIP-AC](/en/topics/nip-ac/)（P2P Voice and Video Calls）支持：[PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143) 为 NIP-AC 通话状态机增加了完整测试套件，[PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164) 则防止应用重启后过期的 call offer 被再次触发。
+
+### Nostur v1.27.0 增加视频录制和私密回复
+
+[Nostur](https://github.com/nostur-com/nostur-ios-public) 这个 iOS Nostr 客户端，于 4 月 2 日发布了 [v1.27.0](https://github.com/nostur-com/nostur-ios-public/releases/tag/v1.27.0)。这个版本增加了应用内视频录制和上传前裁剪，用户可以直接拍摄短片、剪到合适长度，然后不离开客户端就发布出去。动画 GIF 支持扩展到了头像和横幅图片，同时也增加了动画 WebP 渲染。新的 Shortcuts 集成允许用户从 Apple Shortcuts 自动化中发送 Nostr 帖子。该版本还增加了私密回复，并修复了影响 Nostur 与其他客户端之间消息送达的 DM 兼容性问题。
+
+### Shosho v0.15.0 推出 Shows 和竖屏视频轮播
+
+[Shosho](https://github.com/r0d8lsh0p/shosho-releases) 这个 Nostr 直播应用，于 4 月 7 日发布了 [v0.15.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.0) 和 [v0.15.1](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v0.15.1)。这轮发布的核心功能是 Shows：主播可以在开播前先设置自定义节目资料，并将节目连接到 OBS 或任何外部编码器。这把“我正在播什么”的元数据与真正开播的动作分离开来，因此主播可以在开始直播前先准备好标题、描述和商品。同一版本还增加了类似 TikTok 的竖屏视频轮播，可以在全屏信息流中滑动浏览直播、片段和回放，并增加了 Quick Add，允许用户直接从个人资料页发布视频片段和添加商品。v0.15.1 修复了键盘遮住直播聊天输入框的 bug。
+
+## 本周发布
+
+### Notedeck v0.10.0-beta 发布 Zapstore 自更新
+
+[Notedeck](https://github.com/damus-io/notedeck) 这个来自 Damus 团队的桌面和移动客户端，发布了 [v0.10.0-beta.1](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.1) 和 [v0.10.0-beta.2](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.2)，作为 APK 自更新功能的测试预发布版本。[PR #1417](https://github.com/damus-io/notedeck/pull/1417) 在 Android 上通过 Nostr/Zapstore updater 增加了 APK 自更新，延续了[周刊 #14 中报道的 Nostr 原生版本发现工作](/en/newsletters/2026-03-18-newsletter/#notedeck-moves-release-discovery-onto-nostr)。这套更新流程通过发布到 relay 的 Nostr event 发现新版本，然后从开发者托管 APK 的位置下载文件，无论是 GitHub releases、Blossom CDN 还是其他来源，接着将 SHA-256 哈希与已签名的 Nostr event 进行校验，再完成安装。[PR #1438](https://github.com/damus-io/notedeck/pull/1438) 修复了欢迎页中 Login 和 CreateAccount 按钮立即跳回上一页的问题，[PR #1424](https://github.com/damus-io/notedeck/pull/1424) 则修复了 Agentium AI 会话视图中的文本溢出。
+
+### Amber v6.0.0-pre1 增加按连接隔离的 NIP-46 签名密钥
+
+[Amber](https://github.com/greenart7c3/Amber) 这个 [NIP-55](/zh/topics/nip-55/)（Android Signer Application）签名器应用，于 4 月 4 日发布了 [v6.0.0-pre1](https://github.com/greenart7c3/Amber/releases/tag/v6.0.0-pre1)。这次最重要的变化，是为 [NIP-46](/zh/topics/nip-46/)（Nostr Remote Signing）bunker 协议增加了按连接隔离的签名密钥。Amber 现在不再为所有 bunker 连接共用同一个 keypair，而是为每个已连接客户端生成独立的密钥。如果某一个客户端连接被攻破，攻击者也无法冒充该 signer 去影响其他客户端。
+
+[PR #377](https://github.com/greenart7c3/Amber/pull/377) 增加了通过 Zapstore 进行应用内更新检查与安装，使 Amber 与 [Notedeck](#notedeck-v0100-beta-发布-zapstore-自更新) 一起采用 Nostr 原生应用分发。[PR #375](https://github.com/greenart7c3/Amber/pull/375) 通过向用户显示警告而不是直接崩溃的方式，优雅处理 AndroidKeyStore 失败。[PR #371](https://github.com/greenart7c3/Amber/pull/371) 则通过大小限制和内容截断增加数据库清理，防止存储无界增长。这个预发布版本还包含了[上周报道的 v5.0.x 周期](/en/newsletters/2026-04-01-newsletter/#amber-v502-through-v504)中的 [NIP-42](/zh/topics/nip-42/) relay auth 白名单和助记词恢复短语登录。
+
+### Nostria 发布原生移动应用
+
+[Nostria](https://github.com/nostria-app/nostria) 这个由 SondreB 维护的跨平台 Nostr 客户端，发布了原生 Android 移动应用，并连续发布了从 [v3.1.11](https://github.com/nostria-app/nostria/releases/tag/v3.1.11) 到 [v3.1.18](https://github.com/nostria-app/nostria/releases/tag/v3.1.18) 的八个版本。最重要的新能力是对 [Amber](https://github.com/greenart7c3/Amber) 和 Aegis 这类 signer 的原生本地 signer 支持。项目也提供了适用于 Linux、macOS 和 Windows 的[桌面安装包](https://www.nostria.app/download)。[PR #610](https://github.com/nostria-app/nostria/pull/610) 通过自适应运行时限制和 preview URL 清理降低了信息流内存压力。v3.1.14 修复了与 [Web of Trust](/zh/topics/web-of-trust/) 提供方 Brainstorm 的集成。v3.1.15 则聚焦于音乐相关改进。新的 Android 应用已在 [Zapstore](https://zapstore.dev/apps/app.nostria) 上提供。
+
+### diVine 1.0.8 发布可恢复上传和 DMs
+
+[diVine](https://github.com/divinevideo/divine-mobile) 这个短视频客户端发布了 [1.0.8](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8)，其中包含 87 个已合并 PR。可恢复上传让创作者在不稳定网络下可以按 chunk 继续中断的上传，而不必从头开始。该版本还加入了视频质量和 bitrate 设置、双击点赞，以及 DM 改进。[PR #2722](https://github.com/divinevideo/divine-mobile/pull/2722) 为桌面视频采集加入了 macOS camera plugin，[PR #2820](https://github.com/divinevideo/divine-mobile/pull/2820) 则将通知系统迁移到带 enrichment 和 grouping 的 BLoC 架构。团队还用 OpenMoji SVG 替换了 AI 生成的贴纸和分类插图（[PR #2844](https://github.com/divinevideo/divine-mobile/pull/2844)、[PR #2842](https://github.com/divinevideo/divine-mobile/pull/2842)）。
+
+### Manent v1.3.0 增加敏感笔记模糊和 NIP-42 认证
+
+[Manent](https://github.com/dtonon/manent) 这个私密加密笔记与文件存储应用，于 4 月 2 日发布了 [v1.3.0](https://github.com/dtonon/manent/releases/tag/v1.3.0)。用户现在可以将笔记标记为敏感内容，在列表视图中将其模糊显示，从而在日常滚动浏览时隐藏私密内容。该版本还增加了 [NIP-42](/zh/topics/nip-42/)（Authentication of Clients to Relays）支持，使 Manent 能在 relay 要求认证时先完成认证再发送 event。Manent 使用用户的 keypair 将所有数据加密后存储在 Nostr relay 上，因此 NIP-42 支持扩大了它可用于存储的 relay 范围。
+
+### Wisp v0.17.0 到 v0.17.3 增加直播 zaps 和钱包备份
+
+[Wisp](https://github.com/barrydeen/wisp) 这个 Android Nostr 客户端，连续发布了从 [v0.16.2-beta](https://github.com/barrydeen/wisp/releases/tag/v0.16.2-beta) 到 [v0.17.3-beta](https://github.com/barrydeen/wisp/releases/tag/v0.17.3-beta) 的六个版本，合并了 44 个 PR。v0.17.0 增加了钱包备份安全提示和 zap UX 改进。[v0.17.1](https://github.com/barrydeen/wisp/releases/tag/v0.17.1-beta) 增加了跨平台直播聊天可见性以及直播 zap 功能。[PR #423](https://github.com/barrydeen/wisp/pull/423) 增加了自动搜索资料、zap 成功动画和用户状态改进。[PR #426](https://github.com/barrydeen/wisp/pull/426) 修复了带大型 tag 列表 event 在 `computeId` 中触发的 out-of-memory 崩溃。v0.16.x 系列则增加了 emoji shortcode 自动补全、群聊 UI 改进，以及贯穿所有通知路径的已屏蔽用户过滤。
+
+### Mostro 发布深层链接、Nostr 汇率和重复付款修复
+
+[Mostro](https://github.com/MostroP2P/mostro) 这个构建在 Nostr 上的点对点 Bitcoin 交易所，本周在服务器守护进程和移动客户端两侧都有更新。服务器端方面，[PR #692](https://github.com/MostroP2P/mostro/pull/692) 防止过期订单写入导致重复付款，这个 bug 可能让卖家在同一笔交易中被支付两次。[PR #693](https://github.com/MostroP2P/mostro/pull/693) 则对 dev_fee 写入使用定向更新，而不是整单覆盖。
+
+[Mostro Mobile](https://github.com/MostroP2P/mobile) 这个 Flutter 客户端，于 4 月 3 日发布了 [v1.2.3](https://github.com/MostroP2P/mobile/releases/tag/v1.2.3)。该版本可以处理来自不同 Mostro 实例的深层链接，因此用户点开链接时会被正确路由到相应的交易服务器。[PR #498](https://github.com/MostroP2P/mobile/pull/498) 在后台通知管线中检测管理员和 dispute DMs，应用现在还会优先通过 Nostr 获取汇率，并在失败时回退到 HTTP/cache。[PR #560](https://github.com/MostroP2P/mobile/pull/560) 修复了一个 relay 连接阻塞 bug，该问题会在某些网络条件下阻止应用连上 relay。
+
+### Unfiltered v1.0.12 增加 hashtags 和 comments
+
+[Unfiltered](https://github.com/dmcarrington/unfiltered) 这个偏重图片内容的 Nostr 客户端，发布了 [v1.0.12](https://github.com/dmcarrington/unfiltered/releases/tag/v1.0.12)。[PR #69](https://github.com/dmcarrington/unfiltered/pull/69) 增加了 hashtag 支持，[PR #72](https://github.com/dmcarrington/unfiltered/pull/72) 增加了在帖子上撰写和显示 comments 的能力。[PR #71](https://github.com/dmcarrington/unfiltered/pull/71) 修复了单帖多图时的导航问题。
+
+### Primal Android 发布钱包多账户共享和 remote signer 自动重连
+
+[Primal](https://github.com/PrimalHQ/primal-android-app) 这个 Android Nostr 客户端，于 4 月 7 日发布了一个版本更新。新版本增加了钱包多账户共享，以及 Dev Tools 中带删除钱包功能的 overflow menu。remote signer 现在会在连接断开时自动重连，钱包服务也获得了自己的自动重连逻辑。修复内容包括：投票 zap 票不再显示为 Top Zaps、空投票选项不再触发崩溃、未配置钱包时隐藏钱包余额，以及将 WalletException 类型映射为 NWC 响应中的错误码。
+
+### Titan v0.1.0 推出原生 nsite:// 浏览器和 Bitcoin 名称注册
+
+[Titan](https://github.com/btcjt/titan) 这个面向 Nostr Web 的原生桌面浏览器，于 4 月 7 日发布了 [v0.1.0](https://github.com/btcjt/titan/releases/tag/v0.1.0)。Titan 通过查询注册在 Bitcoin 上的人类可读名称来解析 `nsite://` URL，随后从 Nostr relay 获取站点内容 event，并渲染从 [Blossom](/zh/topics/blossom/) 服务器取回的页面。最终得到的是一种不依赖 DNS、不依赖 TLS 证书、也不依赖托管服务商的 Web 浏览体验。名称通过一个与 Bitcoin 交易绑定的[网页界面](https://npub1hmq6xuqnplk5lw0h3700cujmx5gymqn5wrn42u6432r6ntzumezqc3marw.nsite.lol/register)进行注册。首个版本以 macOS `.dmg` 形式发布（ARM，并通过 Rosetta 2 支持 Intel），同时也包含 Nix 开发环境支持。
+
+### Bikel v1.5.0 为去 Google 化手机加入原生前台服务
+
+[Bikel](https://github.com/Mnpezz/bikel) 这个将骑行活动转化为公共基础设施数据的去中心化骑行追踪器，于 4 月 4 日发布了 [v1.5.0](https://github.com/Mnpezz/bikel/releases/tag/v1.5.0)。该版本从依赖 GMS 的 Expo TaskManager 迁移到自定义原生前台服务，以确保在 LineageOS、GrapheneOS 和其他去 Google 化 Android 变体上也能可靠进行后台骑行追踪。Bikel Bot 还获得了 dual-pocket 架构，并通过 Cashu nutzaps 实现自动 eCash 收取。v1.4.3 和 v1.4.2 修复了非标准 Android 环境中的后台追踪同步问题，应用还增加了 OSM 自行车停放点地图开关。
+
+### Sprout 增加 NIP-01、NIP-23 和 NIP-33 支持
+
+[Sprout](https://github.com/block/sprout) 这个由 Block 构建并内置 Nostr relay 的通信平台，于 4 月 6 日发布了 [desktop/v0.1.0-rc7](https://github.com/block/sprout/releases/tag/desktop/v0.1.0-rc7)。本周团队增加了对 [NIP-23](/en/topics/nip-23/)（Long-form Content）kind `30023` 文章、[NIP-33](/en/topics/nip-33/) 参数化可替换 event 及其以 `d` tag 为键的替换机制，以及 [NIP-01](/zh/topics/nip-01/)/[NIP-02](/en/topics/nip-02/) kind `1` 文本笔记和 kind `3` follow list 的支持。该版本还增加了带 54 个主题的自适应 IDE 主题系统、workflow 和 agent run history 的 UX 打磨，以及成员侧边栏清理。
+
+### mesh-llm v0.56.0 发布分布式配置协议
+
+[mesh-llm](https://github.com/michaelneale/mesh-llm) 这个使用 Nostr keypair 作为节点身份的分布式 LLM 推理系统，于 4 月 7 日发布了 [v0.56.0](https://github.com/michaelneale/mesh-llm/releases/tag/v0.56.0)。该版本增加了带所有权语义的分布式配置协议、非对称 KV cache 量化（Q8_0 keys 搭配 Q4 values）以降低内存占用、用于身份 keystore 的 OS keychain 存储、带消息排队的平滑聊天流，以及对全屏布局和使用 flash attention 时 KV cache 拆分问题的修复。
+
+### Nostr VPN 发布出口节点支持和 Umbrel 打包
+
+[Nostr VPN](https://github.com/mmalmi/nostr-vpn) 这个使用 Nostr relay 进行信令、使用 WireGuard 建立加密隧道的点对点 VPN，本周连续发布了从 [v0.3.0](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.0) 到 [v0.3.6](https://github.com/mmalmi/nostr-vpn/releases/tag/v0.3.6) 的六个版本。v0.3.x 周期在 Windows 和 macOS 上增加了出口节点支持，使 peer 可以通过网络中的其他节点转发互联网流量。invite 和 alias 传播现在也通过 Nostr 同步，因此用户可以在不依赖带外协调的情况下共享网络访问。该系列版本还增加了面向自托管部署的 Umbrel 打包、利用记忆的公网 endpoint 进行 NAT punch-through、自动清理过期出口节点，以及已发布的协议规范。项目同时稳定了 macOS 的 route 处理，加入自愈默认路由和 underlay 修复，并通过 Tauri 增加了 Android 构建。当前可提供的构建包括 macOS（Apple Silicon 和 Intel）、Linux（AppImage 和 .deb）、Windows 和 Android。
+
+### Nymchat 回退 Marmot，并发布增强版 NIP-17 群聊
+
+[Nymchat](https://github.com/Spl0itable/NYM) 这个具备 MLS 能力的聊天客户端，连续发布了从 [v3.56.261](https://github.com/Spl0itable/NYM/releases/tag/3.56.261) 到 [v3.58.274](https://github.com/Spl0itable/NYM/releases/tag/v3.58.274) 的 14 个版本。最重要的变化是协议方向调整：[v3.57.261](https://github.com/Spl0itable/NYM/releases/tag/v3.57.261) 增加了 Marmot MLS 群聊，但 [v3.58.268](https://github.com/Spl0itable/NYM/releases/tag/v3.58.268) 又回退到 [NIP-17](/zh/topics/nip-17/)，因为 Marmot 的多设备支持尚未完成，这导致群聊状态在多设备之间同步时出现问题。v3.58.271 引入了增强版 NIP-17 群聊，为所有消息使用轮换的临时密钥，目标是防止时序和关联攻击。这一周的更新还带来了对设置具备细粒度控制的 friend system（[v3.58.262](https://github.com/Spl0itable/NYM/releases/tag/v3.58.262)）、加密应用设置中的 MLS 群聊消息同步，以及多项 relay 连接修复。
+
+### nak v0.19.5 增加 Blossom 多服务器和 outbox 发布
+
+[nak](https://github.com/fiatjaf/nak) 这个 fiatjaf 的命令行 Nostr 工具包，发布了 [v0.19.5](https://github.com/fiatjaf/nak/releases/tag/v0.19.5)。`blossom` 命令现在接受多个 `--server` 参数，可以在一次调用中上传到多个 [Blossom](/zh/topics/blossom/) 服务器。新的 `key` 命令可以通过左侧补零来扩展不完整的 key。`event` 命令增加了 `--outbox` 标志，用于通过 outbox model 发布 event，而 `fetch` 在没有返回 event 时现在会以错误码退出。
+
+## 开发中
+
+### White Noise 增加 thumbhash 预览和 push registration bridge
+
+[White Noise](https://github.com/marmot-protocol/whitenoise) 这个基于 [Marmot](/zh/topics/marmot/) 协议的私密信使，本周合并了五个 PR。[PR #549](https://github.com/marmot-protocol/whitenoise/pull/549) 用 thumbhash 替换了 blurhash 图片预览，这是一种更新的算法，能以更小的载荷生成更清晰的占位图像，通常低于 30 字节，而 blurhash 大约需要 50 到 100 字节，同时还能保留原图的宽高比和颜色分布。blurhash 仍然保留为旧内容的回退方案。[PR #548](https://github.com/marmot-protocol/whitenoise/pull/548) 更新了 whitenoise-rs，并加入 [MIP-05](/zh/topics/mip-05/) push registration bridge，将[上周的 push notification 规范工作](/en/newsletters/2026-04-01-newsletter/#marmot-moves-keypackages-to-addressable-events-and-tightens-push-notifications)接到客户端中。[PR #493](https://github.com/marmot-protocol/whitenoise/pull/493) 为聊天消息增加了基于 cursor 的分页，用滚动驱动的方式替代此前的加载策略。
+
+### Route96 增加动态标签配置和零出口流量清理
+
+[Route96](https://github.com/v0l/route96) 这个由 v0l 构建的 [Blossom](/zh/topics/blossom/) 媒体服务器，合并了三个 PR。[PR #80](https://github.com/v0l/route96/pull/80) 通过 admin API 增加了动态 label model 配置，使运营者无需重启服务器就能切换内容分类模型。[PR #82](https://github.com/v0l/route96/pull/82) 为 admin UI 增加了标签配置字段。[PR #79](https://github.com/v0l/route96/pull/79) 则增加了 zero-egress 文件清理策略，自动删除那些从未被下载过的文件，从而帮助运营者压低存储成本。
+
+### Snort 发布安全加固和 DVM 支付发票
+
+[Snort](https://github.com/v0l/snort) 这个 Web 客户端，本周发布了两个版本，并完成了一次全面的安全审计。修复内容包括 Schnorr 签名验证、[NIP-46](/zh/topics/nip-46/) relay 消息伪造防护，防止攻击者通过已被攻破的 relay 注入签名请求，以及 PIN 加密改进和移除对 NIP-26 delegation 的信任。性能提升则来自 WASM 中的批量 Schnorr 验证、lazy-loaded routes、预编译翻译，以及取消每个 event 的双重验证。[PR #618](https://github.com/v0l/snort/pull/618) 增加了 [NIP-90](/en/topics/nip-90/)（Data Vending Machine）kind `7000` payment-required 发票显示，因此当 DVM 返回支付要求时，Snort 会直接在信息流中渲染 Lightning invoice。
+
+### Damus 改进 LMDB 压缩
+
+[Damus](https://github.com/damus-io/damus) 这个 iOS 客户端，合并了 [PR #3719](https://github.com/damus-io/damus/pull/3719)，按计划周期自动执行 LMDB 压缩，防止本地数据库随着时间推移无界增长。[PR #3663](https://github.com/damus-io/damus/pull/3663) 则改进了 BlurOverlayView，使其看起来像一种保护措施，而不是坏掉的界面。
+
+### Captain's Log 增加 tag 索引和笔记同步
+
+[Captain's Log](https://github.com/nodetec/captains-log)（Comet）这个来自 Nodetec 的 Nostr 原生长文写作工具，本周合并了四个 PR。[PR #156](https://github.com/nodetec/captains-log/pull/156) 为笔记增加了 tag 索引和跨笔记同步支持，[PR #157](https://github.com/nodetec/captains-log/pull/157) 重构了笔记同步和 tag 处理，[PR #159](https://github.com/nodetec/captains-log/pull/159) 则修复了已删除笔记的同步问题，确保被删除的笔记在各设备间仍保持删除状态。
+
+### Relatr v0.2.x 重新设计插件系统，并推出 Nostr 原生验证器市场
+
+[Relatr](https://github.com/ContextVM/relatr) 这个 [Web of Trust](/zh/topics/web-of-trust/) 评分引擎，通过社交图距离和可配置验证器计算信任排名，发布了 v0.2.x 系列，并对插件系统进行了完整重构。验证器现在使用 Elo 编写，这是一种可移植的函数式表达语言，经过分叉后支持多步骤的宿主编排能力，例如 Nostr 查询、社交图查找和 NIP-05 解析。插件以 kind `765` 的 Nostr event 发布，使分发过程天然适配 relay 网络。新的[插件市场](https://relatr.net)让运营者可以在浏览器中发现、安装和加权验证器，同时还提供一个 CLI（`relo`）用于本地编写和发布。整体架构是沙箱化的：插件只能调用宿主明确提供的能力，因此恶意验证器无法逃逸出其既定作用域。Relatr 实例现在还可以通过网站进行管理，运营者可以完整看到评分算法由哪些插件构成，以及各自的权重。
+
+### Shopstr 改进移动端导航和访问控制
+
+[Shopstr](https://github.com/shopstr-eng/shopstr) 这个使用 Bitcoin 买卖商品的 Nostr 原生市场，本周在主应用和配套项目 [Milk Market](https://github.com/shopstr-eng/milk-market) 上一共推进了 158 次提交。修复内容包括移动端社区布局改进、导航时菜单自动关闭，以及 dropdown 自动关闭。受保护路由现在不能再通过直接输入 URL 的方式绕过登录，同时 slug 匹配逻辑现在也能正确处理多个精确匹配结果。
+
+### Pollerama 增加通知、电影搜索和评分 UI
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls) 这个基于 Nostr 的投票、问卷和社交评分应用，增加了线程通知、电影搜索功能，以及评分 UI 重构。该版本还修复了信息流加载问题，并升级了依赖版本。
+
+### Purser 构建带 Marmot 加密的 Nostr 原生支付守护进程
+
+[Purser](https://github.com/EthnTuttle/purser) 这个设计为 Zaprite 替代品的 Nostr 原生支付守护进程，本周合并了九个 PR，持续搭建其核心架构。该项目通过 MDK 使用 [Marmot](/zh/topics/marmot/) MLS，为商户和客户之间的消息提供加密，并使用 Strike 和 Square 作为支付提供方。本周落地的内容包括配置和目录加载、消息 schema 校验、MDK 通信层、Strike 和 Square provider 实现、polling engine、anti-spam rate limiting、待处理支付持久化以及订单处理管线。在团队移除 mock MLS、改为在本地模式中使用真实加密之后，全部 99 个测试现在都在运行真实的 mdk-core MLS 操作。
+
+### Vector 重构 DM 附件并增加资料编辑
+
+[Vector](https://github.com/VectorPrivacy/Vector) 这个以隐私为重点、基于 Tauri 构建的 Nostr 私信客户端，合并了 [PR #55](https://github.com/VectorPrivacy/Vector/pull/55)，对前端进行了重构。DM 附件解密和保存逻辑已迁移到 vector-core 库中，应用现在也支持资料编辑。上传取消标志已通过 TauriSendCallback 正确串接，未使用的附件预览回调也被清理掉了。
+
+## 协议与规范工作
+
+### NIP 更新
+
+[NIPs 仓库](https://github.com/nostr-protocol/nips)的最新变更：
+
+**已合并：**
+
+- **[NIP-58](/zh/topics/nip-58/)（Badges）：Profile Badges 迁移到 kind 10008，Badge Sets 迁移到 kind 30008**（[PR #2276](https://github.com/nostr-protocol/nips/pull/2276)）：将 Profile Badges 从 kind `30008` 迁移到 kind `10008`，也就是每个 pubkey 一个的可替换 event，并为 Badge Sets 引入 kind `30008`。此前，Profile Badges 与 Badge 定义共用同一个 kind（`30008`），因此它们都是由 `d` tag 键控的参数化可替换 event。新的 kind `10008` 是简单可替换 event：每个 pubkey 一个，不需要 `d` tag。客户端现在只需为每个用户查询一个可替换 event，而不是扫描参数化可替换 event。Amethyst v1.07.3 已经带上了这次迁移。
+
+- **[NIP-34](/zh/topics/nip-34/)（Git Stuff）：增加与 git 相关的 follow lists**（[PR #2130](https://github.com/nostr-protocol/nips/pull/2130)）：为 NIP-34 仓库和 issue 跟踪增加了 follow list 约定。用户可以发布 kind `30000` 的 follow set，使用 `git-repos` 或 `git-issues` 这样的 `d` tag，并在其中通过 `a` tag 引用他们想跟踪的仓库（kind `30617`）。客户端可以订阅这些 follow set，在用户信息流中展示仓库活动，类似于 kind `3` 联系人列表对 pubkey 的作用方式。
+
+**开放 PR 和讨论：**
+
+- **NIP-AC：通过 WebRTC 进行点对点语音和视频通话**（[PR #2301](https://github.com/nostr-protocol/nips/pull/2301)）：在最初由 0xChat 实现的 NIP-100 基础上，草案提出了三个变化：迁移到 [NIP-44](/zh/topics/nip-44/) 加密，并包裹在 [NIP-59](/zh/topics/nip-59/) gift wraps 中以消除元数据泄露；明确语音和视频通话建立的 WebRTC 工作流，包括 offer、answer 和 ICE candidates；以及一种 mesh 群组通话模型，其中每个 peer 都与其他所有 peer 建立直接 WebRTC 连接。该规范与 NIP-100 不向后兼容。Amethyst 已经开始围绕它开发，本周落地了通话状态机测试套件（[PR #2143](https://github.com/vitorpamplona/amethyst/pull/2143)）以及过期 call offer 处理（[PR #2164](https://github.com/vitorpamplona/amethyst/pull/2164)）。
+
+- **[NIP-340](/en/topics/nip-340/)（FROST Quorum）**（[PR #2299](https://github.com/nostr-protocol/nips/pull/2299)）：提出了在 Nostr 上进行 [FROST](/zh/topics/frost/)（Flexible Round-Optimized Schnorr Threshold）门限签名的约定。FROST 允许一组签名者共同控制一个 Nostr 身份，只要满足 t-of-n 条件，成员就能在不重建完整私钥的情况下签署 event。该 NIP 定义了如何协调签名轮次、分发密钥份额以及发布门限签名 event，并建立在来自 [FROSTR 项目](/en/newsletters/2026-04-01-newsletter/#igloo-signer-11)的 Igloo signer 工作之上。
+
+- **[NIP-5D](/en/topics/nip-5d/)（Nostr Web Applets）**（[PR #2303](https://github.com/nostr-protocol/nips/pull/2303)）：定义了一套 `postMessage` 协议，使运行在 iframe 中的沙箱化 Web 应用，也就是“napplets”，能够与宿主应用，也就是“shell”，通信。shell 通过结构化消息 API 向 napplet 提供 Nostr 签名、relay 访问和用户上下文，而 iframe 沙箱则阻止其直接访问密钥。这将 [NIP-5A](/en/topics/nip-5a/) 的静态网站托管模型进一步推进到可读写 Nostr event 的交互式应用。该 NIP 目前正在积极开发中，并已有可运行的 runtime 实现。
+
+- **[NIP-5C](/en/topics/nip-5c/)（Scrolls）**（[PR #2281](https://github.com/nostr-protocol/nips/pull/2281)）：此前名为 NIP-A5 提案。它定义了在 Nostr 上发布和发现 WebAssembly 程序的约定。WASM 二进制被存储为 Nostr event，客户端则可以在沙箱化 runtime 中下载并执行它们。一个[演示应用](https://nprogram.netlify.app/)展示了在浏览器中运行 scrolls 的方式，其中示例程序以 Nostr event 发布，任何客户端都可以获取并执行。
+
+- **[NIP-85](/zh/topics/nip-85/)（Trusted Assertions）：澄清说明**（[PR #2304](https://github.com/nostr-protocol/nips/pull/2304)）：收紧了关于单个服务提供方使用多个 key 和多个 relay 的规范表述，明确客户端应如何处理那些跨多个 pubkey 或 relay endpoint 运营的提供方所发布的 assertions。
+
+- **[NIP-24](/zh/topics/nip-24/)（Extra Metadata Fields）：为可替换 event 增加 published_at**（[PR #2300](https://github.com/nostr-protocol/nips/pull/2300)）：将 [NIP-23](/en/topics/nip-23/)（Long-form Content）中的 `published_at` tag 泛化到所有可替换和可寻址 event。这个 tag 只用于显示：如果 `published_at` 等于 `created_at`，客户端将 event 显示为在该时间“创建”；如果两者不同，也就是 event 被更新过，客户端就可以显示为“更新于”。这样 kind `0` 资料可以显示“joined at”日期，其他可替换 event 也可以在更新后保留原始发布时间戳。与之配套的 [NIP-51](/zh/topics/nip-51/) 提案（[PR #2302](https://github.com/nostr-protocol/nips/pull/2302)）则把同样的 tag 加到列表类 event 中。
+
+- **[NIP-59](/zh/topics/nip-59/)（Gift Wrap）：临时 gift wrap kind**（[PR #2245](https://github.com/nostr-protocol/nips/pull/2245)）：新增 kind `21059`，作为现有 kind `1059` gift wrap 的临时版本。临时 event（kinds `20000`-`29999`）遵循 [NIP-01](/zh/topics/nip-01/) 语义：relay 不需要存储它们，并且可以在投递后将其丢弃。这样一来，应用就可以发送在投递后从 relay 上消失的 gift-wrapped 消息，从而降低高吞吐消息场景下的存储需求，同时保留与普通 [NIP-17](/zh/topics/nip-17/) DMs 相同的三层加密模型。
+
+### OpenSats 宣布第十六轮 Nostr grants
+
+[OpenSats](https://opensats.org) 于 4 月 8 日宣布了其[第十六轮 Nostr grants](https://opensats.org/blog/sixteenth-wave-of-nostr-grants)，资助了四个首次获得资助的项目和一个续期项目。[Amethyst Desktop](https://github.com/vitorpamplona/amethyst/tree/main/desktopApp) 获得资助，由贡献者 Robert Nagy 基于 [Quartz](/zh/topics/quartz/) 和 Commons 模块构建独立桌面应用，将 Android 客户端的功能集带到以鼠标为主的界面和持久 relay 连接环境中。[Nostr Mail](https://github.com/nogringo/nostr-mail) 获得资助，以 kind `1301` event 加上 [NIP-59](/zh/topics/nip-59/) gift wraps 在 Nostr 上构建完整邮件系统，并提供 Flutter 客户端以及用于兼容 Gmail/Outlook 的 SMTP bridge 服务器。[Nostrord](https://github.com/Nostrord/nostrord) 获得资助，用于构建基于 Kotlin Multiplatform 的 [NIP-29](/en/topics/nip-29/) relay 群组客户端，提供类似 Discord 的群消息、审核和线程。[Nurunuru](https://github.com/tami1A84/null--nostr) 获得资助，用于构建面向日语用户、界面风格参考 LINE 的原生 iOS Nostr 客户端，并为引导流程加入基于 passkey 的生物识别登录。HAMSTR 则获得了续期资助，最早一次资助来自[第十一轮](https://opensats.org/blog/eleventh-wave-of-nostr-grants#hamstr)。
+
+## NIP 深度解析：NIP-17（Private Direct Messages）
+
+[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) 定义了 Nostr 上当前的私密私信标准。它取代了更早的 [NIP-04](/zh/topics/nip-04/)（Encrypted Direct Messages）方案，后者会泄露元数据，发送方、接收方和时间戳都对 relay 可见，而且使用的是更弱的加密构造。NIP-17 将 [NIP-44](/zh/topics/nip-44/)（Encrypted Payloads）用于内容加密，并结合 [NIP-59](/zh/topics/nip-59/)（Gift Wrap）进行元数据保护，形成一个 relay 无法看出是谁在和谁通信的三层系统。
+
+这个协议使用三层嵌套的 event kinds。最内层是真正的消息，一个未签名的 kind `14` event：
+
+```json
+{
+  "id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744108800,
+  "kind": 14,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef", "wss://inbox.example.com"],
+    ["subject", "Project update"]
+  ],
+  "content": "The new relay config is deployed. Let me know if you see any issues.",
+  "sig": ""
+}
+```
+
+这个 kind `14` event 被刻意设计成未签名，也就是 `sig` 为空。规范将其描述为提供可否认性，但在实践中这种保护非常有限。包裹 rumor 的 kind `13` seal 是由发送者的真实密钥签名的。接收者可以把这个已签名 seal 展示给第三方，从而证明发送者曾与其通信，即便不暴露消息内容。借助零知识证明，接收者甚至可以证明精确的消息内容，而无需暴露自己的私钥。这个未签名 rumor 更像是一封放在已签名信封里的未签名信件，信封上的签名仍将发送者与内容联系起来。真正的可否认性需要对称认证，例如 Signal 使用的 HMAC，但这与 Nostr 的去中心化 relay 模型不兼容，因为消息必须能够自我认证。NIP-17 真正的优势在于元数据隐私和内容保密，而不是可否认性。
+
+这条未签名消息随后会被包裹进一个 kind `13` seal 中。这个 seal 由实际发送者签名，并通过 [NIP-44](/zh/topics/nip-44/) 加密后发送给接收者：
+
+```json
+{
+  "id": "b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1744022400,
+  "kind": 13,
+  "tags": [],
+  "content": "<nip44-encrypted kind 14 payload>",
+  "sig": "e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4"
+}
+```
+
+这个 seal 没有 tags，因此即便被解密，也不会暴露接收者。seal 由发送者的真实密钥签名，因此接收者可以通过检查 seal 的 `pubkey` 是否与内部 kind `14` 的 `pubkey` 一致，来确认消息身份。
+
+接着，这个 seal 会再被包裹进一个 kind `1059` gift wrap 中，由一个随机的一次性密钥签名，并指向接收者：
+
+```json
+{
+  "id": "c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2",
+  "pubkey": "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+  "created_at": 1744065600,
+  "kind": 1059,
+  "tags": [
+    ["p", "f1a2b3c4d5e6f7890123456789abcdef01234567890abcdef1234567890abcdef"]
+  ],
+  "content": "<nip44-encrypted kind 13 payload>",
+  "sig": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+}
+```
+
+gift wrap 的 `pubkey` 是专门为这条消息随机生成的密钥，而 `created_at` 则会被随机回拨，最多回拨到过去两天。这是 relay 真正能看到的最外层：一条来自未知 pubkey、发给接收者的消息，时间戳并不反映消息真实发送时间。随机时间戳可以防止事后对已存储 event 进行分析，但如果攻击者主动连接着 relay，仍然可以观察到 gift wrap 首次出现的时间，因此这种防护只对之后才查询 relay 数据的被动观察者有效。由于 pubkey 是随机的，时间戳也是伪造的，relay 无法确定真实发送者。接收者要读取消息时，会用自己的 key 和这个随机 pubkey 解密 gift wrap，找到里面的 seal，再用自己的 key 和 seal 中发送者的 pubkey 解密 seal，最终拿到内部的 kind `14` 消息。
+
+NIP-17 不提供前向保密。所有消息都使用静态 Nostr keypair 进行加密，也就是使用 NIP-44 基于发送者和接收者密钥派生的方式。如果私钥被攻破，过去和未来所有发往该密钥的消息都可以被解密。这是一个有意的权衡：因为加密只依赖 nsec，所以只要用户备份了自己的 nsec，就可以从任何仍存有 gift wraps 的 relay 中恢复全部消息历史。像 MLS 这样的协议，也就是 [Marmot](/zh/topics/marmot/) 所使用的方案，则通过轮换密钥材料提供前向保密，但代价是要求状态同步，并且在密钥轮换后无法恢复历史消息。
+
+NIP-17 还定义了 kind `15` 用于加密文件消息，它增加了 `file-type`、`encryption-algorithm`、`decryption-key` 和 `decryption-nonce` tags，使接收者能够解密一个在上传到 Blossom 服务器前通过 AES-GCM 加密的附件。kind `10050` 用于发布用户偏好的 DM relay 列表，以便发送者知道应把 gift wraps 送到哪里。消息中的 `pubkey` 加上 `p` tags 的集合定义了一个聊天室，增加或移除参与者就会生成一个带有全新历史边界的新房间。
+
+实现方面已经覆盖了大多数主流客户端。[nospeak](https://github.com/psic4t/nospeak) 将 NIP-17 用于全部一对一消息。[Flotilla](https://gitea.coracle.social/coracle/flotilla) 将 NIP-17 用于其工作量证明 DMs。[Amethyst](https://github.com/vitorpamplona/amethyst)、[Primal](https://github.com/PrimalHQ/primal-android-app)、[Nostur](https://github.com/nostur-com/nostur-ios-public)、[Damus](https://github.com/damus-io/damus)、[noStrudel](https://github.com/hzrd149/nostrudel) 和 [Coracle](https://github.com/coracle-social/coracle) 都将 NIP-17 作为其主要 DM 协议。该规范还支持通过在 gift wrap 中设置 `expiration` tag 来实现消息阅后消失。
+
+## NIP 深度解析：NIP-46（Nostr Remote Signing）
+
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) 定义了一种将用户私钥与客户端应用分离开的协议。用户不再需要把 nsec 粘贴进 Web 应用，而是运行一个 remote signer，也叫 “bunker”，由它持有私钥，并通过 Nostr relay 响应签名请求。客户端永远看不到私钥。这缩小了攻击面：即便客户端被攻破，攻击者也只能请求签名，无法直接提取密钥本身。
+
+该协议使用 kind `24133` 同时承载请求和响应，并通过 [NIP-44](/zh/topics/nip-44/)（Encrypted Payloads）加密。客户端会为会话生成一次性的 `client-keypair`，并通过带有彼此 pubkey tag 的 NIP-44 加密消息与 remote signer 通信。下面是一条客户端发给 remote signer 的签名请求：
+
+```json
+{
+  "id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd11223344556677889900aabb",
+  "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+  "created_at": 1744108800,
+  "kind": 24133,
+  "tags": [
+    ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC request>",
+  "sig": "1122334455667788990011223344556677889900aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0011223344556677"
+}
+```
+
+其中加密后的 `content` 包含一个类似 JSON-RPC 的结构：
+
+```json
+{
+  "id": "random-request-id-1",
+  "method": "sign_event",
+  "params": ["{\"kind\":1,\"content\":\"Hello from remote signing\",\"tags\":[],\"created_at\":1744108800}"]
+}
+```
+
+remote signer 会解密请求，将其展示给用户批准，或者依据已配置权限自动批准，然后使用用户私钥对 event 进行签名，并在响应中返回已签名 event：
+
+```json
+{
+  "id": "bb22cc33dd44ee55ff6677889900aabb11223344556677889900aabbccddeeff",
+  "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+  "created_at": 1744108801,
+  "kind": 24133,
+  "tags": [
+    ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]
+  ],
+  "content": "<nip44-encrypted JSON-RPC response>",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+连接可以由任意一方发起。remote signer 会提供一个包含其 pubkey 和 relay 信息的 `bunker://` URL。客户端则会提供一个 `nostrconnect://` URL，其中带有客户端 pubkey、relays，以及用于连接校验的 secret。`secret` 参数用于防止连接伪造：只有通过带外方式收到该 URL 的一方，才能完成握手。
+
+协议定义了八种方法：`connect` 用于建立会话，`sign_event` 用于对 event 签名，`get_public_key` 用于获取用户 pubkey，`ping` 用于 keepalive，`nip04_encrypt`/`nip04_decrypt` 用于旧加密方式，`nip44_encrypt`/`nip44_decrypt` 用于当前加密方式，`switch_relays` 用于 relay 管理。relay 迁移由 remote signer 负责处理，因此它可以随着时间将连接迁移到新的 relay 上，而不会打断会话。
+
+客户端在连接时可以通过权限系统请求特定能力。像 `nip44_encrypt,sign_event:1,sign_event:14` 这样的权限字符串，表示请求 NIP-44 加密能力，以及仅对 kind `1` 和 kind `14` event 的签名能力。remote signer 可以接受、拒绝或修改这些权限。这意味着一个用于阅读和发帖的 Web 客户端可能只需要 `sign_event:1` 权限，而一个 DM 客户端则可能还需要 `sign_event:14` 和 `nip44_encrypt` 权限。
+
+[Amber](https://github.com/greenart7c3/Amber) 在 Android 上实现了 NIP-46，而其本周发布的 [v6.0.0-pre1](#amber-v600-pre1-增加按连接隔离的-nip-46-签名密钥) 又进一步加入了按连接隔离的签名密钥，以实现客户端间隔离。[nsec.app](https://github.com/nicktee/nsecapp)（此前名为 Nostr Connect）则提供了一个基于 Web 的 bunker。[nostr-tools](https://github.com/nbd-wtf/nostr-tools) 为 JavaScript 客户端提供了 `BunkerSigner`，而[上周的 PR #530](/en/newsletters/2026-04-01-newsletter/#nostr-tools-adds-bunker-relay-control-and-fixes-nip-47-multi-relay-parsing)增加了 `skipSwitchRelays`，以便手动管理 relay。该协议也支持 auth challenge：当 remote signer 需要额外认证，例如密码、生物识别或硬件 token 时，它会返回一个 `auth_url`，由客户端在浏览器中打开，让用户完成认证。
+
+---
+
+本周内容就是这些。你在构建什么，或者有什么新闻想分享？欢迎在 Nostr 上私信我们，或访问 [nostrcompass.org](https://nostrcompass.org)。


### PR DESCRIPTION
## Summary
- Add Newsletter #17 translations for German, Spanish, French, Italian, Japanese, Korean, Dutch, Portuguese, and Simplified Chinese.
- Preserve localized topic links where translated topic pages already exist, while keeping untranslated topic links on English paths.
- Verify the translated newsletter set with a successful `hugo` build.