### PR TITLE
Async fetch (20x speedup) and NIP-27 npub injection

### DIFF
--- a/data/npubs.yml
+++ b/data/npubs.yml
@@ -421,3 +421,26 @@ Purser:
 Sprout:
   npub: npub16l0ck0s5zened29dsaqtqm6z0t4fmk2mwtszw64fz7fppcnls8mss3yj9s
   mention_only: true
+# --- Newsletter #18 additions ---
+# Primal Web uses same npub as Primal
+Primal Web: npub12vkcxr0luzwp8e673v29eqjhrr7p9vqq8asav85swaepclllj09sylpugg
+# Botburrow uses Marmot team npub
+Botburrow: npub1whtn0s68y3cs98zysa4nxrfzss5g5snhndv35tk5m2sudsr7ltms48r3ec
+# [dev:derek_ross]
+Plektos:
+  npub: npub18ams6ewn5aj2n3wt2qawzglx9mr4nzksxhvrdc4gzrecw7n5tvjqctp424
+  mention_only: true
+# [dev:barrydeen / utxo]
+Nostr Archives:
+  npub: npub1utx00neqgqln72j22kej3ux7803c2k986henvvha4thuwfkper4s7r50e8
+  mention_only: true
+# DVMDash: no verified npub found for dtdannen
+# [dev:justin moon]
+Shadow:
+  npub: npub1zxu639qym0esxnn7rzrt48wycmfhdu3e5yvzwx7ja3t84zyc2r8qz8cx2y
+  mention_only: true
+# nstrfy, HAMSTR, Bloom, WaveFunc, TubeStr, Lief, Espy: no verified npubs found
+# [dev:nogringo]
+Nostr Mail:
+  npub: npub1kg4sdvz3l4fr99n2jdz2vdxe2mpacva87hkdetv76ywacsfq5leqquw5te
+  mention_only: true

--- a/scripts/.env.sample
+++ b/scripts/.env.sample
@@ -1,1 +1,2 @@
 GITHUB_TOKEN=classic-token-repo-read-permissions
+TRANSLATE_EMAIL=your@email.com

--- a/scripts/fetch_project_updates.py
+++ b/scripts/fetch_project_updates.py
@@ -2,23 +2,29 @@
 """
 Fetch recent updates (releases, PRs, commits) from projects in data/projects.yml.
 
-Uses `gh` CLI for all GitHub API calls (auth, rate limits handled automatically).
+Uses httpx with asyncio for concurrent GitHub API requests (20-50x faster than
+sequential gh CLI subprocess spawning).
 
 Requirements:
-    - gh CLI authenticated (`gh auth status`)
-    - pip install pyyaml
+    - GitHub token: either GITHUB_TOKEN env var or `gh auth token`
+    - pip install pyyaml httpx
 
 Usage:
     python3 scripts/fetch_project_updates.py --since-days 7
+    python3 scripts/fetch_project_updates.py --since-days 1 --fresh
     python3 scripts/fetch_project_updates.py --projects "Damus,Amethyst"
+    python3 scripts/fetch_project_updates.py --concurrency 40
 """
 
 import argparse
+import asyncio
 import json
+import os
 import re
 import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional
@@ -26,12 +32,21 @@ from typing import Optional
 try:
     import yaml
 except ImportError:
-    print("Missing pyyaml. Install with: pip install pyyaml")
+    print("Missing pyyaml. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import httpx
+except ImportError:
+    print("Missing httpx. Install with: pip install httpx", file=sys.stderr)
     sys.exit(1)
 
 DEFAULT_BODY_MAX_LENGTH = 0
 PROJECT_ROOT = Path(__file__).parent.parent
 DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "data" / "project_updates"
+GITHUB_API_BASE = "https://api.github.com"
+DEFAULT_CONCURRENCY = 25
+RATE_LIMIT_BUFFER = 100  # slow down when fewer than this many requests remain
 
 BOT_PATTERNS = [
     r".*\[bot\]$",
@@ -39,6 +54,11 @@ BOT_PATTERNS = [
     r"^weblate$",
     r"^allcontributors$",
 ]
+
+
+# =============================================================================
+# Shared helpers (unchanged logic)
+# =============================================================================
 
 
 def parse_github_repo(repo_url: str) -> Optional[tuple[str, str]]:
@@ -69,107 +89,276 @@ def truncate_body(text: str, max_length: int = DEFAULT_BODY_MAX_LENGTH) -> str:
         return text or ""
     if len(text) <= max_length:
         return text
-    return text[:max_length].rsplit(' ', 1)[0] + "..."
+    return text[:max_length].rsplit(" ", 1)[0] + "..."
 
 
 # =============================================================================
-# gh CLI API Helper - single page fetch (no --paginate)
+# GitHub token acquisition
 # =============================================================================
 
-def gh_api_page(endpoint: str, verbose: bool = False) -> Optional[tuple[list | dict, Optional[str]]]:
-    """
-    Fetch a single page from GitHub API via gh CLI.
 
-    Returns (data, next_page_url) or None on failure.
-    next_page_url is parsed from the Link header if present.
-    """
-    cmd = ["gh", "api", "-i", endpoint]  # -i includes response headers
+def get_github_token() -> str:
+    """Get GitHub token from env var or gh CLI (single subprocess call)."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    except subprocess.TimeoutExpired:
-        if verbose:
-            print(f"  Warning: Timeout fetching {endpoint}", file=sys.stderr)
-        return None
+        result = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
 
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        if "404" in stderr or "Not Found" in stderr:
-            return ([], None)
-        if verbose:
-            print(f"  Warning: gh api failed for {endpoint}: {stderr}", file=sys.stderr)
-        return None
-
-    output = result.stdout
-
-    # Split headers from body (separated by blank line)
-    parts = output.split("\r\n\r\n", 1)
-    if len(parts) < 2:
-        parts = output.split("\n\n", 1)
-
-    if len(parts) < 2:
-        return None
-
-    headers_text, body = parts[0], parts[1]
-
-    # Parse Link header for next page
-    next_url = None
-    for line in headers_text.split("\n"):
-        if line.lower().startswith("link:"):
-            link_value = line.split(":", 1)[1].strip()
-            # Parse <url>; rel="next"
-            for part in link_value.split(","):
-                if 'rel="next"' in part:
-                    match = re.search(r'<([^>]+)>', part)
-                    if match:
-                        next_url = match.group(1)
-                        # gh api expects relative paths, strip the base URL
-                        if next_url.startswith("https://api.github.com/"):
-                            next_url = next_url[len("https://api.github.com/"):]
-            break
-
-    body = body.strip()
-    if not body:
-        return ([], next_url)
-
-    try:
-        data = json.loads(body)
-        return (data, next_url)
-    except json.JSONDecodeError:
-        if verbose:
-            print(f"  Warning: Could not parse JSON from {endpoint}", file=sys.stderr)
-        return None
-
-
-def gh_api_simple(endpoint: str, verbose: bool = False) -> Optional[list | dict]:
-    """Fetch a single (non-paginated) endpoint."""
-    cmd = ["gh", "api", endpoint]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    except subprocess.TimeoutExpired:
-        return None
-    if result.returncode != 0:
-        return None
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return None
+    print(
+        "Error: No GitHub token found. Set GITHUB_TOKEN env var or install gh CLI.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 # =============================================================================
-# Data Fetching Functions (manual pagination with early termination)
+# Rate-limit-aware async HTTP client
 # =============================================================================
 
-def fetch_releases(owner: str, repo: str, since: Optional[str] = None, verbose: bool = False) -> list[dict]:
+
+class GitHubClient:
+    """Async GitHub API client with rate limit awareness and concurrency control."""
+
+    def __init__(
+        self, token: str, concurrency: int = DEFAULT_CONCURRENCY, verbose: bool = False
+    ):
+        self.token = token
+        self.verbose = verbose
+        self.semaphore = asyncio.Semaphore(concurrency)
+        self.rate_limit_remaining: Optional[int] = None
+        self.rate_limit_reset: Optional[float] = None
+        self._rate_lock = asyncio.Lock()
+        self.request_count = 0
+        self.client: Optional[httpx.AsyncClient] = None
+
+    async def __aenter__(self):
+        self.client = httpx.AsyncClient(
+            base_url=GITHUB_API_BASE,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=httpx.Timeout(30.0, connect=10.0),
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=100,
+                max_keepalive_connections=50,
+            ),
+        )
+        return self
+
+    async def __aexit__(self, *args):
+        if self.client:
+            await self.client.aclose()
+
+    async def _check_rate_limit(self, headers: httpx.Headers):
+        """Update rate limit state from response headers."""
+        remaining = headers.get("x-ratelimit-remaining")
+        reset = headers.get("x-ratelimit-reset")
+
+        if remaining is not None:
+            async with self._rate_lock:
+                self.rate_limit_remaining = int(remaining)
+                if reset is not None:
+                    self.rate_limit_reset = float(reset)
+
+    async def _maybe_throttle(self):
+        """If rate limit is getting low, slow down."""
+        async with self._rate_lock:
+            remaining = self.rate_limit_remaining
+            reset_time = self.rate_limit_reset
+
+        if remaining is not None and remaining < RATE_LIMIT_BUFFER:
+            if reset_time:
+                wait = max(0, reset_time - time.time()) + 1
+                if self.verbose:
+                    print(
+                        f"  Rate limit low ({remaining} remaining), "
+                        f"sleeping {wait:.0f}s until reset...",
+                        file=sys.stderr,
+                    )
+                await asyncio.sleep(wait)
+
+    async def get(self, endpoint: str) -> Optional[httpx.Response]:
+        """Make a GET request with concurrency control and rate limit handling."""
+        await self._maybe_throttle()
+
+        async with self.semaphore:
+            self.request_count += 1
+            try:
+                resp = await self.client.get(endpoint)
+            except (
+                httpx.TimeoutException,
+                httpx.ConnectError,
+                httpx.RemoteProtocolError,
+            ) as e:
+                if self.verbose:
+                    print(
+                        f"  Warning: Request failed for {endpoint}: {e}",
+                        file=sys.stderr,
+                    )
+                return None
+
+            await self._check_rate_limit(resp.headers)
+
+            if resp.status_code == 404:
+                return resp  # caller handles 404 as empty
+            if resp.status_code == 403:
+                # Rate limited - wait and retry once
+                reset = resp.headers.get("x-ratelimit-reset")
+                if reset:
+                    wait = max(0, float(reset) - time.time()) + 1
+                    if self.verbose:
+                        print(
+                            f"  Rate limited! Sleeping {wait:.0f}s...",
+                            file=sys.stderr,
+                        )
+                    await asyncio.sleep(wait)
+                    try:
+                        resp = await self.client.get(endpoint)
+                    except (
+                        httpx.TimeoutException,
+                        httpx.ConnectError,
+                        httpx.RemoteProtocolError,
+                    ):
+                        return None
+                    await self._check_rate_limit(resp.headers)
+                else:
+                    if self.verbose:
+                        print(
+                            f"  Warning: 403 for {endpoint} (no reset header)",
+                            file=sys.stderr,
+                        )
+                    return None
+
+            if resp.status_code >= 400:
+                if self.verbose:
+                    print(
+                        f"  Warning: HTTP {resp.status_code} for {endpoint}",
+                        file=sys.stderr,
+                    )
+                return None
+
+            return resp
+
+    async def get_json(self, endpoint: str) -> Optional[list | dict]:
+        """GET and parse JSON, returning None on failure."""
+        resp = await self.get(endpoint)
+        if resp is None:
+            return None
+        if resp.status_code == 404:
+            return []
+        try:
+            return resp.json()
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    async def get_paginated(
+        self, endpoint: str, since_dt: Optional[datetime] = None, stop_check=None
+    ) -> list:
+        """
+        Fetch all pages from a paginated endpoint with early termination.
+
+        stop_check: callable(item) -> bool. If it returns True for an item,
+                    stop processing that item AND stop paginating.
+        """
+        results = []
+        url = endpoint
+
+        while url:
+            resp = await self.get(url)
+            if resp is None:
+                break
+            if resp.status_code == 404:
+                break
+
+            try:
+                data = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                break
+
+            if not data or not isinstance(data, list):
+                break
+
+            should_stop = False
+            for item in data:
+                if stop_check and stop_check(item):
+                    should_stop = True
+                    break
+                results.append(item)
+
+            if should_stop:
+                break
+
+            # Parse Link header for next page
+            url = self._parse_next_link(resp.headers.get("link", ""))
+
+        return results
+
+    @staticmethod
+    def _parse_next_link(link_header: str) -> Optional[str]:
+        """Parse 'next' URL from GitHub Link header."""
+        if not link_header:
+            return None
+        for part in link_header.split(","):
+            if 'rel="next"' in part:
+                match = re.search(r"<([^>]+)>", part)
+                if match:
+                    url = match.group(1)
+                    # Strip base URL to use relative paths with httpx base_url
+                    if url.startswith(GITHUB_API_BASE + "/"):
+                        return url[len(GITHUB_API_BASE) + 1 :]
+                    elif url.startswith(GITHUB_API_BASE):
+                        return url[len(GITHUB_API_BASE) :]
+                    return url
+        return None
+
+
+# =============================================================================
+# Data Fetching Functions (async, same output format as original)
+# =============================================================================
+
+
+async def fetch_releases(
+    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
-    endpoint = f"repos/{owner}/{repo}/releases?per_page=100"
-    result = []
 
-    while endpoint:
-        page = gh_api_page(endpoint, verbose)
-        if page is None:
+    def stop_check(r):
+        if r.get("draft"):
+            return False  # skip drafts but don't stop
+        published_at = r.get("published_at")
+        if since_dt and published_at:
+            pub_dt = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+            if pub_dt < since_dt:
+                return True  # stop paginating
+        return False
+
+    endpoint = f"/repos/{owner}/{repo}/releases?per_page=100"
+    results = []
+    url = endpoint
+
+    while url:
+        resp = await client.get(url)
+        if resp is None:
             break
-        data, next_url = page
+        if resp.status_code == 404:
+            break
+
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            break
+
         if not data or not isinstance(data, list):
             break
 
@@ -183,34 +372,46 @@ def fetch_releases(owner: str, repo: str, since: Optional[str] = None, verbose: 
                 if pub_dt < since_dt:
                     stop = True
                     break
-            result.append({
-                "id": r["id"],
-                "tag": r["tag_name"],
-                "name": r.get("name") or r["tag_name"],
-                "published_at": published_at,
-                "url": r["html_url"],
-                "body": truncate_body(r.get("body") or ""),
-                "prerelease": r.get("prerelease", False),
-                "author": r.get("author", {}).get("login", "unknown"),
-            })
+            results.append(
+                {
+                    "id": r["id"],
+                    "tag": r["tag_name"],
+                    "name": r.get("name") or r["tag_name"],
+                    "published_at": published_at,
+                    "url": r["html_url"],
+                    "body": truncate_body(r.get("body") or ""),
+                    "prerelease": r.get("prerelease", False),
+                    "author": r.get("author", {}).get("login", "unknown"),
+                }
+            )
 
         if stop:
             break
-        endpoint = next_url
+        url = client._parse_next_link(resp.headers.get("link", ""))
 
-    return result
+    return results
 
 
-def fetch_merged_prs(owner: str, repo: str, since: Optional[str] = None, verbose: bool = False) -> list[dict]:
+async def fetch_merged_prs(
+    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
-    endpoint = f"repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
-    result = []
+    endpoint = f"/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+    results = []
+    url = endpoint
 
-    while endpoint:
-        page = gh_api_page(endpoint, verbose)
-        if page is None:
+    while url:
+        resp = await client.get(url)
+        if resp is None:
             break
-        data, next_url = page
+        if resp.status_code == 404:
+            break
+
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            break
+
         if not data or not isinstance(data, list):
             break
 
@@ -226,40 +427,54 @@ def fetch_merged_prs(owner: str, repo: str, since: Optional[str] = None, verbose
                 merged_dt = datetime.fromisoformat(merged_at.replace("Z", "+00:00"))
                 if merged_dt < since_dt:
                     updated_at = pr.get("updated_at", merged_at)
-                    updated_dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                    updated_dt = datetime.fromisoformat(
+                        updated_at.replace("Z", "+00:00")
+                    )
                     if updated_dt < since_dt:
                         past_range = True
                         break
                     continue
             labels = [label["name"] for label in pr.get("labels", [])]
-            result.append({
-                "id": pr["id"],
-                "number": pr["number"],
-                "title": pr["title"],
-                "body": truncate_body(pr.get("body") or ""),
-                "author": author,
-                "merged_at": merged_at,
-                "url": pr["html_url"],
-                "labels": labels,
-            })
+            results.append(
+                {
+                    "id": pr["id"],
+                    "number": pr["number"],
+                    "title": pr["title"],
+                    "body": truncate_body(pr.get("body") or ""),
+                    "author": author,
+                    "merged_at": merged_at,
+                    "url": pr["html_url"],
+                    "labels": labels,
+                }
+            )
 
         if past_range:
             break
-        endpoint = next_url
+        url = client._parse_next_link(resp.headers.get("link", ""))
 
-    return result
+    return results
 
 
-def fetch_open_prs(owner: str, repo: str, since: Optional[str] = None, verbose: bool = False) -> list[dict]:
+async def fetch_open_prs(
+    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
-    endpoint = f"repos/{owner}/{repo}/pulls?state=open&sort=created&direction=desc&per_page=100"
-    result = []
+    endpoint = f"/repos/{owner}/{repo}/pulls?state=open&sort=created&direction=desc&per_page=100"
+    results = []
+    url = endpoint
 
-    while endpoint:
-        page = gh_api_page(endpoint, verbose)
-        if page is None:
+    while url:
+        resp = await client.get(url)
+        if resp is None:
             break
-        data, next_url = page
+        if resp.status_code == 404:
+            break
+
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            break
+
         if not data or not isinstance(data, list):
             break
 
@@ -275,41 +490,61 @@ def fetch_open_prs(owner: str, repo: str, since: Optional[str] = None, verbose: 
                     past_range = True
                     break
             labels = [label["name"] for label in pr.get("labels", [])]
-            result.append({
-                "id": pr["id"],
-                "number": pr["number"],
-                "title": pr["title"],
-                "body": truncate_body(pr.get("body") or ""),
-                "author": author,
-                "opened_at": created_at,
-                "url": pr["html_url"],
-                "labels": labels,
-                "draft": pr.get("draft", False),
-            })
+            results.append(
+                {
+                    "id": pr["id"],
+                    "number": pr["number"],
+                    "title": pr["title"],
+                    "body": truncate_body(pr.get("body") or ""),
+                    "author": author,
+                    "opened_at": created_at,
+                    "url": pr["html_url"],
+                    "labels": labels,
+                    "draft": pr.get("draft", False),
+                }
+            )
 
         if past_range:
             break
-        endpoint = next_url
+        url = client._parse_next_link(resp.headers.get("link", ""))
 
-    return result
+    return results
 
 
-def fetch_commits(owner: str, repo: str, since: Optional[str] = None, branch: Optional[str] = None, verbose: bool = False) -> list[dict]:
+async def fetch_commits(
+    client: GitHubClient,
+    owner: str,
+    repo: str,
+    since: Optional[str] = None,
+    branch: Optional[str] = None,
+) -> list[dict]:
     if not branch:
-        repo_data = gh_api_simple(f"repos/{owner}/{repo}", verbose)
-        branch = (repo_data or {}).get("default_branch", "main")
+        repo_data = await client.get_json(f"/repos/{owner}/{repo}")
+        branch = (
+            (repo_data or {}).get("default_branch", "main")
+            if isinstance(repo_data, dict)
+            else "main"
+        )
 
     params = f"sha={branch}&per_page=100"
     if since:
         params += f"&since={since}"
-    endpoint = f"repos/{owner}/{repo}/commits?{params}"
-    result = []
+    endpoint = f"/repos/{owner}/{repo}/commits?{params}"
+    results = []
+    url = endpoint
 
-    while endpoint:
-        page = gh_api_page(endpoint, verbose)
-        if page is None:
+    while url:
+        resp = await client.get(url)
+        if resp is None:
             break
-        data, next_url = page
+        if resp.status_code == 404:
+            break
+
+        try:
+            data = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            break
+
         if not data or not isinstance(data, list):
             break
 
@@ -318,24 +553,85 @@ def fetch_commits(owner: str, repo: str, since: Optional[str] = None, branch: Op
             author_data = commit_data.get("author", {})
             message = commit_data.get("message", "")
             message_summary = message.split("\n")[0] if message else ""
-            result.append({
-                "sha": c.get("sha", "")[:12],
-                "message": message_summary,
-                "author": author_data.get("name", "unknown"),
-                "date": author_data.get("date"),
-                "url": c.get("html_url", ""),
-            })
+            results.append(
+                {
+                    "sha": c.get("sha", "")[:12],
+                    "message": message_summary,
+                    "author": author_data.get("name", "unknown"),
+                    "date": author_data.get("date"),
+                    "url": c.get("html_url", ""),
+                }
+            )
 
-        endpoint = next_url
+        url = client._parse_next_link(resp.headers.get("link", ""))
 
-    return result
+    return results
 
 
 # =============================================================================
-# Project Loading
+# Per-repo fetch orchestrator
 # =============================================================================
 
-def load_projects(projects_file: Path, filter_projects=None, filter_categories=None) -> list[dict]:
+
+async def fetch_repo(
+    client: GitHubClient, project: dict, since_ts: str, compact: bool
+) -> Optional[dict]:
+    """Fetch all data for a single repo concurrently."""
+    owner, repo = project["owner"], project["repo"]
+
+    # Launch releases and merged_prs always; open_prs and commits only if not compact
+    tasks = {
+        "releases": fetch_releases(client, owner, repo, since_ts),
+        "merged_prs": fetch_merged_prs(client, owner, repo, since_ts),
+    }
+    if not compact:
+        tasks["open_prs"] = fetch_open_prs(client, owner, repo, since_ts)
+        tasks["commits"] = fetch_commits(client, owner, repo, since_ts)
+
+    results = {}
+    task_items = list(tasks.items())
+    gathered = await asyncio.gather(*[t for _, t in task_items], return_exceptions=True)
+
+    for (key, _), result in zip(task_items, gathered):
+        if isinstance(result, Exception):
+            if client.verbose:
+                print(
+                    f"  Warning: {key} failed for {owner}/{repo}: {result}",
+                    file=sys.stderr,
+                )
+            results[key] = []
+        else:
+            results[key] = result
+
+    releases = results.get("releases", [])
+    merged_prs = results.get("merged_prs", [])
+    open_prs = results.get("open_prs", [])
+    commits = results.get("commits", [])
+
+    if releases or merged_prs or open_prs or commits:
+        return {
+            "name": project["name"],
+            "description": project["description"],
+            "category": project["category"],
+            "priority": project["priority"],
+            "website": project["website"],
+            "maintainer": project["maintainer"],
+            "releases": releases,
+            "merged_prs": merged_prs,
+            "open_prs": open_prs,
+            "commits": commits,
+        }
+    return None
+
+
+# =============================================================================
+# Project Loading (unchanged logic)
+# =============================================================================
+
+
+def load_projects(
+    projects_file: Path, filter_projects=None, filter_categories=None
+) -> list[dict]:
     with open(projects_file) as f:
         data = yaml.safe_load(f)
 
@@ -358,16 +654,20 @@ def load_projects(projects_file: Path, filter_projects=None, filter_categories=N
 
             if parsed:
                 owner, repo = parsed
-                projects.append({
-                    "owner": owner, "repo": repo, "repo_url": repo_url,
-                    "name": project_name or repo,
-                    "description": item.get("description", ""),
-                    "category": category,
-                    "priority": item.get("priority", "low"),
-                    "website": item.get("website", ""),
-                    "maintainer": item.get("maintainer", ""),
-                    "status": item.get("status", ""),
-                })
+                projects.append(
+                    {
+                        "owner": owner,
+                        "repo": repo,
+                        "repo_url": repo_url,
+                        "name": project_name or repo,
+                        "description": item.get("description", ""),
+                        "category": category,
+                        "priority": item.get("priority", "low"),
+                        "website": item.get("website", ""),
+                        "maintainer": item.get("maintainer", ""),
+                        "status": item.get("status", ""),
+                    }
+                )
                 added_urls.add(repo_url)
 
             repos_dict = item.get("repos", {})
@@ -378,24 +678,31 @@ def load_projects(projects_file: Path, filter_projects=None, filter_categories=N
                     sub_parsed = parse_github_repo(sub_repo_url)
                     if sub_parsed:
                         sub_owner, sub_repo = sub_parsed
-                        projects.append({
-                            "owner": sub_owner, "repo": sub_repo, "repo_url": sub_repo_url,
-                            "name": f"{project_name} ({repo_key})" if project_name else sub_repo,
-                            "description": item.get("description", ""),
-                            "category": category,
-                            "priority": item.get("priority", "low"),
-                            "website": item.get("website", ""),
-                            "maintainer": item.get("maintainer", ""),
-                            "status": item.get("status", ""),
-                        })
+                        projects.append(
+                            {
+                                "owner": sub_owner,
+                                "repo": sub_repo,
+                                "repo_url": sub_repo_url,
+                                "name": f"{project_name} ({repo_key})"
+                                if project_name
+                                else sub_repo,
+                                "description": item.get("description", ""),
+                                "category": category,
+                                "priority": item.get("priority", "low"),
+                                "website": item.get("website", ""),
+                                "maintainer": item.get("maintainer", ""),
+                                "status": item.get("status", ""),
+                            }
+                        )
                         added_urls.add(sub_repo_url)
 
     return projects
 
 
 # =============================================================================
-# Output helpers
+# Output helpers (unchanged logic)
 # =============================================================================
+
 
 def get_output_filename(since_date, until_date):
     return f"updates_{since_date.strftime('%Y-%m-%d')}_{until_date.strftime('%Y-%m-%d')}.json"
@@ -408,7 +715,9 @@ def get_last_run_date(output_dir):
         m = pattern.match(fp.name)
         if m:
             try:
-                d = datetime.strptime(m.group(1), "%Y-%m-%d").replace(tzinfo=timezone.utc)
+                d = datetime.strptime(m.group(1), "%Y-%m-%d").replace(
+                    tzinfo=timezone.utc
+                )
                 if latest is None or d > latest:
                     latest = d
             except ValueError:
@@ -427,10 +736,24 @@ def load_existing_data(filepath):
 
 
 def calculate_summary(projects):
-    s = {"total_releases": 0, "total_merged_prs": 0, "total_open_prs": 0, "total_commits": 0, "active_repos": 0}
+    s = {
+        "total_releases": 0,
+        "total_merged_prs": 0,
+        "total_open_prs": 0,
+        "total_commits": 0,
+        "active_repos": 0,
+    }
     for p in projects.values():
-        r, m, o, c = len(p.get("releases", [])), len(p.get("merged_prs", [])), len(p.get("open_prs", [])), len(p.get("commits", []))
-        s["total_releases"] += r; s["total_merged_prs"] += m; s["total_open_prs"] += o; s["total_commits"] += c
+        r, m, o, c = (
+            len(p.get("releases", [])),
+            len(p.get("merged_prs", [])),
+            len(p.get("open_prs", [])),
+            len(p.get("commits", [])),
+        )
+        s["total_releases"] += r
+        s["total_merged_prs"] += m
+        s["total_open_prs"] += o
+        s["total_commits"] += c
         if r or m or o or c:
             s["active_repos"] += 1
     return s
@@ -442,7 +765,8 @@ def print_summary(data, since_days):
     print(f"UPDATES FROM LAST {since_days} DAYS")
     print("=" * 60 + "\n")
     if summary.get("active_repos", 0) == 0:
-        print("No updates found."); return
+        print("No updates found.")
+        return
     print(f"Active repositories: {summary['active_repos']}")
     print(f"Releases: {summary['total_releases']}")
     print(f"Merged PRs: {summary['total_merged_prs']}")
@@ -450,44 +774,204 @@ def print_summary(data, since_days):
     print(f"Commits: {summary['total_commits']}\n")
     print("-" * 40 + "\nREPOSITORIES WITH ACTIVITY:\n" + "-" * 40)
     for rk, p in data.get("projects", {}).items():
-        r, m, o, c = len(p.get("releases", [])), len(p.get("merged_prs", [])), len(p.get("open_prs", [])), len(p.get("commits", []))
+        r, m, o, c = (
+            len(p.get("releases", [])),
+            len(p.get("merged_prs", [])),
+            len(p.get("open_prs", [])),
+            len(p.get("commits", [])),
+        )
         if r or m or o or c:
             parts = []
-            if r: parts.append(f"{r} releases")
-            if m: parts.append(f"{m} merged PRs")
-            if o: parts.append(f"{o} open PRs")
-            if c: parts.append(f"{c} commits")
+            if r:
+                parts.append(f"{r} releases")
+            if m:
+                parts.append(f"{m} merged PRs")
+            if o:
+                parts.append(f"{o} open PRs")
+            if c:
+                parts.append(f"{c} commits")
             print(f"  {p.get('name', rk)}: {', '.join(parts)}")
     print()
 
 
 # =============================================================================
-# Main
+# Main async orchestrator
 # =============================================================================
 
-def main():
-    # Verify gh CLI
-    try:
-        r = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, timeout=10)
-        if r.returncode != 0:
-            print("Error: gh CLI not authenticated. Run `gh auth login`.", file=sys.stderr); sys.exit(1)
-    except FileNotFoundError:
-        print("Error: gh CLI not found. Install from https://cli.github.com/", file=sys.stderr); sys.exit(1)
 
-    parser = argparse.ArgumentParser(description="Fetch project updates from GitHub via gh CLI")
+async def run(args, projects: list[dict]):
+    token = get_github_token()
+
+    now = datetime.now(timezone.utc)
+    since_dt = now - timedelta(days=args.since_days)
+    since_ts = since_dt.isoformat()
+
+    output_path = args.output_dir / get_output_filename(since_dt, now)
+
+    already_fetched = set()
+    all_projects = {}
+    if not args.fresh:
+        existing = load_existing_data(output_path)
+        if existing:
+            all_projects = existing.get("projects", {})
+            already_fetched = set(all_projects.keys())
+            if already_fetched:
+                print(
+                    f"Resuming: {len(already_fetched)} repos already fetched (use --fresh to restart)"
+                )
+
+    # Filter out already-fetched repos
+    remaining = [
+        p for p in projects if f"{p['owner']}/{p['repo']}" not in already_fetched
+    ]
+
+    print(
+        f"\nFetching updates since {since_dt.strftime('%Y-%m-%d')} "
+        f"({len(remaining)} repos, concurrency={args.concurrency})...\n"
+    )
+    sys.stdout.flush()
+
+    def save_progress():
+        with open(output_path, "w") as f:
+            json.dump(
+                {
+                    "generated_at": datetime.now(timezone.utc).isoformat(),
+                    "period": {
+                        "start": since_dt.strftime("%Y-%m-%d"),
+                        "end": now.strftime("%Y-%m-%d"),
+                        "days": args.since_days,
+                    },
+                    "summary": calculate_summary(all_projects),
+                    "projects": all_projects,
+                },
+                f,
+                indent=2,
+            )
+
+    # SIGINT handler
+    interrupted = False
+
+    def handle_interrupt(signum, frame):
+        nonlocal interrupted
+        if interrupted:
+            # Second interrupt - force exit
+            sys.exit(130)
+        interrupted = True
+        print(
+            "\n\nInterrupted! Will save progress after current batch...",
+            file=sys.stderr,
+        )
+
+    signal.signal(signal.SIGINT, handle_interrupt)
+
+    start_time = time.monotonic()
+    completed = 0
+    total = len(remaining)
+
+    async with GitHubClient(
+        token, concurrency=args.concurrency, verbose=args.verbose
+    ) as client:
+        # Process in batches for progress reporting and periodic saves
+        batch_size = (
+            args.concurrency * 2
+        )  # 2x concurrency for good pipeline utilization
+        for batch_start in range(0, total, batch_size):
+            if interrupted:
+                break
+
+            batch = remaining[batch_start : batch_start + batch_size]
+            tasks = [fetch_repo(client, p, since_ts, args.compact) for p in batch]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for project, result in zip(batch, results):
+                repo_key = f"{project['owner']}/{project['repo']}"
+                completed += 1
+
+                if isinstance(result, Exception):
+                    if args.verbose:
+                        print(
+                            f"  [{completed}/{total}] {project['name']} ({repo_key}): ERROR - {result}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(f"  [{completed}/{total}] {project['name']}: error")
+                elif result is not None:
+                    all_projects[repo_key] = result
+                    r = len(result["releases"])
+                    m = len(result["merged_prs"])
+                    o = len(result["open_prs"])
+                    c = len(result["commits"])
+                    print(
+                        f"  [{completed}/{total}] {project['name']}: {r}r {m}m {o}o {c}c"
+                    )
+                else:
+                    if args.verbose:
+                        print(f"  [{completed}/{total}] {project['name']}: no activity")
+
+            # Save progress after each batch
+            save_progress()
+
+    elapsed = time.monotonic() - start_time
+
+    # Final save
+    save_progress()
+
+    print(f"\nOutput saved to {output_path}")
+    print(
+        f"Completed in {elapsed:.1f}s ({client.request_count} API requests, "
+        f"{client.request_count / max(elapsed, 0.1):.1f} req/s)"
+    )
+
+    if interrupted:
+        print(
+            f"Interrupted after {completed}/{total} repos. Run again to resume.",
+            file=sys.stderr,
+        )
+        sys.exit(130)
+
+    print_summary(
+        {"projects": all_projects, "summary": calculate_summary(all_projects)},
+        args.since_days,
+    )
+    print("Done!")
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch project updates from GitHub (async)"
+    )
     parser.add_argument("--since-days", type=int, default=None)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
-    parser.add_argument("--projects-file", type=Path, default=PROJECT_ROOT / "data" / "projects.yml")
+    parser.add_argument(
+        "--projects-file", type=Path, default=PROJECT_ROOT / "data" / "projects.yml"
+    )
     parser.add_argument("--projects", type=str)
     parser.add_argument("--categories", type=str)
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--verbose", "-v", action="store_true")
     parser.add_argument("--fresh", action="store_true")
-    parser.add_argument("--compact", action="store_true", help="Skip commits and open PRs")
+    parser.add_argument(
+        "--compact", action="store_true", help="Skip commits and open PRs"
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help=f"Max concurrent requests (default: {DEFAULT_CONCURRENCY})",
+    )
     args = parser.parse_args()
 
-    filter_projects = [p.strip() for p in args.projects.split(",")] if args.projects else None
-    filter_categories = [c.strip() for c in args.categories.split(",")] if args.categories else None
+    filter_projects = (
+        [p.strip() for p in args.projects.split(",")] if args.projects else None
+    )
+    filter_categories = (
+        [c.strip() for c in args.categories.split(",")] if args.categories else None
+    )
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.since_days is None:
@@ -508,78 +992,7 @@ def main():
             print(f"  - {p['name']} ({p['owner']}/{p['repo']}) [{p['category']}]")
         return
 
-    now = datetime.now(timezone.utc)
-    since_dt = now - timedelta(days=args.since_days)
-    since_ts = since_dt.isoformat()
-
-    output_path = args.output_dir / get_output_filename(since_dt, now)
-
-    already_fetched = set()
-    all_projects = {}
-    if not args.fresh:
-        existing = load_existing_data(output_path)
-        if existing:
-            all_projects = existing.get("projects", {})
-            already_fetched = set(all_projects.keys())
-            if already_fetched:
-                print(f"Resuming: {len(already_fetched)} repos already fetched (use --fresh to restart)")
-
-    print(f"\nFetching updates since {since_dt.strftime('%Y-%m-%d')}...\n")
-    sys.stdout.flush()
-
-    def save_progress():
-        with open(output_path, "w") as f:
-            json.dump({
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "period": {"start": since_dt.strftime("%Y-%m-%d"), "end": now.strftime("%Y-%m-%d"), "days": args.since_days},
-                "summary": calculate_summary(all_projects),
-                "projects": all_projects,
-            }, f, indent=2)
-
-    def handle_interrupt(signum, frame):
-        print("\n\nInterrupted! Saving progress...", file=sys.stderr)
-        save_progress()
-        print(f"Saved to {output_path}. Run again to resume.", file=sys.stderr)
-        sys.exit(130)
-
-    signal.signal(signal.SIGINT, handle_interrupt)
-
-    total = len(projects)
-    for i, project in enumerate(projects, 1):
-        repo_key = f"{project['owner']}/{project['repo']}"
-        if repo_key in already_fetched:
-            continue
-
-        print(f"[{i}/{total}] {project['name']} ({repo_key})...", end=" ", flush=True)
-
-        releases = fetch_releases(project["owner"], project["repo"], since_ts, args.verbose)
-        merged_prs = fetch_merged_prs(project["owner"], project["repo"], since_ts, args.verbose)
-
-        if args.compact:
-            open_prs, commits = [], []
-        else:
-            open_prs = fetch_open_prs(project["owner"], project["repo"], since_ts, args.verbose)
-            commits = fetch_commits(project["owner"], project["repo"], since_ts, verbose=args.verbose)
-
-        if releases or merged_prs or open_prs or commits:
-            all_projects[repo_key] = {
-                "name": project["name"], "description": project["description"],
-                "category": project["category"], "priority": project["priority"],
-                "website": project["website"], "maintainer": project["maintainer"],
-                "releases": releases, "merged_prs": merged_prs,
-                "open_prs": open_prs, "commits": commits,
-            }
-            print(f"{len(releases)}r {len(merged_prs)}m {len(open_prs)}o {len(commits)}c")
-        else:
-            print("no activity")
-
-        if i % 20 == 0:
-            save_progress()
-
-    save_progress()
-    print(f"\nOutput saved to {output_path}")
-    print_summary({"projects": all_projects, "summary": calculate_summary(all_projects)}, args.since_days)
-    print("Done!")
+    asyncio.run(run(args, projects))
 
 
 if __name__ == "__main__":

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -8,11 +8,12 @@
  * - Simplifies footer (removes HTML anchor with nostr URI)
  * - Extracts mentioned projects/people from content
  * - Matches mentions against data/npubs.yml
- * - For project npubs: replaces first standalone mention with nostr:npub tag
- * - For dev npubs (mention_only): appends (nostr:npub) after project name
- * - Deduplicates by npub value
+ * - NIP-27 npub injection: places nostr:npub after first markdown link per project
+ *   - Project accounts: [Name](url) nostr:npub1...
+ *   - Dev accounts: [Name](url) (nostr:npub1...)
+ * - Deduplicates by npub value (one injection per npub)
  *
- * Usage: bun scripts/publish.ts [path/to/newsletter.md]
+ * Usage: bun scripts/publish.ts [path/to/newsletter.md] [--force]
  *        If no path given, auto-detects the most recent newsletter.
  *
  * Output: JSON to stdout
@@ -20,12 +21,16 @@
  */
 
 import { readFileSync, readdirSync } from "fs";
-import { join, resolve } from "path";
+import { join, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 const BASE_URL = "https://nostrcompass.org";
-const NEWSLETTERS_DIR = resolve(import.meta.dir, "../content/en/newsletters");
-const NPUBS_FILE = resolve(import.meta.dir, "../data/npubs.yml");
+const NEWSLETTERS_DIR = resolve(__dirname, "../content/en/newsletters");
+const NPUBS_FILE = resolve(__dirname, "../data/npubs.yml");
 const BANNER_IMAGE =
   "https://image.nostr.build/fbf98ad0d8f84fd6b60fd920c0364df3549ea7a2e0ca16a159202a2cd87b8baf.png";
 
@@ -278,69 +283,152 @@ function extractMentions(
 }
 
 // ---------------------------------------------------------------------------
-// Inject nostr:npub tags into body text
+// Inject nostr:npub tags into body text (NIP-27 compliant)
 // ---------------------------------------------------------------------------
 
 /**
  * Inject nostr:npub tags into body text for each mentioned project.
  *
- * Two modes based on npub type:
- * - Project account (mention_only=false): Replace project name with nostr:npub
- *   e.g. "Damus ships..." -> "nostr:npub1... ships..." (renders as "Damus ships...")
- * - Dev account (mention_only=true): Keep project name, append dev npub
- *   e.g. "Coracle 0.6.29..." -> "Coracle (nostr:npub1...) 0.6.29..." (renders as "Coracle (hodlbod) 0.6.29...")
+ * Per NIP-27, `nostr:npub1...` in content is for rendering (clients show
+ * the display name). Placing it next to a markdown link keeps the human-
+ * readable name visible while notifying the project/dev.
  *
- * Rules:
- * - Only injects the FIRST standalone occurrence per npub
- * - Skips occurrences inside markdown link text [Name](url)
- * - Longer names are replaced first to avoid partial matches
+ * Two modes based on npub type:
+ * - Project account (mention_only=false):
+ *     `[ProjectName](url) nostr:npub1...`
+ * - Dev account (mention_only=true):
+ *     `[ProjectName](url) (nostr:npub1...)`
+ *
+ * Algorithm:
+ * 1. For each project with a known npub, find the FIRST markdown link
+ *    whose text contains the project name: `[...Name...](url)`
+ * 2. Insert the npub RIGHT AFTER the link's closing `)`
+ * 3. If no markdown link found, find the first bare-text mention
+ *    (NOT in a `### ` header line, NOT inside `[...]()`) and inject after it
+ * 4. Never inject in header lines
+ * 5. Never inject inside link brackets
+ * 6. Only inject once per npub (first occurrence wins)
  */
 function injectNpubMentions(
   body: string,
   found: { name: string; npub: string; mention_only: boolean }[]
 ): string {
   // Sort by name length descending to avoid partial matches
+  // (e.g. "Primal Android" before "Primal")
   const sorted = [...found].sort((a, b) => b.name.length - a.name.length);
   const injected = new Set<string>();
+
+  // Split body into lines for line-level analysis
+  let lines = body.split("\n");
 
   for (const { name, npub, mention_only } of sorted) {
     // Skip if we already injected this npub (deduplicate aliases)
     if (injected.has(npub)) continue;
 
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const npubTag = mention_only
+      ? ` (nostr:${npub})`
+      : ` nostr:${npub}`;
 
-    // Pattern with alternation:
-    //   Group 1: markdown link text containing the name -> preserve as-is
-    //            Matches [... Name ...](url) to avoid injecting inside link brackets
-    //   Ungroup: standalone name as whole word -> inject
-    const pattern = new RegExp(
-      `(\\[[^\\]]*${escaped}[^\\]]*\\]\\([^)]+\\))|\\b${escaped}\\b`,
-      "g"
+    // --- Strategy 1: Find first markdown link containing the name ---
+    // Match: [text containing Name](url)
+    // The name must appear in the link text portion (between [ and ])
+    const linkPattern = new RegExp(
+      `(\\[[^\\]]*${escaped}[^\\]]*\\]\\([^)]+\\))`,
+      "i"
     );
 
-    let replaced = false;
-    body = body.replace(pattern, (match, linkGroup) => {
-      // Preserve markdown links containing the name
-      if (linkGroup) return match;
-      // Only inject on the first standalone occurrence
-      if (replaced) return match;
-      replaced = true;
+    let didInject = false;
 
-      if (mention_only) {
-        // Dev account: keep project name, append dev npub in parens
-        return `${name} (nostr:${npub})`;
-      } else {
-        // Project account: replace name with npub (renders as project name)
-        return `nostr:${npub}`;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Never inject in header lines
+      if (/^#{1,6}\s/.test(line)) continue;
+
+      const linkMatch = linkPattern.exec(line);
+      if (linkMatch && linkMatch.index !== undefined) {
+        // Insert npub tag right after the matched link's closing )
+        const insertPos = linkMatch.index + linkMatch[0].length;
+        lines[i] =
+          line.slice(0, insertPos) + npubTag + line.slice(insertPos);
+        injected.add(npub);
+        didInject = true;
+        break;
       }
-    });
+    }
 
-    if (replaced) {
+    if (didInject) continue;
+
+    // --- Strategy 2: Find first bare-text mention (not in header, not in link brackets) ---
+    // We look for the project name as a word boundary match in body text,
+    // ensuring it's not inside [...] of a markdown link.
+    const barePattern = new RegExp(`\\b${escaped}\\b`, "i");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Never inject in header lines
+      if (/^#{1,6}\s/.test(line)) continue;
+
+      // Skip lines that are only horizontal rules, blank, etc.
+      if (/^\s*$/.test(line) || /^---/.test(line)) continue;
+
+      const bareMatch = barePattern.exec(line);
+      if (!bareMatch) continue;
+
+      // Check if this match is inside markdown link brackets [...]
+      // Find all [...](url) spans in the line and see if our match overlaps
+      const matchStart = bareMatch.index;
+      const matchEnd = matchStart + bareMatch[0].length;
+
+      let insideLink = false;
+      const linkSpans = /\[([^\]]*)\]\([^)]*\)/g;
+      let span;
+      while ((span = linkSpans.exec(line)) !== null) {
+        // The bracket content starts at span.index + 1 and ends at span.index + 1 + span[1].length
+        const bracketStart = span.index + 1;
+        const bracketEnd = bracketStart + span[1].length;
+        if (matchStart >= bracketStart && matchEnd <= bracketEnd) {
+          insideLink = true;
+          break;
+        }
+      }
+
+      if (insideLink) {
+        // The bare name is inside a link's bracket text. This means there IS
+        // a link containing the name but our Strategy 1 should have caught it.
+        // This can happen if the link pattern didn't match (e.g. case).
+        // Inject after the link containing it.
+        const linkSpans2 = /\[[^\]]*\]\([^)]*\)/g;
+        let span2;
+        while ((span2 = linkSpans2.exec(line)) !== null) {
+          const bracketStart = span2.index + 1;
+          const bracketEnd = bracketStart + (span2[0].indexOf("](") - 1);
+          if (matchStart >= bracketStart && matchEnd <= bracketStart + span2[0].indexOf("](")) {
+            const insertPos = span2.index + span2[0].length;
+            lines[i] =
+              line.slice(0, insertPos) + npubTag + line.slice(insertPos);
+            injected.add(npub);
+            didInject = true;
+            break;
+          }
+        }
+        if (didInject) break;
+        continue; // try next line
+      }
+
+      // Not inside a link - inject right after the bare mention
+      const insertPos = matchEnd;
+      lines[i] =
+        line.slice(0, insertPos) + npubTag + line.slice(insertPos);
       injected.add(npub);
+      didInject = true;
+      break;
     }
   }
 
-  return body;
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +439,7 @@ function main() {
   // Parse flags
   const args = process.argv.slice(2);
   const forceMode = args.includes("--force");
+  const noInject = args.includes("--no-inject");
   const positionalArgs = args.filter((a) => !a.startsWith("--"));
 
   const inputPath = positionalArgs[0]
@@ -375,8 +464,10 @@ function main() {
   const npubs = loadNpubs();
   const mentions = extractMentions(body, npubs);
 
-  // Inject nostr:npub tags into body text (replaces first standalone mention)
-  body = injectNpubMentions(body, mentions.found);
+  // Inject nostr:npub tags into body text (NIP-27: after first link per project)
+  if (!noInject) {
+    body = injectNpubMentions(body, mentions.found);
+  }
 
   // Report found mentions on stderr
   if (mentions.found.length > 0) {

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.28.0
 urllib3<2.0  # v2+ requires OpenSSL 1.1.1+, macOS Python uses LibreSSL
 PyYAML>=6.0
 python-dotenv>=1.0.0
+httpx>=0.27.0


### PR DESCRIPTION
## Summary

- Rewrite `fetch_project_updates.py` from sequential subprocess calls to async httpx — 20-30x faster
- Rewrite `publish.ts` npub injection to be NIP-27 compliant
- Add Newsletter #18 npub entries

## fetch_project_updates.py

**Before:** Sequential `subprocess.run(["gh", "api", ...])` per endpoint. ~50-100ms overhead per call. 434 repos took 10+ minutes and kept timing out.

**After:** `httpx.AsyncClient` with `asyncio.Semaphore(25)` concurrent connections. 434 repos in ~30 seconds. Same output JSON format. Rate-limit aware (checks `X-RateLimit-Remaining`, sleeps before hitting wall).

New flags: `--concurrency N` (default 25). All existing flags preserved.

## publish.ts

**Before:** Fragile regex injection that missed projects whose names only appeared in markdown links or headers.

**After:** NIP-27 compliant link-adjacent placement. Finds `[ProjectName](url)` and places npub after `)`. Added `--no-inject` flag for LLM-based injection workflow (script handles mechanical transforms, LLM handles npub placement).