### PR TITLE
Make mobile layout edge-to-edge and update frontend deps

### DIFF
--- a/assets/sass/_minima.scss
+++ b/assets/sass/_minima.scss
@@ -50,6 +50,7 @@ html, body {
 }
 
 body {
+  margin: 0;
   font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
   color: var(--text-color);
   background-color: var(--background-color);
@@ -161,6 +162,18 @@ pre {
   padding-right: $spacing-unit;
   padding-left: $spacing-unit;
   @extend %clearfix;
+
+  // Reduce side padding on small viewports so text goes nearly
+  // edge-to-edge on phones (was 30px, wasting ~20% of width at 390px).
+  @media screen and (max-width: 750px) {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  @media screen and (max-width: 480px) {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
 }
 
 %clearfix:after {

--- a/bun.lock
+++ b/bun.lock
@@ -4,28 +4,30 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "yaml": "^2.8.2",
+        "yaml": "^2.8.3",
       },
       "devDependencies": {
-        "pagefind": "^1.4.0",
+        "pagefind": "^1.5.2",
       },
     },
   },
   "packages": {
-    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ=="],
+    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
 
-    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A=="],
+    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw=="],
 
-    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.4.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q=="],
+    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.5.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA=="],
 
-    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw=="],
+    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw=="],
 
-    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg=="],
+    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA=="],
 
-    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g=="],
+    "@pagefind/windows-arm64": ["@pagefind/windows-arm64@1.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g=="],
 
-    "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
+    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "pagefind": ["pagefind@1.5.2", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.5.2", "@pagefind/darwin-x64": "1.5.2", "@pagefind/freebsd-x64": "1.5.2", "@pagefind/linux-arm64": "1.5.2", "@pagefind/linux-x64": "1.5.2", "@pagefind/windows-arm64": "1.5.2", "@pagefind/windows-x64": "1.5.2" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "build": "bash scripts/build-site.sh"
   },
   "dependencies": {
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
-    "pagefind": "^1.4.0"
+    "pagefind": "^1.5.2"
   }
 }


### PR DESCRIPTION
## Summary

On mobile, the reading column was noticeably narrower than it needed to be. The `.wrapper` had a fixed 30 px horizontal padding at every breakpoint, and `<body>` still carried the UA-default 8 px margin. At a 390 px phone width that burned ~76 px (≈20%) on blank gutters before any content rendered.

This PR ties the wrapper padding to viewport size and zeroes the body margin so content goes nearly edge-to-edge on phones, while leaving desktop centering untouched.

## Changes

- `assets/sass/_minima.scss`
  - `body { margin: 0 }` — removes the 8 px UA default.
  - `.wrapper` padding: 30 px on desktop (unchanged) → **16 px** at ≤750 px → **12 px** at ≤480 px.
- Dependency bumps (no vulnerabilities reported by `bun audit`):
  - `yaml` 2.8.2 → 2.8.3
  - `pagefind` 1.4.0 → 1.5.2 (dev)
  - `bun.lock` now also includes the `@pagefind/windows-arm64` optional native package shipped by 1.5.x.

## Verification

Measured at three viewports (dev server + headless Chromium):

| Viewport | Before (text start x) | After (text start x) | Wrapper max-width | Padding |
|---|---|---|---|---|
| 390 px (phone) | ~39–48 px | **12 px** | full width | 12 px |
| 600 px (tablet) | ~38 px | **16 px** | full width | 16 px |
| 1280 px (desktop) | 190 px (centered) | **190 px (centered)** | 900 px | 30 px |

- No horizontal overflow (`scrollWidth === clientWidth`) on home, newsletters index, newsletter post, topics index, NIP-01 topic page, search.
- No console errors, no failed requests across the tested pages.
- `bun run build` (the CI script) completes cleanly; Pagefind indexing still works; site search still returns results.
- `bun audit`: no vulnerabilities.

## Screenshots (390 px, NIP-01 topic page)

Before — text starts ~39 px from the left edge (8 px body margin + 30 px wrapper padding):
- red line at x=39 shows wasted gutter

After — text starts at x=12:
- green line at x=12 shows the new minimal gutter

Test/Plan
- Merge and let the GH Pages workflow redeploy.
- Spot-check a newsletter post on a phone after deploy.