### PR TITLE
Add Newsletter #19 (2026-04-22) and topic pages

### DIFF
--- a/content/en/newsletters/2026-04-22-newsletter.md
+++ b/content/en/newsletters/2026-04-22-newsletter.md
@@ -1,0 +1,329 @@
+---
+title: 'Nostr Compass #19'
+date: 2026-04-22
+publishDate: 2026-04-22
+draft: false
+type: newsletters
+description: 'Amethyst ships Marmot MIP compliance, NIP-72 community creation, NIP-75 zap goals, and a MoQ-transport audio rooms stack; TollGate v0.1.0 stabilizes pay-per-use internet over Nostr and Cashu; nostream lands NIP-45 counts, NIP-62 vanish, query hardening, and complete NIP-11 parity; the Formstr suite hardens Pollerama security, ships Forms i18n and Google Form import, and lands RRULE support in Nostr Calendar v1.3.0 and v1.4.0; Forgesworn publishes a new signing, identity, and paid-API stack for Nostr; ShockWallet uses Nostr for multi-device Lightning wallet sync; StableKraft ships v1.0.0 as a music-and-podcast feed PWA with Nostr features; WoT Relay v0.2.1 migrates its eventstore to LMDB; and topaz ships as a Nostr relay for Android.'
+---
+
+Welcome back to Nostr Compass, your weekly guide to Nostr.
+
+**This week:** [Amethyst](https://github.com/vitorpamplona/amethyst) lands a large Marmot, communities, and MoQ audio rooms pass, [TollGate](https://github.com/OpenTollGate/tollgate) stabilizes pay-per-use internet access over Nostr and Cashu in [v0.1.0](#tollgate-v010-stabilizes-pay-per-use-internet-over-nostr-and-cashu), and [nostream](https://github.com/Cameri/nostream) closes a week of relay work around [NIP-45](/en/topics/nip-45/), [NIP-62](/en/topics/nip-62/), compression, query hardening, and complete [NIP-11](/en/topics/nip-11/) parity. [Forgesworn](#forgesworn-publishes-a-29-repo-cryptographic-toolkit-for-nostr) drops a full signing, identity, and paid-API stack for Nostr. [ShockWallet](#shockwallet-ships-nostr-native-lightning-wallet-sync-and-multi-node-connections) keeps pushing Nostr-native Lightning wallet flows. The Formstr suite ([Pollerama](#formstr-suite-pollerama-security-pass-forms-i18n-calendar-rrule-support), Forms, Calendar) merges 26 PRs across security hardening and RRULE support. [StableKraft](#stablekraft-v100-ships-the-first-stable-pwa-release), [Keep](#keep-android-v100-ships-with-reproducible-builds-and-zero-trackers), [topaz](#topaz-v002-ships-a-nostr-relay-for-android), [WoT Relay](#wot-relay-v021-migrates-eventstore-to-lmdb), [Flotilla](#flotilla-173-and-174-add-kind-9-wrapping-for-richer-nip-29-rooms), and [NipLock](#niplock-ships-a-nip-17-based-password-manager) round out the shipping list. Deep dives cover [NIP-72 moderated communities](/en/topics/nip-72/) and [NIP-57 zaps](/en/topics/nip-57/).
+
+## Top Stories
+
+### Amethyst ships Marmot MIP compliance, NIP-72 communities, zap goals, and MoQ audio rooms
+
+[Amethyst](https://github.com/vitorpamplona/amethyst), the Android client maintained by vitorpamplona, merged 57 PRs this week. The week's headline themes are [Marmot](/en/topics/marmot/) encrypted-group compliance, first-class moderated communities, zap goals on live streams, and a new audio-rooms stack built on Media over QUIC.
+
+On Marmot compliance, [PR #2462](https://github.com/vitorpamplona/amethyst/pull/2462) aligns the embedded [MDK](https://github.com/marmot-protocol/mdk) implementation with the MIP-01 and MIP-05 wire formats, adding VarInt encoding of TLS-style length prefixes and round-trip validation against MDK test vectors. [PR #2435](https://github.com/vitorpamplona/amethyst/pull/2435) adds MIP-00 KeyPackage Relay List support so invitees advertise which relays serve their KeyPackages, and [PR #2436](https://github.com/vitorpamplona/amethyst/pull/2436) closes the remaining admin-gate and media-handling gaps flagged by cross-client testing with [White Noise](https://github.com/marmot-protocol/whitenoise). Two correctness fixes land the same day: [PR #2466](https://github.com/vitorpamplona/amethyst/pull/2466) corrects MLS commit framing so encrypted welcomes serialize to the same bytes [mdk-core](https://github.com/marmot-protocol/mdk) produces, and [PR #2471](https://github.com/vitorpamplona/amethyst/pull/2471) resolves an outer-layer decryption bug that caused state divergence between Marmot co-admins. A second compliance pass in [PR #2477](https://github.com/vitorpamplona/amethyst/pull/2477) and [PR #2493](https://github.com/vitorpamplona/amethyst/pull/2493) closes additional commit-path and message-encryption gaps and adds a full MLS commit cryptography validator that checks signatures, key schedules, and welcome-message derivation against the reference vectors.
+
+Alongside the protocol work, [PR #2488](https://github.com/vitorpamplona/amethyst/pull/2488) ships `amy`, a command-line tool for Marmot and MLS group operations driven from Amethyst's implementation. Amy gives integrators a scriptable way to create groups, generate KeyPackages, simulate welcomes, and validate commits against a real Amethyst signer, which closes the biggest debugging gap for cross-client Marmot interop today.
+
+[PR #2468](https://github.com/vitorpamplona/amethyst/pull/2468) adds first-class [NIP-72](/en/topics/nip-72/) community creation and management. Users can author the kind `34550` community definition, add moderators and relay hints, submit posts with an `a` tag pointing at the community, and manage pending approvals through kind `4549` approval events. The feature closes a long-standing gap between Amethyst and [noStrudel](https://github.com/hzrd149/nostrudel) on community moderation. [PR #2458](https://github.com/vitorpamplona/amethyst/pull/2458) and [PR #2473](https://github.com/vitorpamplona/amethyst/pull/2473) add emoji-set support and a full [NIP-30](https://github.com/nostr-protocol/nips/blob/master/30.md) emoji-pack management UI so users can curate their own custom emoji libraries.
+
+[PR #2469](https://github.com/vitorpamplona/amethyst/pull/2469) wires [NIP-75](/en/topics/nip-75/) zap goals into the [NIP-53](/en/topics/nip-53/) Live Activities screen. Each live stream now carries a fundraising goal header with a progress bar, a one-tap zap button, and a top-zappers leaderboard. The leaderboard reads kind `9735` zap receipts bound to the stream's kind `30311` event and tallies them against the goal's `amount` target. [PR #2486](https://github.com/vitorpamplona/amethyst/pull/2486) rounds out the live-stream surface with a dedicated Live Streams feed screen, [PR #2491](https://github.com/vitorpamplona/amethyst/pull/2491) adds NIP-53 proof-of-agreement and event-builder helpers, and [PR #2461](https://github.com/vitorpamplona/amethyst/pull/2461) adds lowest-resolution HLS in feed, picture-in-picture playback, and automatic resolution selection in full screen.
+
+The most ambitious new surface is real-time audio. [PR #2494](https://github.com/vitorpamplona/amethyst/pull/2494) adds a [Media over QUIC](https://datatracker.ietf.org/group/moq/about/) transport client and audio-rooms support. MoQ's pub-sub model over QUIC fits live audio better than WebSocket relays because clients can subscribe to specific tracks and priorities and let the transport handle congestion. Paired with the new Public Chats screen in [PR #2487](https://github.com/vitorpamplona/amethyst/pull/2487), Amethyst now has an end-to-end surface for public audio rooms that sits alongside its Marmot encrypted messaging.
+
+On the discovery and reliability side, [PR #2485](https://github.com/vitorpamplona/amethyst/pull/2485) and [PR #2490](https://github.com/vitorpamplona/amethyst/pull/2490) add a Follow Packs discovery feed and wire curated follow sets into the default onboarding preference, giving new users a populated timeline on first launch. [PR #1983](https://github.com/vitorpamplona/amethyst/pull/1983) lands an always-on notification service for real-time relay connections so Marmot DMs and mentions arrive without the app being foregrounded, and [PR #2480](https://github.com/vitorpamplona/amethyst/pull/2480) adds on-demand HLS video caching with adaptive cache sizing.
+
+### TollGate v0.1.0 stabilizes pay-per-use internet over Nostr and Cashu
+
+[TollGate](https://github.com/OpenTollGate/tollgate) cut its [v0.1.0 release](https://github.com/OpenTollGate/tollgate/releases/tag/v0.1.0) on April 21, the first tagged snapshot of its specification set for pay-per-use network access. The protocol lets a device that can gate connectivity, such as a WiFi router, an Ethernet switch, or a Bluetooth tether, advertise pricing, accept [Cashu](/en/topics/cashu/) ecash tokens, and manage sessions through prepaid local tokens instead of accounts or subscriptions. A customer with a few sats in a local Cashu wallet can buy the next minute or megabyte of connectivity from any compatible TollGate on the network.
+
+The release pins three layers of the architecture. The protocol layer, defined in [TIP-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-01.md), specifies three base event shapes (Advertisement, Session, Notice), and [TIP-02](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-02.md) layers Cashu payments on top so a customer can redeem tokens from any mint the gate advertises. Above that sits the interface layer: [HTTP-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/HTTP-01.md) through HTTP-03 define a plain-HTTP surface for devices on restrictive operating systems, and [NOSTR-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/NOSTR-01.md) defines the Nostr-relay transport for clients that can open WebSockets. Finally, [WIFI-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/WIFI-01.md) covers the medium layer by describing the captive-portal routing for paying customers.
+
+The payment asset is a bearer token, so a customer can arrive with Cashu already in a local wallet and spend it immediately for the first minute of connectivity. Gates can also buy uplink from each other, so reach extends beyond a single operator. The new [TollGate topic page](/en/topics/tollgate/) covers the full layer stack.
+
+### nostream merges 53 PRs for NIP-45, NIP-62, compression, and query hardening
+
+[nostream](https://github.com/Cameri/nostream), the TypeScript relay implementation by Cameri, merged 53 PRs in a single week covering new NIP support, query performance, security hardening, and operational polish.
+
+On feature work, [PR #522](https://github.com/Cameri/nostream/pull/522) adds [NIP-45](/en/topics/nip-45/) `COUNT` support so clients can ask the relay how many events match a filter without fetching them, and [PR #544](https://github.com/Cameri/nostream/pull/544) adds [NIP-62](/en/topics/nip-62/) right-to-vanish to the advertised feature list. [PR #548](https://github.com/Cameri/nostream/pull/548) extends the filter schema to accept uppercase tag filters (`#A` through `#Z`) per the recent tag-case conventions, and [PR #514](https://github.com/Cameri/nostream/pull/514) adds gzip and xz compression to event import and export so operators can move large event dumps between nodes without extra tooling.
+
+Query performance and correctness land via [PR #534](https://github.com/Cameri/nostream/pull/534), which introduces a benchmarking harness and an optimization pass on the filter-to-SQL translation. [PR #524](https://github.com/Cameri/nostream/pull/524) fixes a whitelist/blacklist pubkey matching bug by replacing prefix matching with exact-match checks, [PR #553](https://github.com/Cameri/nostream/pull/553) adds a deterministic tie-breaker to `upsertMany` so concurrent inserts no longer race on equal `created_at` timestamps, and [PR #493](https://github.com/Cameri/nostream/pull/493) restricts the relay to trusting `X-Forwarded-For` only from configured trusted proxies. [PR #557](https://github.com/Cameri/nostream/pull/557) brings the relay to complete [NIP-11](/en/topics/nip-11/) relay information parity by aligning every advertised field with the current specification, including retention limits, authentication hints, and the trimmed optional-field set.
+
+## Shipping This Week
+
+### Primal Android ships Explore tab, NIP-05 verification, and audio player
+
+[Primal Android](https://github.com/PrimalHQ/primal-android-app) pushed 11 merged PRs on top of last week's feed redesign. [PR #1021](https://github.com/PrimalHQ/primal-android-app/pull/1021) introduces a new Explore tab built around popular users, follow packs, and curated feeds, and [PR #1015](https://github.com/PrimalHQ/primal-android-app/pull/1015) adds a feed editor that prepopulates from Primal's Advanced Search DSL. [PR #994](https://github.com/PrimalHQ/primal-android-app/pull/994) ships [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md) verification UI for profiles, and [PR #997](https://github.com/PrimalHQ/primal-android-app/pull/997) embeds an in-feed audio player that plays audio file attachments inline. [PR #1018](https://github.com/PrimalHQ/primal-android-app/pull/1018) adds [NIP-46](/en/topics/nip-46/) nostr-connect pairing from the wallet QR scanner, reusing the same camera path for signer pairing and wallet linking.
+
+### strfry adds Prometheus write-path metrics and fixes NIP-42 AUTH envelope
+
+[strfry](https://github.com/hoytech/strfry) shipped a batch of operator-facing improvements. [PR #194](https://github.com/hoytech/strfry/pull/194) adds a dedicated Prometheus write-path metrics exporter and a new connection gauge, and [PR #197](https://github.com/hoytech/strfry/pull/197) logs per-connection bytes up and down plus compression ratios for operators tracking bandwidth. [PR #192](https://github.com/hoytech/strfry/pull/192) promotes the hard-coded filter tag limit to a runtime-configurable option so operators can tune it without a recompile. On protocol correctness, [PR #201](https://github.com/hoytech/strfry/pull/201) changes [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) AUTH failure responses from a `NOTICE` message to the `OK` envelope the NIP actually specifies, which was a long-standing interop wart for auth-gated relays.
+
+### Shopstr hardens storefront security across 13 PRs
+
+[Shopstr](https://github.com/shopstr-eng/shopstr), the Nostr marketplace client, merged 13 PRs this week dominated by security fixes. [PR #434](https://github.com/shopstr-eng/shopstr/pull/434) closes a stored-JavaScript hole in storefront links that allowed seller-to-visitor script execution, [PR #417](https://github.com/shopstr-eng/shopstr/pull/417) escapes storefront policy HTML rendering to block reflected XSS, and [PR #418](https://github.com/shopstr-eng/shopstr/pull/418) closes an unauthenticated cached-event deletion API that allowed cross-user data removal. [PR #433](https://github.com/shopstr-eng/shopstr/pull/433) requires authentication for cached-message reads, [PR #419](https://github.com/shopstr-eng/shopstr/pull/419) secures storefront mutation and event-cache endpoints behind proper auth, and [PR #435](https://github.com/shopstr-eng/shopstr/pull/435) and [PR #414](https://github.com/shopstr-eng/shopstr/pull/414) fix two server-side request forgery findings from code scanning. On functional bugs, [PR #421](https://github.com/shopstr-eng/shopstr/pull/421) makes the failed-relay-publish queue safe against replay, [PR #425](https://github.com/shopstr-eng/shopstr/pull/425) repairs a broken wallet-events fetch, and [PR #392](https://github.com/shopstr-eng/shopstr/pull/392) revalidates stored cart discounts before checkout.
+
+### Nostria v3.1.26 through v3.1.28 add background music playback on Android
+
+[Nostria](https://github.com/nostria-app/nostria) cut six releases this week from [v3.1.22](https://github.com/nostria-app/nostria/releases/tag/v3.1.22) through [v3.1.28](https://github.com/nostria-app/nostria/releases/tag/v3.1.28). The headline change in [v3.1.26](https://github.com/nostria-app/nostria/releases/tag/v3.1.26) is Android background music playback: the app keeps itself alive while audio is playing, with media controls available in the notification bar and on the lock screen. Follow-up releases [v3.1.27](https://github.com/nostria-app/nostria/releases/tag/v3.1.27) and [v3.1.28](https://github.com/nostria-app/nostria/releases/tag/v3.1.28) harden that new media-service surface. [Newsletter #18](/en/newsletters/2026-04-15-newsletter/#nostria-v3119-through-v3121-add-local-ai-image-generation) covered the preceding v3.1.19 through v3.1.21 local-image-generation release.
+
+### Wisp v0.18.0-beta adds Normie Mode, For You feed, and NIP-29 group config
+
+[Wisp](https://github.com/barrydeen/wisp), the Android client that spun out of Amethyst, shipped [v0.18.0-beta](https://github.com/barrydeen/wisp/releases/tag/v0.18.0-beta) on April 16. The release targets users arriving from non-Bitcoin-native contexts: [PR #462](https://github.com/barrydeen/wisp/pull/462) adds a Normie Mode that surfaces fiat-denominated amounts throughout the app, and [PR #464](https://github.com/barrydeen/wisp/pull/464) overhauls onboarding with a topics picker and a first-post coach. [PR #469](https://github.com/barrydeen/wisp/pull/469) adds a For You feed that blends extended follows, trending events, and followed hashtags.
+
+On protocol work, [PR #471](https://github.com/barrydeen/wisp/pull/471) adds [NIP-29](/en/topics/nip-29/) group configuration for flags, invites, roles, and AUTH prompts, and [PR #478](https://github.com/barrydeen/wisp/pull/478) fixes an ordering bug so Wisp waits for [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) AUTH before issuing group `9021`, `9007`, and `9009` events and surfaces admin-side failures. [PR #481](https://github.com/barrydeen/wisp/pull/481) broadcasts notes to the [NIP-65](/en/topics/nip-65/) inbox relays of mentioned pubkeys so replies reach their targets even when the sender's and recipient's relay sets do not overlap.
+
+### NoorNote v0.8.4 adds Scheduled Posts and live stream zapping
+
+[NoorNote](https://github.com/77elements/noornote) shipped [v0.8.4](https://github.com/77elements/noornote/releases/tag/v0.8.4) and [v0.8.5](https://github.com/77elements/noornote/releases/tag/v0.8.5). The headline addition in v0.8.4 is a Scheduled Posts add-on: the app hands a fully signed event to a NoorNote-operated relay which publishes it at the scheduled moment, so private keys never leave the device. The same release adds one-tap zapping from live-stream cards, where the sats appear in the stream's chat overlay via [NIP-53](/en/topics/nip-53/), and keeps the wallet balance visible when the fiat-rate API is briefly unavailable. v0.8.5 fixes a timeline deduplication bug that caused duplicate posts on long Android scrolls.
+
+### topaz v0.0.2 ships a Nostr relay for Android
+
+[topaz](https://github.com/fiatjaf/topaz), a new Nostr relay that runs on Android phones from [fiatjaf](https://github.com/fiatjaf), published its [v0.0.2](https://github.com/fiatjaf/topaz/releases/tag/v0.0.2) release on 2026-04-17. The project is Kotlin-first and positions the phone as an always-available personal relay. At this stage the scope is narrow: a working relay in an installable Android package.
+
+### StableKraft v1.0.0 ships the first stable music-and-podcast PWA release
+
+[StableKraft](https://github.com/ChadFarrow/stablekraft-app) is a Next.js PWA for discovering, organizing, and streaming music pulled from podcast feeds, with Nostr for auth and social features and Lightning for V4V payments. It reached [v1.0.0](https://github.com/ChadFarrow/stablekraft-app/releases/tag/v1.0.0) on 2026-04-18. The same week tightened feed ingestion with a [15-minute OPML cache and illegal-XML stripping](https://github.com/ChadFarrow/stablekraft-app/commit/7ac90f6), and shrank the nightly reparse window from 720 hours to 24 hours in a [follow-up fix](https://github.com/ChadFarrow/stablekraft-app/commit/fbf337b) so newly added feeds self-heal faster.
+
+### NipLock ships a NIP-17-based password manager
+
+[NipLock](https://gitworkshop.dev/npub1z5jf78uhd68znuwwwu926th55rzd0wy8nd9clkr03cx22mwme0jqazk56h/relay.ngit.dev/passwd) is a password manager that stores and syncs credentials across devices using [NIP-17](/en/topics/nip-17/) gift-wrapped direct messages. Each password entry is a NIP-17 DM from the user's key to itself, so the same events replicate to any device that authenticates with the same key. Signing works with a raw `nsec`, browser extensions like [nos2x](https://github.com/fiatjaf/nos2x), or [Amber](https://github.com/greenart7c3/Amber) via [NIP-46](/en/topics/nip-46/), which keeps the master key off the client device.
+
+### flotilla-budabit polishes its NIP-34 repo surface
+
+The Budabit community's fork of [Flotilla](https://gitea.coracle.social/coracle/flotilla), [flotilla-budabit](https://github.com/Pleb5/flotilla-budabit), shipped a cluster of fixes to its NIP-34 git-over-nostr workflow. Updates this week [restore repo discussion controls](https://github.com/Pleb5/flotilla-budabit/commit/a6fb67e), [keep sticky repo tabs visible on detail pages](https://github.com/Pleb5/flotilla-budabit/commit/e2b891a), [load repo announcements from saved GRASP relays](https://github.com/Pleb5/flotilla-budabit/commit/43d5e9e), and [keep maintainer-applied patch status in sync](https://github.com/Pleb5/flotilla-budabit/commit/2dbb9f0). Staying close to upstream Flotilla, the fork prioritizes the repo view for Budabit community contributors.
+
+### rx-nostr 3.7.2 through 3.7.4 add default verifier and optional constructor args
+
+[rx-nostr](https://github.com/penpenpng/rx-nostr), the RxJS-based Nostr library, shipped [3.7.2](https://github.com/penpenpng/rx-nostr/releases/tag/rx-nostr%403.7.2), [3.7.3](https://github.com/penpenpng/rx-nostr/releases/tag/rx-nostr%403.7.3), and [3.7.4](https://github.com/penpenpng/rx-nostr/releases/tag/rx-nostr%403.7.4). [PR #192](https://github.com/penpenpng/rx-nostr/pull/192) adds a default Schnorr signature verifier so callers no longer have to wire one up manually, and a paired [crypto@3.1.6](https://github.com/penpenpng/rx-nostr/releases/tag/crypto%403.1.6) corrects a `@noble/curves` usage bug that was producing spurious verification failures. [PR #195](https://github.com/penpenpng/rx-nostr/pull/195) in 3.7.4 makes the arguments of `createRxNostr()` optional so quick integrations can instantiate the library with zero configuration.
+
+### Keep Android v1.0.0 ships with reproducible builds and zero trackers
+
+[Keep](https://github.com/privkeyio/keep-android), a Nostr-native password and secret manager, shipped [v1.0.0](https://github.com/privkeyio/keep-android/releases/tag/v1.0.0) on April 21 after a run of hardening PRs. [PR #241](https://github.com/privkeyio/keep-android/pull/241) adds a reproducible build recipe with a pinned and verified toolchain, [PR #248](https://github.com/privkeyio/keep-android/pull/248) swaps Google ML Kit for ZXing to remove a Google Play Services dependency, and [PR #252](https://github.com/privkeyio/keep-android/pull/252) publishes an [Exodus Privacy scan](https://reports.exodus-privacy.eu.org/en/) showing zero trackers on the v1.0.0 build. [PR #256](https://github.com/privkeyio/keep-android/pull/256) adds a `zapstore.yaml` manifest so the v1.0.0 APK can be distributed through [zapstore](https://zapstore.dev) without an intermediate publisher.
+
+### Flotilla 1.7.3 and 1.7.4 add kind-9 wrapping for richer NIP-29 rooms
+
+[Flotilla](https://gitea.coracle.social/coracle/flotilla), hodlbod's [NIP-29](/en/topics/nip-29/) groups client, shipped [1.7.3](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.3) and [1.7.4](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.4). The main protocol change is kind-9 wrapping of non-chat content types, announced in [hodlbod's release note](nostr:nevent1qvzqqqqqqypzp978pfzrv6n9xhq5tvenl9e74pklmskh4xw6vxxyp3j8qkke3cezqyvhwumn8ghj76rzwghxxmmjv93kcefwwdhkx6tpdshszrnhwden5te0dehhxtnvdakz7qgawaehxw309a5x7ervvfhkgtnrdaexzcmvv5h8xmmrd9skctcqyrrclae7mhmm5dnumwfzhg3fxu74a4hh24jd8pvn8v0hye9w3g6tuljtr85) and tracked against [NIP PR #2310](https://github.com/nostr-protocol/nips/pull/2310). Wrapping calendar events, polls, and other non-chat payloads in kind `9` preserves the room context when those objects are sent into a group, so clients can render the embedded object without losing which room it came from.
+
+The same release line adds polls, support for the Aegis URL scheme for [NIP-46](/en/topics/nip-46/) login, native share support for space invites, room mentions, mobile clipboard image paste, drafts, video in calls, and feed-pagination improvements. This is the first Flotilla release since [1.7.0 and 1.7.1](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.0), which [Newsletter #16](/en/newsletters/2026-04-01-newsletter/#flotilla-v170-adds-voice-rooms-and-email-login) covered for voice rooms and email login.
+
+### WoT Relay v0.2.1 migrates eventstore to LMDB
+
+[WoT Relay](https://github.com/bitvora/wot-relay), the web-of-trust-filtered relay by bitvora, shipped [v0.2.1](https://github.com/bitvora/wot-relay/releases/tag/v0.2.1) on 2026-04-22. [PR #97](https://github.com/bitvora/wot-relay/pull/97) migrates the eventstore to [LMDB](http://www.lmdb.tech/) and retunes the WoT bootstrap fetches so the relay builds its initial trust graph without exhausting upstream read budgets, and [PR #99](https://github.com/bitvora/wot-relay/pull/99) bumps `golang.org/x/crypto` to v0.45.0 for the corresponding security fixes. [PR #100](https://github.com/bitvora/wot-relay/pull/100) updates the advertised [NIP-11](/en/topics/nip-11/) software URL and version string for the release.
+
+### Formstr suite: Pollerama security pass, Forms i18n, Calendar RRULE support
+
+The Formstr suite merged 26 PRs across Pollerama, Formstr forms, and Nostr Calendar this week, with a clear security theme on the polling app and feature work on the rest.
+
+[Pollerama](https://pollerama.fun), the [nostr-polls](https://github.com/formstr-hq/nostr-polls) web app for creating and voting on Nostr polls, hardened its key handling. [PR #182](https://github.com/formstr-hq/nostr-polls/pull/182) expires cached direct messages on logout so a shared device does not leak prior-user state, [PR #175](https://github.com/formstr-hq/nostr-polls/pull/175) moves the local key to secure browser storage, and [PR #171](https://github.com/formstr-hq/nostr-polls/pull/171) guards `JSON.parse` of kind `0` profile content across every login path so a malformed profile cannot crash the session. On the product side, [PR #186](https://github.com/formstr-hq/nostr-polls/pull/186) wires HTTPS deep linking for `pollerama.fun` so shared poll URLs open the app directly, and [PR #169](https://github.com/formstr-hq/nostr-polls/pull/169) makes author names clickable in poll results.
+
+[Formstr](https://formstr.app), the [nostr-forms](https://github.com/formstr-hq/nostr-forms) suite for Nostr-native forms, broadened its input and onboarding surface. [PR #475](https://github.com/formstr-hq/nostr-forms/pull/475) adds audio and video URL support so a form can embed media directly, [PR #439](https://github.com/formstr-hq/nostr-forms/pull/439) introduces i18n to the web app, and [PR #466](https://github.com/formstr-hq/nostr-forms/pull/466) ships a Google Forms onboarding importer so existing form creators can migrate without rebuilding surveys. [PR #463](https://github.com/formstr-hq/nostr-forms/pull/463) closes a privacy leak by removing sensitive key logs from the browser console.
+
+[Nostr Calendar by Formstr](https://calendar.formstr.app) cut [v1.3.0](https://github.com/formstr-hq/nostr-calendar/releases/tag/v1.3.0) and [v1.4.0](https://github.com/formstr-hq/nostr-calendar/releases/tag/v1.4.0) on the same day, headlined by a proper recurrence-rule surface. [PR #107](https://github.com/formstr-hq/nostr-calendar/pull/107) adds multiple and custom RRULE support so events can repeat on complex schedules beyond the single-cadence case, and [PR #101](https://github.com/formstr-hq/nostr-calendar/pull/101) corrects a long-standing bug by interpreting floating RRULE dates as UTC per RFC 5545, which had been causing event-time drift across timezones. [PR #97](https://github.com/formstr-hq/nostr-calendar/pull/97) lets users add shared events to their calendar, [PR #86](https://github.com/formstr-hq/nostr-calendar/pull/86) introduces list-level notification preferences, and [PR #112](https://github.com/formstr-hq/nostr-calendar/pull/112) ships the reworked login and loading path that lands in v1.4.0. All three projects build on [NIP-52](/en/topics/nip-52/) calendar events and share a common login stack.
+
+### Also shipped: notedeck, nostr.blue, cliprelay, Captain's Log
+
+A handful of clients cut iterative releases without headline features. Damus's Rust desktop and mobile client [notedeck](https://github.com/damus-io/notedeck) published [v0.10.0-beta.4](https://github.com/damus-io/notedeck/releases/tag/v0.10.0-beta.4) with column-rendering and relay-pool fixes. The Dioxus-based Rust client [nostr.blue v0.8.6](https://github.com/patrickulrich/nostr.blue/releases/tag/v0.8.6) pulled in [Dioxus 0.7.5](https://github.com/patrickulrich/nostr.blue/commit/d90b4ff) and unblocked the Android build by [converting the native audio bridge](https://github.com/patrickulrich/nostr.blue/commit/4207f0c) to a `manganis::ffi` plugin. [cliprelay](https://github.com/tajava2006/cliprelay), a cross-device clipboard-sync tool that relays entries through Nostr, shipped [Desktop v0.0.3](https://github.com/tajava2006/cliprelay/releases/tag/desktop%2Fv0.0.3) and [Android v0.0.4](https://github.com/tajava2006/cliprelay/releases/tag/android%2Fv0.0.4), tightening the sync loop and dropping 32-bit Android variants. [Captain's Log](https://github.com/nodetec/comet) published three alpha builds whose most useful addition is sync-relay [liveness detection](https://github.com/nodetec/comet/releases/tag/alpha-95f47bd) so dropped sockets are replaced without user action.
+
+## In Development
+
+### whitenoise-rs refactors to session-scoped account views
+
+[whitenoise-rs](https://github.com/marmot-protocol/whitenoise-rs), the Rust daemon under the [Marmot](/en/topics/marmot/) client, merged 15 PRs advancing a multi-phase refactor from global singletons to per-account `AccountSession` views. The goal is to break one shared monolith into smaller per-account surfaces that are easier to reason about, test, and evolve without side effects leaking across the whole daemon.
+
+The foundation landed in [PR #743](https://github.com/marmot-protocol/whitenoise-rs/pull/743) with the `AccountSession` and `AccountManager` scaffolding, followed by scoped relay handles in [PR #753](https://github.com/marmot-protocol/whitenoise-rs/pull/753). Subsequent phases moved drafts and settings, message ops, group read and write, membership, push notifications, key-package reads, and group creation onto session-owned surfaces across [PRs #760 through #769](https://github.com/marmot-protocol/whitenoise-rs/pulls?q=is%3Apr+is%3Amerged+768+OR+763+OR+766). Phase 15 closed the loop in [PR #770](https://github.com/marmot-protocol/whitenoise-rs/pull/770), which rehomes event dispatch onto the session so each account consumes its own relay traffic without contention on a shared dispatcher.
+
+### White Noise app adds block/unblock UI, leave-group, and offline notices
+
+[White Noise](https://github.com/marmot-protocol/whitenoise), the [Marmot](/en/topics/marmot/) client, added the missing group-lifecycle controls. [PR #578](https://github.com/marmot-protocol/whitenoise/pull/578) ships the block and unblock UI on top of a block hook landed in [PR #573](https://github.com/marmot-protocol/whitenoise/pull/573), and [PR #571](https://github.com/marmot-protocol/whitenoise/pull/571) pairs with [PR #572](https://github.com/marmot-protocol/whitenoise/pull/572) to wire Rust-side `clear_chat`, `delete_chat`, and `leave_and_delete_group` into the app. [PR #569](https://github.com/marmot-protocol/whitenoise/pull/569) and [PR #576](https://github.com/marmot-protocol/whitenoise/pull/576) add offline notices on chat and settings screens so users know when the daemon cannot reach its relays. [PR #585](https://github.com/marmot-protocol/whitenoise/pull/585) narrows the broad "delete all key packages" path to a "delete legacy key packages" operation so a client migrating between KeyPackage formats no longer wipes its current keys along with the legacy ones.
+
+### MDK adds mixed-version invite support and SelfUpdate convergence
+
+[MDK](https://github.com/marmot-protocol/mdk), the [Marmot](/en/topics/marmot/) Development Kit, merged seven PRs. The thread running through the work is compatibility, keeping clients on slightly different Marmot versions able to invite each other, rotate their own state, and recover cleanly from malformed inputs.
+
+The headline fix is [PR #261](https://github.com/marmot-protocol/mdk/pull/261), which computes a group's `RequiredCapabilities` as the LCD of invitee capabilities and unblocks mixed-version invites between [Amethyst](https://github.com/vitorpamplona/amethyst) and [White Noise](https://github.com/marmot-protocol/whitenoise). [PR #264](https://github.com/marmot-protocol/mdk/pull/264) converges the SelfUpdate wire format across implementations; SelfUpdate is the control message a group member sends when rotating its own KeyPackage or capability state, so drift there silently breaks self-rotation across clients even when invites and welcomes still parse. On robustness, [PR #262](https://github.com/marmot-protocol/mdk/pull/262) parses invitee key packages before persisting the creator's signer so a malformed invitee cannot leave stray state, [PR #256](https://github.com/marmot-protocol/mdk/pull/256) fixes receiver-side admin depletion validation, and [PR #259](https://github.com/marmot-protocol/mdk/pull/259) prevents the in-memory storage backend from evicting security-critical state under pressure. [PR #265](https://github.com/marmot-protocol/mdk/pull/265) exposes a `group_required_proposals` accessor so clients can inspect the proposals that MUST land before the next commit is valid without reaching into MDK internals.
+
+### nostter adds NIP-44 encryption across people lists, bookmarks, and mutes
+
+[nostter](https://github.com/SnowCait/nostter) merged 10 PRs. [PR #2088](https://github.com/SnowCait/nostter/pull/2088) adds [NIP-44](/en/topics/nip-44/) encryption to mute lists, [PR #2089](https://github.com/SnowCait/nostter/pull/2089) adds it to bookmarks, and [PR #2090](https://github.com/SnowCait/nostter/pull/2090) adds it to people lists, all migrating away from [NIP-04](/en/topics/nip-04/) where applicable. [PR #2087](https://github.com/SnowCait/nostter/pull/2087) removes a legacy kind-30000 mute migration path now that the encrypted kind-10000 flow has stabilized.
+
+### zap.cooking ships Nourish scoring and a reusable comment thread
+
+[zap.cooking](https://github.com/zapcooking/frontend), the Nostr recipe client, merged 20 PRs this week. The headline feature is a new Nourish recipe-scoring module ([PR #317](https://github.com/zapcooking/frontend/pull/317), [PR #319](https://github.com/zapcooking/frontend/pull/319)) that rates recipes on nutritional axes. Alongside it, a four-stage refactor from [PR #299](https://github.com/zapcooking/frontend/pull/299) through [PR #302](https://github.com/zapcooking/frontend/pull/302) pulls the Comments module into a reusable `CommentThread` that can be dropped into any view. Recipe-side polish includes scaling in [PR #309](https://github.com/zapcooking/frontend/pull/309), a unified media-upload button in [PR #307](https://github.com/zapcooking/frontend/pull/307), and a profile Replies tab in [PR #310](https://github.com/zapcooking/frontend/pull/310).
+
+### ridestr extracts shared rider coordinator
+
+[ridestr](https://github.com/variablefate/ridestr), the decentralized ride-sharing app, merged 10 PRs refactoring its Compose screens into focused components and extracting rider and driver protocol logic into a shared `:common` coordinator module ([PR #70](https://github.com/variablefate/ridestr/pull/70)). [PR #60](https://github.com/variablefate/ridestr/pull/60) adds a kind `3189` driver-ping receiver for the Roadflare side of the app.
+
+### Blossom drafts a BUD-01 Sunset header for blob expiration
+
+[Blossom](https://github.com/hzrd149/blossom), hzrd149's protocol for storing blobs on HTTP servers keyed by SHA-256 hash, opened [PR #99](https://github.com/hzrd149/blossom/pull/99) to add a `Sunset` header to BUD-01. A server can use the header to advertise a future timestamp at which a blob will stop being served, so clients can plan around limited retention without first hitting a 404. Because the proposal uses standard [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html) semantics and is advisory only, a server is free to keep the blob longer or to honor the declared expiration on a best-effort basis.
+
+## New Projects
+
+### Forgesworn publishes a 29-repo cryptographic toolkit for Nostr
+
+[Forgesworn](https://github.com/forgesworn) shipped 29 open-source repositories over five days covering signing, identity, attestations, web-of-trust, and paid-API discovery on Nostr.
+
+The signing stack anchors on [nsec-tree](https://github.com/forgesworn/nsec-tree), a deterministic sub-identity derivation scheme that turns one master secret into unlimited unlinkable Nostr identities, and on [Heartwood](https://github.com/forgesworn/heartwood), an NIP-46 remote signer that runs on a Raspberry Pi with Tor on by default. [Sapwood](https://github.com/forgesworn/sapwood) adds a web management UI for shaping a Heartwood signer, and [heartwood-esp32](https://github.com/forgesworn/heartwood-esp32) ships a spike of the same signing token logic on a Heltec WiFi LoRa 32 board. [nsec-tree-cli](https://github.com/forgesworn/nsec-tree-cli) exposes the derivation, proof, and Shamir recovery flows for offline-first operation.
+
+On identity and trust, [Signet](https://github.com/forgesworn/signet) reached [v1.6.0](https://github.com/forgesworn/signet/releases/tag/v1.6.0) as a decentralized identity verification protocol for Nostr, with a QR-based pairing flow whose session pubkey is validated and pinned to the relay. [nostr-attestations](https://github.com/forgesworn/nostr-attestations) defines a single kind `31000` event (NIP-VA) for credentials, endorsements, vouches, provenance, licensing, and trust, consolidating what today is spread across ad-hoc event shapes. [nostr-veil](https://github.com/forgesworn/nostr-veil) builds a privacy-preserving web of trust on top: NIP-85 assertions backed by [LSAG ring signatures](https://github.com/forgesworn/ring-sig) on secp256k1, so a vouch can prove group membership without revealing which member issued it.
+
+The monetization side covers paid APIs over Lightning and Nostr. [toll-booth](https://github.com/forgesworn/toll-booth) is an L402 middleware for Express, Hono, Deno, Bun, and Cloudflare Workers that turns any API into a Lightning toll booth in one line, with [toll-booth-dvm](https://github.com/forgesworn/toll-booth-dvm) exposing the gated API as a [NIP-90](/en/topics/nip-90/) Data Vending Machine and [toll-booth-announce](https://github.com/forgesworn/toll-booth-announce) bridging to [402-announce](https://github.com/forgesworn/402-announce), which publishes kind `31402` parameterised replaceable events for HTTP 402 service discovery on Nostr. [402-indexer](https://github.com/forgesworn/402-indexer) is the crawler that picks those announcements up. The org also published a [29-NIP draft collection](https://github.com/forgesworn/nip-drafts) covering service coordination, trust, payments, disputes, key hierarchy, resource curation, and paid API discovery.
+
+Everything is TypeScript, zero-dependency where possible, and released through a new bash-only supply-chain-hardened tool called [anvil](https://github.com/forgesworn/anvil) with multi-runner reproducible-build attestation and OIDC trusted publishing. Several primitives in the set, including ring signatures, range proofs, and Shamir word shares, fill long-standing gaps in the Nostr library layer.
+
+### ShockWallet ships Nostr-native Lightning wallet sync and multi-node connections
+
+[ShockWallet](https://github.com/shocknet/wallet2) is a Lightning wallet that uses Nostr as its transport for connecting to self-custodial Lightning nodes. The app pairs with one or more [Lightning.Pub](https://github.com/shocknet/Lightning.Pub) nodes over Nostr via an `nprofile`, then signs payment authorizations end-to-end between the wallet and the node. The team shipped [PR #608](https://github.com/shocknet/wallet2/pull/608) on 2026-04-18 with a channels-dashboard UI pass, landing alongside an admin-invite-link QR flow for new PUB users ([PR #606](https://github.com/shocknet/wallet2/pull/606)) and a readability fix for the metrics dashboard ([PR #607](https://github.com/shocknet/wallet2/pull/607)).
+
+ShockWallet uses [NIP-78](/en/topics/nip-01/) application-specific data events for multi-device wallet state sync, so a user's wallet view stays consistent between a desktop browser and a phone without a centralized sync server. That puts it one layer below [NIP-47](/en/topics/nip-47/) (Nostr Wallet Connect): NIP-47 is the interface an app uses to ask an existing wallet to pay, while ShockWallet uses Nostr as the wallet's own account and session transport to the underlying Lightning node. Alongside the wallet, the team is pushing [CLINK](https://github.com/shocknet/CLINK), a Nostr-based session-pairing protocol for wallet-to-app connections, and maintaining a single TypeScript codebase that builds to web, Android, and iOS.
+
+### Nostrability issues migrate to git over Nostr after GitHub censorship
+
+[Nostrability](https://gitworkshop.dev/elsat@habla.news/nostrability/issues), elsat's interoperability tracker for Nostr clients and relays, is moving its issue workflow to git over Nostr after the Nostrability organization was taken down on GitHub with no response from GitHub support for two weeks. The migrated issue tracker now lives on GitWorkshop/ngit, where existing issues have been carried over and future interop reports can stay inside Nostr-native infrastructure.
+
+### nowhere encodes full websites into URL fragments and routes orders through Nostr
+
+[nowhere](https://github.com/5t34k/nowhere) is a new AGPL-3.0 project from [5t34k](https://github.com/5t34k) that serializes an entire site into the URL fragment after `#`, compresses it with a dictionary substitution pass and raw DEFLATE, and base64url-encodes the result. Because HTTP prohibits browsers from sending fragments to servers, the host that delivers the page never sees the content, and the site itself is never stored on a server. The project ships eight site types (event, fundraiser, store, petition, message, drop, art, forum), and each one can be cryptographically signed by its creator and password-encrypted at the URL.
+
+Five of the eight types are purely static, but store, forum, and petition need live communication for orders, posts, and signatures, and that traffic runs through Nostr relays using ephemeral keys with [NIP-44](/en/topics/nip-44/) encryption, so the relay stores events it cannot read from throwaway keys it cannot trace. A single-item store fits in roughly 120 characters, which means a nowhere link works as a printable QR code for offline use via the companion [nowhr.xyz](https://nowhr.xyz/install) reader. The repo is a pnpm workspace split into a standalone `codec` package, a Svelte 5 `web` component library with Nostr integration and payment handling, and the `nowhr` app shell at [nowhr.xyz](https://nowhr.xyz/app).
+
+### Small new surfaces: relayk.it and Brainstorm Search
+
+Two small projects worth a mention without a heavy changelog hook. [relayk.it](https://relayk.it), built by [sam](https://nostr.com/sam@relayk.it) from the Soapbox team, is a [Shakespeare](https://shakespeare.diy)-built relay-discovery client that runs entirely in the browser and points users toward active Nostr relays. [Brainstorm Search](https://brainstorm.world) ships as a single-page Nostr search UI focused on surfacing content across the network.
+
+## Protocol and Spec Work
+
+### NIP Updates
+
+Recent proposals and discussions in the [NIPs repository](https://github.com/nostr-protocol/nips):
+
+**Open PRs and Discussions:**
+
+- **[NIP-67](/en/topics/nip-67/): EOSE Completeness Hint** ([PR #2317](https://github.com/nostr-protocol/nips/pull/2317)): Proposes adding an optional third element to the [NIP-01](/en/topics/nip-01/) `EOSE` message so a relay can signal whether it has delivered every stored event matching the filter. Today, `EOSE` marks the boundary between stored and real-time events but carries no information about completeness: a client that asks for 500 events from a relay capped at 300 receives 300 events and an `EOSE`, with no way to distinguish "this is all of it" from "we stopped partway through." The proposal adds the form `["EOSE", "<sub_id>", "finish"]` when the relay has delivered all matches, and leaves the legacy two-element form as an unchanged no-claim case. The design is backwards-compatible, since relays that do not advertise support fall through to today's heuristic, and clients that know their relay supports it can stop paginating as soon as they see the positive signal.
+
+- **NIP-5D: Nostr Applets** ([PR #2303](https://github.com/nostr-protocol/nips/pull/2303)): Proposes a new kind for distributing interactive applets on Nostr. Where [NIP-5A](/en/topics/nip-5a/) covers static websites and the in-progress [NIP-5C](/en/topics/nip-5c/) covers executable WASM scrolls, NIP-5D targets the middle ground of self-contained front-end applets that run in a client's sandboxed iframe or WebView, addressable by Nostr event and updateable through a replaceable tag. Clients gain a way to ship third-party experiences (polls, calculators, mini-games) without each one wiring up a full plugin system. The open PR is actively iterating on the security model for message passing between the applet and host.
+
+- **NIP-29: Subgroups spec** ([PR #2319](https://github.com/nostr-protocol/nips/pull/2319)): Extends [NIP-29](/en/topics/nip-29/) relay-based groups with a subgroup hierarchy so a single group can host multiple parallel channels without spawning independent groups on the same relay. The PR defines a subgroup identifier that piggybacks on the existing `h` tag, specifies how kind `9000`-range moderation events scope to a subgroup, and clarifies how clients should render the hierarchy. The change preserves the single-`h`-tag shape for plain messages so older clients keep working in a subgrouped room.
+
+- **NIP-29: Explicit role permissions on kind 39003** ([PR #2316](https://github.com/nostr-protocol/nips/pull/2316)): Defines an explicit permissions schema on the [NIP-29](/en/topics/nip-29/) kind `39003` role event. Each role becomes a named set of granted operations (invite, add-user, remove-user, edit-metadata, delete-event, add-permission) with an optional time-bound expiry. Two NIP-29 relays running the same group can currently disagree on what a "moderator" can do, and clients have no way to reflect that difference to the user; the schema fixes that.
+
+- **NIP-11: access_control field for gated-relay discovery** ([PR #2318](https://github.com/nostr-protocol/nips/pull/2318)): Adds a new optional `access_control` object to the [NIP-11](/en/topics/nip-11/) relay information document, listing the relay's gating mode (open, invite, payment, allowlist) and any endpoint a client can use to request access. The field is advisory only, and it lets clients and directories filter gated relays out of public-discovery lists and show users upfront why a relay refuses writes.
+
+- **NIP-63a: Minimal Payment Gateway Descriptor** ([PR #2315](https://github.com/nostr-protocol/nips/pull/2315)): Covered in [Newsletter #18](/en/newsletters/2026-04-15-newsletter/#nip-updates). The PR continues to iterate on the kind `10164` payment-gateway-descriptor shape and on the field layout for per-tier subscription rules.
+
+- **NIP-XX: Agent Reputation Attestations (Kind 30085)** ([PR #2320](https://github.com/nostr-protocol/nips/pull/2320)): Proposes a kind `30085` addressable event for signed attestations about autonomous agents and services on Nostr, covering reliability, honest-advertising, and dispute-resolution claims. Each attestation points to a target pubkey, carries a score in a bounded range, and references the evidence event that justifies the score. The motivation is that [NIP-90](/en/topics/nip-90/) Data Vending Machines and other service markets currently lack a standard way for customers to publish verifiable feedback that other customers can filter on.
+
+- **NIP-TPLD: Transient Private Location Data** ([PR #2309](https://github.com/nostr-protocol/nips/pull/2309)): Continues from [Newsletter #18](/en/newsletters/2026-04-15-newsletter/#nip-updates) with further iteration on the kind `20411` ephemeral range, the per-recipient [NIP-44](/en/topics/nip-44/) encryption shape, and the `ttl` tag semantics for relay retention.
+
+- **marmot-ts 0.5.0 release PR** ([PR #70](https://github.com/marmot-protocol/marmot-ts/pull/70)): The pending release PR for `@internet-privacy/marmot-ts@0.5.0` bundles the first planned breaking changes in the TypeScript Marmot client. The release switches `KeyPackageManager` to support both legacy kind `443` and new kind `30443` events, removes the `KeyPackageStore` and group-state storage classes in favor of passing a generic key-value store directly into `KeyPackageManager` and `MarmotGroup`, and moves invite and group management onto `MarmotClient.invites` and `MarmotClient.groups`. Projects embedding marmot-ts directly will need constructor and storage-layer changes before they can pick the release up.
+
+## NIP Deep Dive: NIP-72 (Moderated Communities)
+
+[NIP-72](https://github.com/nostr-protocol/nips/blob/master/72.md) defines a model for topic-based communities on Nostr in which moderators curate a read view over otherwise-unrestricted writes. Unlike [NIP-29](/en/topics/nip-29/) relay-based groups, where the relay is the authority for both membership and moderation, a NIP-72 community lives in plain Nostr events and every relay that carries the relevant kinds can serve it. Anyone can post to a community, and only posts that a recognized moderator has approved appear in the community feed.
+
+A community is defined by a kind `34550` addressable event published by its creator. The event is a `d`-tagged replaceable event, so the creator can edit the community's metadata over time without losing the identity. The `d` tag is the community's stable slug, the `name`, `description`, `image`, and `rules` tags carry display metadata, and a series of `p` tags with a `"moderator"` marker list the pubkeys whose approvals count. Optional `relay` tags with an `author`, `requests`, or `approvals` marker hint at where each kind of event should be published and fetched from:
+
+```json
+{
+  "id": "f1e2d3c4b5a69788f1e2d3c4b5a69788f1e2d3c4b5a69788f1e2d3c4b5a69788",
+  "pubkey": "c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2",
+  "created_at": 1745280000,
+  "kind": 34550,
+  "tags": [
+    ["d", "bitcoin-devs"],
+    ["name", "Bitcoin Devs"],
+    ["description", "A moderated community for Bitcoin protocol discussion."],
+    ["image", "https://example.com/bitcoin-devs.png"],
+    ["p", "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876", "", "moderator"],
+    ["p", "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2", "", "moderator"],
+    ["relay", "wss://relay.example.com", "author"],
+    ["relay", "wss://relay.moderator.com", "approvals"]
+  ],
+  "content": "",
+  "sig": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+```
+
+A user submits a post by publishing any ordinary event (a kind `1` note, a kind `30023` long-form article, a kind `31922` calendar event, and so on) and adding an `a` tag whose value is the community's coordinate `34550:<creator_pubkey>:<slug>`. The post is a fully valid Nostr event on its own, and clients without NIP-72 support simply see a note addressed to a community-shaped coordinate. Community-aware clients filter their community view to posts that a recognized moderator has approved.
+
+Approval is a separate kind `4549` event published by a moderator. The approval references the submission by `e` tag, the submitter by `p` tag, and the community by `a` tag, and embeds the stringified submission event in the `content` field as a cached copy. That embedded copy keeps the approved post renderable even if the original author later deletes the source event.
+
+```json
+{
+  "id": "a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3",
+  "pubkey": "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876",
+  "created_at": 1745283600,
+  "kind": 4549,
+  "tags": [
+    ["a", "34550:c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2:bitcoin-devs"],
+    ["e", "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4"],
+    ["p", "e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5"],
+    ["k", "1"]
+  ],
+  "content": "{\"id\":\"b3c4d5e6...\",\"pubkey\":\"e4f5a6b7...\",\"kind\":1,\"content\":\"Question about sighash flags\",\"tags\":[[\"a\",\"34550:c3d2e1f0...:bitcoin-devs\"]],\"created_at\":1745283500,\"sig\":\"...\"}",
+  "sig": "bbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aa"
+}
+```
+
+The approval model has three useful properties. Moderation decisions are transparent: every approval is a signed Nostr event that anyone can fetch, so a skeptical user can audit which moderator approved which post and at what time. Moderation is non-exclusive: the same submission can be approved by multiple communities, and a post that one community rejects may be approved by another, because the `a` tag is just an address on a curated view. Moderation is reversible at the read layer: if a community deletes a moderator from its kind `34550` event, prior approvals from that moderator stop counting in clients that respect the current moderator list.
+
+The read side is where clients differ. Most community-aware clients render the feed by filtering for kind `4549` events tagged with the community's coordinate, deduplicating by the underlying event ID, and then rendering the embedded post. Some clients also fetch the submission events directly and use approvals only as a whitelist, which makes sense when approvals are incomplete or stale. A few clients (including [noStrudel](https://github.com/hzrd149/nostrudel) and, as of [PR #2468](https://github.com/vitorpamplona/amethyst/pull/2468) this week, [Amethyst](https://github.com/vitorpamplona/amethyst)) expose the pending submission queue to moderators as a separate view.
+
+Compared to [NIP-29](/en/topics/nip-29/) relay-based groups, the tradeoff is clear. NIP-72 communities work over any relay network with no special support, so the write path is portable, and moderation is visible and forkable. A submission is public the moment it is published, and unapproved posts are hidden at the client-render layer. For spaces where spam must stay off the wire entirely, NIP-29 is the better fit. For public topic communities where approvals function more like a curated front page than a gate, NIP-72 fits better.
+
+## NIP Deep Dive: NIP-57 (Zaps)
+
+[NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) defines zaps, a way to attach Lightning payments to Nostr identities and events and to publish a verifiable receipt of payment back onto relays. A zap proves that a specific sender paid a specific amount to a specific recipient for a specific target, and the proof is readable by any Nostr client without trusting the sender's word. The spec reaches across three systems (LNURL, Lightning, and Nostr) and pins down how each of them must cooperate.
+
+The flow has four actors. A sender's client discovers the recipient's LNURL endpoint from either the recipient's kind `0` profile metadata (`lud06` or `lud16` field) or a `zap` tag on the event being zapped. That client then signs a kind `9734` zap request event describing the intended payment and posts it to the recipient's LNURL callback, not to relays. On the other side, the recipient's LNURL server validates the request, returns a Lightning invoice whose description hash commits to the stringified request event, and, once the sender pays, publishes a kind `9735` zap receipt to the relay set the sender requested.
+
+A zap request (kind `9734`) is a signed event that declares the payment's intent. The critical fields are a `p` tag with the recipient pubkey, an optional `e` or `a` tag identifying the event or addressable content being zapped, an `amount` tag in millisats, and a `relays` tag listing where the receipt should be published. The `content` carries an optional sender-supplied message that accompanies the zap. A `k` tag records the target kind so a consumer can filter zaps by the type of content they fund:
+
+```json
+{
+  "id": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "pubkey": "a5b4c3d2e1f09876a5b4c3d2e1f09876a5b4c3d2e1f09876a5b4c3d2e1f09876",
+  "created_at": 1745280000,
+  "kind": 9734,
+  "tags": [
+    ["p", "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876"],
+    ["e", "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4"],
+    ["amount", "21000"],
+    ["relays", "wss://relay.damus.io", "wss://nos.lol", "wss://relay.nostr.band"],
+    ["k", "1"]
+  ],
+  "content": "great post",
+  "sig": "ccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbcc"
+}
+```
+
+The zap receipt (kind `9735`) is published by the recipient's wallet server after payment confirmation. It is not signed by the sender; it is signed by the wallet server using the `nostrPubkey` that the recipient advertised in their LNURL response. A valid receipt carries the stringified zap request in the `description` tag, the paid invoice in the `bolt11` tag, and a `preimage` tag proving the invoice was settled:
+
+```json
+{
+  "id": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "pubkey": "e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0",
+  "created_at": 1745280060,
+  "kind": 9735,
+  "tags": [
+    ["p", "d7e3a4b9c1f2e8d6a5b4c3d2e1f09876d7e3a4b9c1f2e8d6a5b4c3d2e1f09876"],
+    ["P", "a5b4c3d2e1f09876a5b4c3d2e1f09876a5b4c3d2e1f09876a5b4c3d2e1f09876"],
+    ["e", "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4"],
+    ["bolt11", "lnbc210n1pj...bolt11invoicestring"],
+    ["description", "{\"id\":\"c1d2e3f4...\",\"pubkey\":\"a5b4c3d2...\",\"kind\":9734,\"content\":\"great post\",\"tags\":[...]}"],
+    ["preimage", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
+  ],
+  "content": "",
+  "sig": "ddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccdd"
+}
+```
+
+The validation rule is where NIP-57 earns its trust guarantees. A client that displays a kind `9735` receipt as a zap should verify four things: the receipt's signature matches the `nostrPubkey` advertised in the recipient's LNURL response, the `bolt11` invoice amount matches the `amount` tag in the embedded zap request, the invoice's description hash commits to the stringified zap request, and the `preimage` hashes to the invoice's `payment_hash`. A receipt that fails any of these checks is only a claim of payment, not proof of it. Clients that render tallied zap counts without performing these checks are trivially spoofable by an attacker who publishes forged kind `9735` events.
+
+Private zaps add a confidentiality layer on top. A sender can encrypt the zap request's `content` for the recipient and include an `anon` tag on the outer zap request, so the relay network sees the payment target but cannot read the attached note. Some clients go one step further and generate a fresh ephemeral keypair for the zap request itself, so the receipt still proves a payment happened but the recipient cannot link the zap back to the sender's long-lived pubkey. That "anonymous zap" pattern is stronger than a plain private zap, where the message is hidden but the sender key can still be visible in the request path.
+
+NIP-57 also underpins the zap-goal system specified in [NIP-75](/en/topics/nip-75/). A goal is a kind `9041` event that declares a target amount and a relay set where receipts count, and any zap receipt bound to the goal's event ID contributes to its progress. Clients tally goal progress by summing the validated `bolt11` amounts of matched kind `9735` events. [Amethyst](https://github.com/vitorpamplona/amethyst)'s [PR #2469](https://github.com/vitorpamplona/amethyst/pull/2469) this week wires goals into the [NIP-53](/en/topics/nip-53/) Live Activities screen and renders a top-zappers leaderboard from the same receipts.
+
+Zap splits are defined in an appendix to the NIP. A recipient can publish a kind `0` profile with multiple `zap` tags, each carrying a weight, so a single zap payment is divided among several pubkeys according to the published weights. Content creators, collaborators, and platform fee recipients can all be paid atomically from a single sender-signed zap request. Several clients, including [Amethyst](https://github.com/vitorpamplona/amethyst), [Damus](https://github.com/damus-io/damus), and [noStrudel](https://github.com/hzrd149/nostrudel), implement split-paying end-to-end.
+
+---
+
+That's it for this week. If you're building something or have news to share, DM us on Nostr or find us at [nostrcompass.org](https://nostrcompass.org).

--- a/content/en/topics/cashu.md
+++ b/content/en/topics/cashu.md
@@ -34,6 +34,7 @@ Cashu integrates with Nostr in several ways:
 - **Escrow**: HTLC-based payment escrow for services like ridesharing
 - **Wallets**: Nostr-native wallets store encrypted Cashu tokens on relays
 - **[NIP-87](/en/topics/nip-87/)**: Mint discovery and reviews via Nostr
+- **[TollGate](/en/topics/tollgate/)**: Pay-per-use network access protocol that accepts Cashu ecash tokens for connectivity, defined in [TIP-02](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-02.md) as of the [v0.1.0 release](https://github.com/OpenTollGate/tollgate/releases/tag/v0.1.0)
 
 ## Tradeoffs
 
@@ -52,7 +53,9 @@ In practice, users often need the same mint, or they need a swap or bridge betwe
 **Mentioned in:**
 - [Newsletter #7](/en/newsletters/2026-01-28-newsletter/)
 - [Newsletter #11](/en/newsletters/2026-02-25-newsletter/)
+- [Newsletter #19: TollGate v0.1.0](/en/newsletters/2026-04-22-newsletter/#tollgate-v010-stabilizes-pay-per-use-internet-over-nostr-and-cashu)
 
 **See also:**
 - [NIP-60: Cashu Wallet](/en/topics/nip-60/)
 - [NIP-87: Cashu Mint Recommendations](/en/topics/nip-87/)
+- [TollGate](/en/topics/tollgate/)

--- a/content/en/topics/marmot.md
+++ b/content/en/topics/marmot.md
@@ -22,17 +22,28 @@ That division of labor is the useful insight. Nostr solves identity and transpor
 
 ## Implementation Status
 
-The protocol remains experimental, but it now has multiple implementations and active application use. MDK is the main Rust reference stack, `marmot-ts` brings the model to TypeScript, and applications such as White Noise, Pika, and Vector have been using Marmot-compatible components.
+The protocol remains experimental, but it now has multiple implementations and active application use. [MDK](https://github.com/marmot-protocol/mdk) is the main Rust reference stack, [marmot-ts](https://github.com/marmot-protocol/marmot-ts) brings the model to TypeScript, and applications such as [White Noise](https://github.com/marmot-protocol/whitenoise), [Amethyst](https://github.com/vitorpamplona/amethyst), Pika, and Vector have been using Marmot-compatible components.
 
 Recent work has focused on hardening and interop. Audit-driven fixes landed in early 2026, and MIP-03 introduced deterministic commit resolution so clients can converge when concurrent group state changes race across relays.
+
+In April 2026, Amethyst brought its embedded MDK into line with the MIP-01 and MIP-05 wire formats: [PR #2462](https://github.com/vitorpamplona/amethyst/pull/2462) added VarInt encoding of TLS-style length prefixes and round-trip validation against MDK test vectors, [PR #2435](https://github.com/vitorpamplona/amethyst/pull/2435) added MIP-00 KeyPackage Relay List support, and [PR #2436](https://github.com/vitorpamplona/amethyst/pull/2436) closed remaining admin-gate and media-handling gaps flagged by cross-client testing against White Noise. [PR #2466](https://github.com/vitorpamplona/amethyst/pull/2466) corrected MLS commit framing so encrypted welcome bytes match mdk-core output, and [PR #2471](https://github.com/vitorpamplona/amethyst/pull/2471) fixed an outer-layer decryption bug that caused state divergence between co-admins. Follow-up [PR #2493](https://github.com/vitorpamplona/amethyst/pull/2493) adds comprehensive MLS commit cryptography validation, and [PR #2488](https://github.com/vitorpamplona/amethyst/pull/2488) ships `amy`, a CLI interface for Marmot and MLS group operations driven from Amethyst's implementation.
+
+MDK landed [PR #261](https://github.com/marmot-protocol/mdk/pull/261) to compute a group's `RequiredCapabilities` as the LCD of invitee capabilities (unblocking mixed-version invites between Amethyst and White Noise), [PR #262](https://github.com/marmot-protocol/mdk/pull/262) to parse invitee key packages before persisting the creator's signer, [PR #264](https://github.com/marmot-protocol/mdk/pull/264) to converge the SelfUpdate wire format across implementations, and [PR #265](https://github.com/marmot-protocol/mdk/pull/265) to expose a `group_required_proposals` accessor.
+
+[whitenoise-rs](https://github.com/marmot-protocol/whitenoise-rs) is in the middle of a multi-phase refactor from global singletons to per-account `AccountSession` views: [PR #743](https://github.com/marmot-protocol/whitenoise-rs/pull/743) established the `AccountSession` and `AccountManager` scaffolding, and follow-on phases have migrated relay handles, drafts and settings, message ops, group read and write, membership, push notifications, key-package reads, group creation, and, as of [PR #770](https://github.com/marmot-protocol/whitenoise-rs/pull/770), session-scoped event dispatch. [marmot-ts PR #68](https://github.com/marmot-protocol/marmot-ts/pull/68) migrates the TypeScript client to addressable kind `30443` key packages.
 
 ---
 
 **Primary sources:**
 - [Marmot Protocol Repository](https://github.com/marmot-protocol/marmot)
 - [MLS Protocol](https://messaginglayersecurity.rocks/)
-- [Marmot Development Kit](https://github.com/marmot-protocol/mdk)
+- [Marmot Development Kit (MDK)](https://github.com/marmot-protocol/mdk)
 - [marmot-ts](https://github.com/marmot-protocol/marmot-ts)
+- [whitenoise-rs](https://github.com/marmot-protocol/whitenoise-rs)
+- [White Noise client](https://github.com/marmot-protocol/whitenoise)
+- [Amethyst PR #2462](https://github.com/vitorpamplona/amethyst/pull/2462) - MIP-01/MIP-05 wire format alignment
+- [Amethyst PR #2435](https://github.com/vitorpamplona/amethyst/pull/2435) - MIP-00 KeyPackage Relay List
+- [Amethyst PR #2488](https://github.com/vitorpamplona/amethyst/pull/2488) - Amy CLI
 
 **Mentioned in:**
 - [Newsletter #1: News](/en/newsletters/2025-12-17-newsletter/#news)
@@ -40,6 +51,9 @@ Recent work has focused on hardening and interop. Audit-driven fixes landed in e
 - [Newsletter #4](/en/newsletters/2026-01-07-newsletter/)
 - [Newsletter #7](/en/newsletters/2026-01-28-newsletter/)
 - [Newsletter #12](/en/newsletters/2026-03-04-newsletter/)
+- [Newsletter #19: Amethyst MIP compliance](/en/newsletters/2026-04-22-newsletter/#amethyst-ships-marmot-mip-compliance-nip-72-communities-and-live-stream-zap-goals)
+- [Newsletter #19: MDK interop work](/en/newsletters/2026-04-22-newsletter/#mdk-adds-mixed-version-invite-support-and-selfupdate-wire-format-convergence)
+- [Newsletter #19: whitenoise-rs session refactor](/en/newsletters/2026-04-22-newsletter/#whitenoise-rs-refactors-to-session-scoped-account-views)
 
 **See also:**
 - [MLS (Message Layer Security)](/en/topics/mls/)

--- a/content/en/topics/nip-01.md
+++ b/content/en/topics/nip-01.md
@@ -65,6 +65,7 @@ Two details cause many implementation bugs. First, clients should treat relay re
 
 **Mentioned in:**
 - [Newsletter #1: NIP Deep Dive](/en/newsletters/2025-12-17-newsletter/#nip-deep-dive-nip-01-and-nip-19)
+- [Newsletter #19: NIP-67 EOSE completeness hint proposal](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [NIP-19: Bech32-Encoded Entities](/en/topics/nip-19/)

--- a/content/en/topics/nip-04.md
+++ b/content/en/topics/nip-04.md
@@ -49,6 +49,7 @@ Legacy clients and signers still expose NIP-04 encrypt/decrypt methods because o
 **Mentioned in:**
 - [Newsletter #4: NIP Deep Dive](/en/newsletters/2026-01-07-newsletter/#nip-04-encrypted-direct-messages-legacy)
 - [Newsletter #3: December Recap](/en/newsletters/2025-12-31-newsletter/#december-recap-five-years-of-nostr-decembers)
+- [Newsletter #19: nostter NIP-44 migration](/en/newsletters/2026-04-22-newsletter/#nostter-adds-nip-44-encryption-across-people-lists-bookmarks-and-mutes)
 
 **See also:**
 - [NIP-44: Encrypted Payloads](/en/topics/nip-44/)

--- a/content/en/topics/nip-11.md
+++ b/content/en/topics/nip-11.md
@@ -38,6 +38,12 @@ This distinction matters for relay selection. A relay may advertise NIP-50 searc
 
 The specification has been trimmed over time. Older optional fields such as `software`, `version`, privacy policy details, and retention metadata were removed after years of weak adoption. That makes current NIP-11 documents smaller and more realistic, but it also means clients should not expect rich policy metadata from relays.
 
+[PR #2318](https://github.com/nostr-protocol/nips/pull/2318) proposes adding an optional `access_control` object to the relay information document, listing the relay's gating mode (open, invite, payment, allowlist) and any endpoint a client can use to request access. The field is advisory only, intended to let clients and directories filter gated relays out of public-discovery lists and show users upfront why a relay refuses writes.
+
+## Implementations
+
+- [nostream PR #557](https://github.com/Cameri/nostream/pull/557) brings nostream to complete NIP-11 relay info parity.
+
 ---
 
 **Primary sources:**
@@ -45,10 +51,13 @@ The specification has been trimmed over time. Older optional fields such as `sof
 - [PR #1764](https://github.com/nostr-protocol/nips/pull/1764) - relay identity field update
 - [PR #1946](https://github.com/nostr-protocol/nips/pull/1946) - cleanup of rarely used fields
 - [PR #2231](https://github.com/nostr-protocol/nips/pull/2231) - removal of deprecated fields
+- [PR #2318](https://github.com/nostr-protocol/nips/pull/2318) - `access_control` field for gated-relay discovery
+- [nostream PR #557](https://github.com/Cameri/nostream/pull/557) - Complete NIP-11 relay info parity
 
 **Mentioned in:**
 - [Newsletter #1: NIP Updates](/en/newsletters/2025-12-17-newsletter/#nip-updates)
 - [Newsletter #13: NIP Updates](/en/newsletters/2026-03-11-newsletter/#nip-updates)
+- [Newsletter #19: NIP Updates (`access_control` proposal)](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [NIP-66: Relay Discovery and Liveness Monitoring](/en/topics/nip-66/)

--- a/content/en/topics/nip-17.md
+++ b/content/en/topics/nip-17.md
@@ -62,6 +62,7 @@ NIP-17 also defines inbox relay lists for private messaging. Clients can publish
 - [Newsletter #3: Notable Code Changes](/en/newsletters/2025-12-31-newsletter/#shopstr-marketplace)
 - [Newsletter #5: News](/en/newsletters/2026-01-13-newsletter/#news)
 - [Newsletter #13: Vector](/en/newsletters/2026-03-11-newsletter/#vector-v032-ships-nip-77-negentropy-sync-and-mls-improvements)
+- [Newsletter #19: NipLock password manager](/en/newsletters/2026-04-22-newsletter/#niplock-ships-a-nip-17-based-password-manager)
 
 **See also:**
 - [NIP-04: Encrypted Direct Messages (Deprecated)](/en/topics/nip-04/)

--- a/content/en/topics/nip-21.md
+++ b/content/en/topics/nip-21.md
@@ -1,0 +1,48 @@
+---
+title: "NIP-21: nostr: URI Scheme"
+date: 2026-04-22
+draft: false
+categories:
+  - Protocol
+  - Interoperability
+---
+
+NIP-21 defines the `nostr:` URI scheme, a standard way for applications, websites, and operating systems to register interest in opening Nostr identifiers such as `npub`, `nprofile`, `nevent`, and `naddr` through whichever Nostr client the user has registered as a handler.
+
+## How It Works
+
+A `nostr:` URI is the scheme prefix followed by any of the [NIP-19](/en/topics/nip-19/) bech32 identifiers except `nsec`. Clients and operating systems treat the scheme the same way they treat `mailto:` or `tel:`: registering as a handler lets the user click a `nostr:` link anywhere in the system and have it open in their Nostr client of choice.
+
+Examples from the specification:
+
+- `nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9` points to a user profile
+- `nostr:nprofile1...` points to a user profile with relay hints bundled in
+- `nostr:nevent1...` points to a specific event with relay hints
+- `nostr:naddr1...` points to a parameterised replaceable event (such as a long-form article)
+
+## Linking HTML Pages to Nostr Entities
+
+NIP-21 also specifies two useful `<link>` conventions for web pages that correspond to Nostr entities. A page that serves the same content as a Nostr event (for example a blog post rendered from a [NIP-23](/en/topics/nip-23/) `kind:30023` article) can include a `<link rel="alternate">` pointing at the Nostr URI. A profile page can include a `<link rel="me">` or `<link rel="author">` pointing at an `nprofile` to assert Nostr-based authorship.
+
+## Why It Matters
+
+The scheme is the interoperability layer that lets any Nostr identifier become a working link outside of a single client's UI. Browser extensions, mobile OS handlers, and desktop shells can all route `nostr:` URIs to whichever client the user has installed, which makes it possible to share a profile or event by pasting a URI anywhere without losing the ability to open it in a Nostr-native way.
+
+## Implementations
+
+Support for `nostr:` URIs is broad across the client ecosystem, including the major web, mobile, and desktop Nostr clients. Browser extensions such as [nos2x](https://github.com/fiatjaf/nos2x) and [Alby](https://github.com/getAlby/lightning-browser-extension) handle URI registration on desktop browsers.
+
+---
+
+**Primary sources:**
+
+- [NIP-21 Specification](https://github.com/nostr-protocol/nips/blob/master/21.md)
+
+**Mentioned in:**
+
+- [Newsletter #19: Nostrability migrates to NIP-34](/en/newsletters/2026-04-22-newsletter/#nostrability-migrates-to-nip-34-and-opens-19-per-nip-interop-trackers)
+
+**See also:**
+
+- [NIP-19: bech32-encoded entities](/en/topics/nip-19/)
+- [NIP-23: Long-form content](/en/topics/nip-23/)

--- a/content/en/topics/nip-29.md
+++ b/content/en/topics/nip-29.md
@@ -36,6 +36,17 @@ That makes migration and forking possible, but not automatic. The same group id 
 - Group state is reconstructed from moderation history, while 39000-series relay events are informative snapshots of that state
 - Timeline `previous` references are there to prevent out-of-context rebroadcasting across relay forks, not just to improve UI threading
 
+## Recent Spec Work
+
+- [PR #2310](https://github.com/nostr-protocol/nips/pull/2310) and hodlbod's [Flotilla 1.7.3/1.7.4 release notes](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.4) propose kind-9 wrapping of non-chat content types (calendar events, polls, other payloads) so the room context is preserved when those objects are sent into a group.
+- [PR #2319](https://github.com/nostr-protocol/nips/pull/2319) extends the spec with a subgroup hierarchy so a single group can host multiple parallel channels without spawning independent groups on the same relay; the subgroup identifier piggybacks on the existing `h` tag, preserving single-`h`-tag messages for older clients.
+- [PR #2316](https://github.com/nostr-protocol/nips/pull/2316) defines explicit permissions on the kind `39003` role event so each role becomes a named set of granted operations (invite, add-user, remove-user, edit-metadata, delete-event, add-permission) with an optional time-bound expiry.
+
+## Implementations
+
+- [Flotilla](https://gitea.coracle.social/coracle/flotilla) is hodlbod's primary NIP-29 client; [1.7.3](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.3) and [1.7.4](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.4) shipped kind-9 wrapping, polls, [NIP-46](/en/topics/nip-46/) login via the Aegis URL scheme, native share support for space invites, room mentions, mobile clipboard image paste, drafts, and video in calls.
+- [Wisp](https://github.com/barrydeen/wisp) added NIP-29 group configuration for flags, invites, roles, and AUTH prompts in [PR #471](https://github.com/barrydeen/wisp/pull/471) and hardened AUTH sequencing before group `9021`, `9007`, and `9009` events in [PR #478](https://github.com/barrydeen/wisp/pull/478).
+
 ---
 
 **Primary sources:**
@@ -43,6 +54,11 @@ That makes migration and forking possible, but not automatic. The same group id 
 - [PR #2106](https://github.com/nostr-protocol/nips/pull/2106) - Clarified `private`, `closed`, and `hidden`
 - [PR #2190](https://github.com/nostr-protocol/nips/pull/2190) - Clarified relay URL as the relay key
 - [PR #2111](https://github.com/nostr-protocol/nips/pull/2111) - Added `unallowpubkey` and `unbanpubkey`
+- [PR #2310](https://github.com/nostr-protocol/nips/pull/2310) - Kind-9 wrapping for non-chat content
+- [PR #2319](https://github.com/nostr-protocol/nips/pull/2319) - Subgroups spec
+- [PR #2316](https://github.com/nostr-protocol/nips/pull/2316) - Explicit role permissions on kind 39003
+- [Flotilla 1.7.4](https://gitea.coracle.social/coracle/flotilla/src/tag/1.7.4)
+- [Wisp PR #471](https://github.com/barrydeen/wisp/pull/471) - NIP-29 group configuration
 
 **Mentioned in:**
 - [Newsletter #2: NIP Updates](/en/newsletters/2025-12-24-newsletter/#nip-updates)
@@ -50,6 +66,9 @@ That makes migration and forking possible, but not automatic. The same group id 
 - [Newsletter #6: NIP Updates](/en/newsletters/2026-01-21-newsletter/#nip-updates)
 - [Newsletter #11: NIP Updates](/en/newsletters/2026-02-25-newsletter/#nip-updates)
 - [Newsletter #12: NIP Updates](/en/newsletters/2026-03-04-newsletter/#nip-updates)
+- [Newsletter #19: Flotilla 1.7.3/1.7.4](/en/newsletters/2026-04-22-newsletter/#flotilla-173-and-174-add-kind-9-wrapping-for-richer-nip-29-rooms)
+- [Newsletter #19: Wisp NIP-29 config](/en/newsletters/2026-04-22-newsletter/#wisp-v0180-beta-adds-normie-mode-for-you-feed-and-nip-29-group-config)
+- [Newsletter #19: NIP Updates (subgroups, role permissions)](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [NIP-11: Relay Information Document](/en/topics/nip-11/)

--- a/content/en/topics/nip-44.md
+++ b/content/en/topics/nip-44.md
@@ -70,6 +70,8 @@ NIP-44 revision 3 was merged in December 2023 following an independent Cure53 se
 - [Newsletter #3: December 2024](/en/newsletters/2025-12-31-newsletter/#december-2024-protocol-advancement)
 - [Newsletter #12: Marmot](/en/newsletters/2026-03-04-newsletter/#marmot-development-kit-ships-first-public-release)
 - [Newsletter #13: Vector](/en/newsletters/2026-03-11-newsletter/#vector-v032-ships-nip-77-negentropy-sync-and-mls-improvements)
+- [Newsletter #19: nostter NIP-44 migration](/en/newsletters/2026-04-22-newsletter/#nostter-adds-nip-44-encryption-across-people-lists-bookmarks-and-mutes)
+- [Newsletter #19: nowhere encrypts Nostr traffic](/en/newsletters/2026-04-22-newsletter/#nowhere-encodes-full-websites-into-url-fragments-and-routes-orders-through-nostr)
 
 **See also:**
 - [NIP-04: Encrypted Direct Messages (deprecated)](/en/topics/nip-04/)

--- a/content/en/topics/nip-45.md
+++ b/content/en/topics/nip-45.md
@@ -47,14 +47,22 @@ Follower counts, reaction counts, and reply counts are the main use cases. Witho
 
 ---
 
+## Implementations
+
+- [nostream](https://github.com/Cameri/nostream) added `COUNT` support in [PR #522](https://github.com/Cameri/nostream/pull/522), letting clients ask how many events match a filter without fetching them.
+
+---
+
 **Primary sources:**
 - [NIP-45: Event Counting](https://github.com/nostr-protocol/nips/blob/master/45.md)
 - [PR #1561: HyperLogLog Relay Response](https://github.com/nostr-protocol/nips/pull/1561)
+- [nostream PR #522](https://github.com/Cameri/nostream/pull/522) - NIP-45 COUNT support
 
 **Mentioned in:**
 - [Newsletter #9: NIP Deep Dive](/en/newsletters/2026-02-11-newsletter/#nip-deep-dive-nip-45-event-counting-and-hyperloglog)
 - [Newsletter #9: NIP Updates](/en/newsletters/2026-02-11-newsletter/#nip-updates)
 - [Newsletter #12: Five Years of Nostr Februaries](/en/newsletters/2026-03-04-newsletter/)
+- [Newsletter #19: nostream NIP-45 support](/en/newsletters/2026-04-22-newsletter/#nostream-merges-53-prs-for-nip-45-nip-62-compression-and-query-hardening)
 
 **See also:**
 - [NIP-11: Relay Information Document](/en/topics/nip-11/)

--- a/content/en/topics/nip-46.md
+++ b/content/en/topics/nip-46.md
@@ -49,6 +49,9 @@ The `switch_relays` method exists so the signer can move the session to a differ
 - [Newsletter #3: December Recap](/en/newsletters/2025-12-31-newsletter/#december-recap-five-years-of-nostr-decembers)
 - [Newsletter #4: Primal Android Becomes a Full Signing Hub](/en/newsletters/2026-01-07-newsletter/#primal-android-becomes-a-full-signing-hub)
 - [Newsletter #12: NDK Collaborative Events and NIP-46 Timeout](/en/newsletters/2026-03-04-newsletter/#ndk-collaborative-events-and-nip-46-timeout)
+- [Newsletter #19: NipLock signer support](/en/newsletters/2026-04-22-newsletter/#niplock-ships-a-nip-17-based-password-manager)
+- [Newsletter #19: Forgesworn Heartwood signer](/en/newsletters/2026-04-22-newsletter/#forgesworn-publishes-a-29-repo-cryptographic-toolkit-for-nostr)
+- [Newsletter #19: Flotilla Aegis NIP-46 login](/en/newsletters/2026-04-22-newsletter/#flotilla-173-and-174-add-kind-9-wrapping-for-richer-nip-29-rooms)
 
 **See also:**
 - [NIP-55: Android Signer](/en/topics/nip-55/)

--- a/content/en/topics/nip-47.md
+++ b/content/en/topics/nip-47.md
@@ -45,6 +45,7 @@ NIP-44 is now the preferred encryption mode. The spec still documents NIP-04 fal
 - [Newsletter #8: NIP Deep Dive](/en/newsletters/2026-02-04-newsletter/#nip-deep-dive-nip-47-nostr-wallet-connect)
 - [Newsletter #10: NIP Updates](/en/newsletters/2026-02-18-newsletter/#nip-updates)
 - [Newsletter #13: Shopstr and Milk Market Open MCP Commerce Surfaces](/en/newsletters/2026-03-11-newsletter/#shopstr-and-milk-market-open-mcp-commerce-surfaces)
+- [Newsletter #19: ShockWallet Nostr-native wallet sync](/en/newsletters/2026-04-22-newsletter/#shockwallet-ships-nostr-native-lightning-wallet-sync-and-multi-node-connections)
 
 **See also:**
 - [NIP-57: Zaps](/en/topics/nip-57/)

--- a/content/en/topics/nip-53.md
+++ b/content/en/topics/nip-53.md
@@ -21,15 +21,23 @@ The event can include topic tags (`t`), participant references (`p`), and option
 - [Shosho](https://github.com/r0d8lsh0p/shosho-releases) publishes live stream metadata and chat around Nostr-native live broadcasts.
 - [Zap.stream](https://zap.stream/) uses Nostr events for stream discovery and interaction.
 - [WaveFunc](https://github.com/zeSchlausKwab/wavefunc) uses kind `1311` live chat events in its internet radio context.
+- [Amethyst](https://github.com/vitorpamplona/amethyst) wired [NIP-75](/en/topics/nip-75/) zap goals into the Live Activities screen via [PR #2469](https://github.com/vitorpamplona/amethyst/pull/2469): each live stream carries a fundraising goal header with a progress bar, a one-tap zap button, and a top-zappers leaderboard computed from kind `9735` zap receipts bound to the stream's kind `30311` event. Follow-up [PR #2491](https://github.com/vitorpamplona/amethyst/pull/2491) adds NIP-53 proof-of-agreement and event builders, and [PR #2486](https://github.com/vitorpamplona/amethyst/pull/2486) ships a dedicated Live Streams feed screen with filtering and discovery.
+- [NoorNote v0.8.4](https://github.com/77elements/noornote/releases/tag/v0.8.4) adds one-tap zapping from live-stream cards where the sats appear in the stream's chat overlay via NIP-53.
 
 ---
 
 **Primary sources:**
 - [NIP-53 Specification](https://github.com/nostr-protocol/nips/blob/master/53.md)
+- [Amethyst PR #2469](https://github.com/vitorpamplona/amethyst/pull/2469) - Live stream goal header and top-zappers leaderboard
+- [Amethyst PR #2491](https://github.com/vitorpamplona/amethyst/pull/2491) - NIP-53 proof of agreement and event builders
 
 **Mentioned in:**
 - [Newsletter #18: WaveFunc launch](/en/newsletters/2026-04-15-newsletter/#wavefunc-v010-and-v011-launch-nostr-internet-radio)
+- [Newsletter #19: Amethyst live stream zap goals](/en/newsletters/2026-04-22-newsletter/#amethyst-ships-marmot-mip-compliance-nip-72-communities-and-live-stream-zap-goals)
+- [Newsletter #19: NoorNote v0.8.4](/en/newsletters/2026-04-22-newsletter/#noornote-v084-adds-scheduled-posts-and-live-stream-zapping)
 
 **See also:**
 - [NIP-29: Relay-based Groups](/en/topics/nip-29/)
+- [NIP-75: Zap Goals](/en/topics/nip-75/)
+- [NIP-57: Zaps](/en/topics/nip-57/)
 - [NIP-C7: Chat Messages](/en/topics/nip-c7/)

--- a/content/en/topics/nip-57.md
+++ b/content/en/topics/nip-57.md
@@ -43,6 +43,18 @@ Clients should validate the receipt against the recipient's LNURL `nostrPubkey`,
 
 Zaps are useful because they make payments visible inside the social graph, but the receipt is still created by the recipient's wallet infrastructure. The spec itself notes that a zap receipt is not a universal proof of payment. It is best understood as a wallet-signed statement that an invoice tied to a zap request was paid.
 
+A validating client should check four things before displaying a receipt as a zap: the receipt's signature matches the `nostrPubkey` advertised in the recipient's LNURL response, the `bolt11` invoice amount matches the `amount` tag in the embedded zap request, the invoice's description hash commits to the stringified zap request, and the `preimage` hashes to the invoice's `payment_hash`. Clients that render tallied zap counts without performing these checks are trivially spoofable by an attacker who publishes forged kind `9735` events.
+
+## Private and Anonymous Zaps
+
+Private zaps add a confidentiality layer on top. A sender can encrypt the zap request's `content` for the recipient and include an `anon` tag on the outer request, so the relay network sees the payment target but cannot read the attached note. An anonymous zap goes one step further: the client generates a fresh ephemeral keypair for the zap request itself, so the receipt still proves a payment happened but the recipient cannot link the zap back to the sender's long-lived pubkey.
+
+## Zap Goals and Splits
+
+NIP-57 underpins the zap-goal system specified in [NIP-75](/en/topics/nip-75/). A goal is a kind `9041` event that declares a target amount and a relay set where receipts count, and clients tally goal progress by summing validated `bolt11` amounts of matched kind `9735` events.
+
+Zap splits, defined in an appendix to the NIP, let a recipient publish a kind `0` profile with multiple weighted `zap` tags so a single zap payment is divided among several pubkeys atomically. [Amethyst](https://github.com/vitorpamplona/amethyst), [Damus](https://github.com/damus-io/damus), and [noStrudel](https://github.com/hzrd149/nostrudel) implement split-paying end-to-end.
+
 ---
 
 **Primary sources:**
@@ -53,6 +65,9 @@ Zaps are useful because they make payments visible inside the social graph, but 
 - [Newsletter #2: News](/en/newsletters/2025-12-24-newsletter/#news)
 - [Newsletter #3: Notable Code Changes](/en/newsletters/2025-12-31-newsletter/#amethyst-android)
 - [Newsletter #9: NIP Updates](/en/newsletters/2026-02-11-newsletter/#nip-updates)
+- [Newsletter #19: NIP Deep Dive](/en/newsletters/2026-04-22-newsletter/#nip-deep-dive-nip-57-zaps)
 
 **See also:**
 - [NIP-47: Nostr Wallet Connect](/en/topics/nip-47/)
+- [NIP-75: Zap Goals](/en/topics/nip-75/)
+- [NIP-53: Live Activities](/en/topics/nip-53/)

--- a/content/en/topics/nip-5a.md
+++ b/content/en/topics/nip-5a.md
@@ -53,6 +53,7 @@ Root sites use the npub as the subdomain. Named sites use a 50-character base36 
 **Mentioned in:**
 - [Newsletter #16: NIP-5A merges](/en/newsletters/2026-04-01-newsletter/#nip-5a-merges-bringing-static-websites-to-nostr)
 - [Newsletter #16: NIP Deep Dive](/en/newsletters/2026-04-01-newsletter/#nip-deep-dive-nip-5a-static-websites)
+- [Newsletter #19: NIP-5D applets proposal](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [Blossom](/en/topics/blossom/)

--- a/content/en/topics/nip-5c.md
+++ b/content/en/topics/nip-5c.md
@@ -27,6 +27,7 @@ A [demo app](https://nprogram.netlify.app/) shows scrolls running in-browser, wi
 
 **Mentioned in:**
 - [Newsletter #17](/en/newsletters/2026-04-08-newsletter/#nip-updates)
+- [Newsletter #19: NIP-5D applets proposal](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [NIP-5D (Web Applets)](/en/topics/nip-5d/)

--- a/content/en/topics/nip-62.md
+++ b/content/en/topics/nip-62.md
@@ -65,6 +65,7 @@ It also goes beyond [NIP-09](/en/topics/nip-09/). NIP-09 deletes individual even
 - [rust-nostr PR #1316](https://github.com/rust-nostr/nostr/pull/1316) - LMDB backend support
 - [rust-nostr PR #1317](https://github.com/rust-nostr/nostr/pull/1317) - SQLite backend support
 - [rust-nostr PR #1318](https://github.com/rust-nostr/nostr/pull/1318) - Database test coverage for relay-specific vanish support
+- [nostream PR #544](https://github.com/Cameri/nostream/pull/544) - Added NIP-62 right-to-vanish to the advertised feature list
 
 ---
 
@@ -75,12 +76,14 @@ It also goes beyond [NIP-09](/en/topics/nip-09/). NIP-09 deletes individual even
 - [rust-nostr PR #1316](https://github.com/rust-nostr/nostr/pull/1316)
 - [rust-nostr PR #1317](https://github.com/rust-nostr/nostr/pull/1317)
 - [rust-nostr PR #1318](https://github.com/rust-nostr/nostr/pull/1318)
+- [nostream PR #544](https://github.com/Cameri/nostream/pull/544)
 
 **Mentioned in:**
 - [Newsletter #5: Notable Code Changes](/en/newsletters/2026-01-13-newsletter/#rust-nostr-library)
 - [Newsletter #12: rust-nostr](/en/newsletters/2026-03-04-newsletter/#rust-nostr-nip-62-request-to-vanish)
 - [Newsletter #16: Amethyst ships NIP-62 support](/en/newsletters/2026-04-01-newsletter/#amethyst-ships-pinned-notes-relay-management-and-request-to-vanish)
 - [Newsletter #16: NIP Deep Dive](/en/newsletters/2026-04-01-newsletter/#nip-deep-dive-nip-62-request-to-vanish)
+- [Newsletter #19: nostream NIP-62 support](/en/newsletters/2026-04-22-newsletter/#nostream-merges-53-prs-for-nip-45-nip-62-compression-and-query-hardening)
 
 **See also:**
 - [NIP-09: Event Deletion Request](/en/topics/nip-09/)

--- a/content/en/topics/nip-65.md
+++ b/content/en/topics/nip-65.md
@@ -71,6 +71,7 @@ Mix general-purpose relays with any specialized relays you use. For instance, yo
 **Mentioned in:**
 - [Newsletter #5: NIP Deep Dive](/en/newsletters/2026-01-13-newsletter/#nip-65-relay-list-metadata)
 - [Newsletter #12: Outbox Model Benchmarks](/en/newsletters/2026-03-04-newsletter/)
+- [Newsletter #19: Wisp inbox-relay broadcasting](/en/newsletters/2026-04-22-newsletter/#wisp-v0180-beta-adds-normie-mode-for-you-feed-and-nip-29-group-config)
 
 **See also:**
 - [NIP-11: Relay Information](/en/topics/nip-11/)

--- a/content/en/topics/nip-67.md
+++ b/content/en/topics/nip-67.md
@@ -1,0 +1,45 @@
+---
+title: "NIP-67: EOSE Completeness Hint"
+date: 2026-04-22
+draft: false
+categories:
+  - NIPs
+---
+
+NIP-67 is an open proposal that extends the existing `EOSE` message in [NIP-01](/en/topics/nip-01/) with an optional third element indicating whether the relay has delivered every stored event matching the filter. It is intended to replace the unreliable heuristic clients use today to decide whether a subscription is exhausted or cut short by a relay-side cap.
+
+## The Problem
+
+`EOSE` marks the boundary between stored and real-time events, but it carries no information about completeness. In practice, relays enforce a per-subscription cap, commonly between 300 and 1000 events, that is independent of the client's `limit`. A client that asks for the last 500 notes from a relay capped at 300 receives 300 events and an `EOSE`, with no way to distinguish "this is all of it" from "we stopped partway through." The current workaround is to compare the event count to the client's `limit` and paginate defensively, which both misses events when the cap is below the requested limit and wastes a round trip when the cap is a multiple of the actual match count.
+
+Boundary ties make this worse. Paginating with `until = oldest_created_at` risks either missing or double-fetching events that share the oldest timestamp in the batch, depending on how the relay compares timestamps.
+
+## The Change
+
+NIP-67 adds an optional third element to `EOSE`:
+
+```
+["EOSE", "<subscription_id>", "finish"]   // all matching stored events delivered
+["EOSE", "<subscription_id>"]             // no claim of completeness (legacy)
+```
+
+Only the positive signal is specified. A relay that advertises NIP-67 support but omits the hint is saying there is more. A relay that does not advertise support falls through to the existing heuristic, so the change is backward compatible with every current client and relay.
+
+Clients that know their relay supports NIP-67 can stop paginating as soon as they see `"finish"`, avoid the mandatory extra round trip when the cap exactly matches the result set, and surface accurate completeness to the user.
+
+## Status
+
+The proposal is [open as PR #2317](https://github.com/nostr-protocol/nips/pull/2317) against the NIPs repository.
+
+---
+
+**Primary sources:**
+- [PR #2317: NIP-67 EOSE Completeness Hint](https://github.com/nostr-protocol/nips/pull/2317)
+- [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/master/01.md)
+
+**Mentioned in:**
+- [Newsletter #19: NIP Updates](/en/newsletters/2026-04-22-newsletter/#nip-updates)
+
+**See also:**
+- [NIP-01: Basic protocol flow](/en/topics/nip-01/)
+- [NIP-11: Relay Information Document](/en/topics/nip-11/)

--- a/content/en/topics/nip-72.md
+++ b/content/en/topics/nip-72.md
@@ -40,10 +40,23 @@ Because approval events are separate Nostr events, moderation decisions are tran
 
 Relay support matters for community functionality. Clients need to query for both the community definition and approval events, which requires relays that index these event kinds efficiently.
 
+Compared to [NIP-29](/en/topics/nip-29/) relay-based groups, where the relay is the authority for both membership and moderation, NIP-72 lives in plain Nostr events. Any relay that carries kinds `34550`, `4549`, and the submission kinds can serve a community, and moderation is visible and forkable. The tradeoff is that unapproved submissions are only hidden at the client-render layer, so NIP-29 remains the better fit when spam must stay off the wire entirely.
+
+## Implementations
+
+- [noStrudel](https://github.com/hzrd149/nostrudel) has long-standing NIP-72 community support, including a pending submission queue for moderators.
+- [Amethyst](https://github.com/vitorpamplona/amethyst) added first-class community creation and management in [PR #2468](https://github.com/vitorpamplona/amethyst/pull/2468): authoring the kind `34550` community definition, adding moderators and relay hints, submitting posts with an `a` tag, and managing pending approvals via kind `4549` events.
+
 ---
 
 **Primary sources:**
 - [NIP-72 Specification](https://github.com/nostr-protocol/nips/blob/master/72.md) - Moderated Communities
+- [Amethyst PR #2468](https://github.com/vitorpamplona/amethyst/pull/2468) - NIP-72 community creation and moderation
 
 **Mentioned in:**
 - [Newsletter #15](/en/newsletters/2026-03-25-newsletter/)
+- [Newsletter #19: Amethyst community support](/en/newsletters/2026-04-22-newsletter/#amethyst-ships-marmot-mip-compliance-nip-72-communities-and-live-stream-zap-goals)
+- [Newsletter #19: NIP Deep Dive](/en/newsletters/2026-04-22-newsletter/#nip-deep-dive-nip-72-moderated-communities)
+
+**See also:**
+- [NIP-29: Relay-based Groups](/en/topics/nip-29/)

--- a/content/en/topics/nip-75.md
+++ b/content/en/topics/nip-75.md
@@ -1,0 +1,50 @@
+---
+title: "NIP-75: Zap Goals"
+date: 2026-04-22
+draft: false
+categories:
+  - NIPs
+---
+
+NIP-75 defines a fundraising goal event that users can zap toward. A goal declares a target amount in millisatoshis and a list of relays where zap receipts for the goal are tallied. Any [NIP-57](/en/topics/nip-57/) zap that references the goal event counts toward its progress.
+
+## How It Works
+
+A zap goal is a `kind:9041` event. The `.content` is a human-readable description. The required tags are `amount` (target in millisats) and `relays` (the relay list used for tallying zap receipts). Optional tags include `closed_at` to cut off the tally at a given timestamp, `image`, and `summary`. The goal may also include an `r` or `a` tag linking to an external URL or an addressable event, and it may carry multiple beneficiary pubkeys via zap-split tags borrowed from NIP-57 appendix G.
+
+```json
+{
+  "id": "<64-char hex>",
+  "pubkey": "<64-char hex>",
+  "created_at": 1776500000,
+  "kind": 9041,
+  "tags": [
+    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com"],
+    ["amount", "210000"],
+    ["image", "<image url>"],
+    ["summary", "Nostrasia travel expenses"]
+  ],
+  "content": "Nostrasia travel expenses",
+  "sig": "<128-char hex>"
+}
+```
+
+Clients attach a zap to a goal by including an `e` tag pointing at the goal event inside the zap request. Goal progress is the sum of matched zap receipt amounts on the relays the goal specified. When `closed_at` is set, zap receipts published after that timestamp do not count.
+
+## Implementations
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) now renders goal progress bars and one-tap zap buttons inside live-stream headers via [PR #2469](https://github.com/vitorpamplona/amethyst/pull/2469), which wires NIP-75 into the NIP-53 Live Activities screen.
+
+---
+
+**Primary sources:**
+- [NIP-75 Specification](https://github.com/nostr-protocol/nips/blob/master/75.md)
+- [Amethyst PR #2469: live stream top zappers and goal header](https://github.com/vitorpamplona/amethyst/pull/2469)
+
+**Mentioned in:**
+- [Newsletter #19: Amethyst live stream zap goals](/en/newsletters/2026-04-22-newsletter/#amethyst-ships-marmot-mip-compliance-nip-72-communities-and-live-stream-zap-goals)
+- [Newsletter #19: NIP Deep Dive on NIP-57](/en/newsletters/2026-04-22-newsletter/#nip-deep-dive-nip-57-zaps)
+
+**See also:**
+- [NIP-57: Lightning Zaps](/en/topics/nip-57/)
+- [NIP-53: Live Activities](/en/topics/nip-53/)

--- a/content/en/topics/nip-90.md
+++ b/content/en/topics/nip-90.md
@@ -34,6 +34,8 @@ Provider discovery is outside the request/response loop itself. The spec points 
 
 **Mentioned in:**
 - [Newsletter #11: NIP-AC DVM Agent Coordination](/en/newsletters/2026-02-25-newsletter/#nip-updates)
+- [Newsletter #19: Forgesworn toll-booth-dvm](/en/newsletters/2026-04-22-newsletter/#forgesworn-publishes-a-29-repo-cryptographic-toolkit-for-nostr)
+- [Newsletter #19: Agent Reputation Attestations proposal](/en/newsletters/2026-04-22-newsletter/#nip-updates)
 
 **See also:**
 - [NIP-89: Recommended Application Handlers](/en/topics/nip-89/)

--- a/content/en/topics/tollgate.md
+++ b/content/en/topics/tollgate.md
@@ -1,0 +1,43 @@
+---
+title: "TollGate: Pay-per-use Internet Over Nostr and Cashu"
+date: 2026-04-22
+draft: false
+categories:
+  - Protocols
+---
+
+TollGate is a protocol for selling network access in exchange for small, frequent bearer asset payments. A device that can gate connectivity, such as a WiFi router, an Ethernet switch, or a Bluetooth tether, acts as a TollGate that advertises pricing, accepts [Cashu](/en/topics/cashu/) ecash tokens, and manages sessions. Customers pay for exactly the minutes or megabytes they consume. There are no accounts, no subscriptions, no KYC.
+
+## How It Works
+
+TollGate separates concerns into three layers. The protocol layer defines the event shapes and payment semantics. The interface layer defines how customer and gate exchange those events. The medium layer describes the physical link carrying the paid-for traffic. A working TollGate combines one spec from each layer, and some interfaces run over Nostr relays while others run over plain HTTP.
+
+At the protocol layer, [TIP-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-01.md) defines three base events: an Advertisement kind that lists prices and accepted mints, a Session kind that tracks how much the customer has paid for and how much they have consumed, and a Notice kind for out-of-band messaging. [TIP-02](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-02.md) layers Cashu payments on top, so a customer can redeem ecash tokens from any mint the TollGate advertises and receive session credit in return.
+
+At the interface layer, [HTTP-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/HTTP-01.md) through HTTP-03 define the HTTP surface for devices on restrictive operating systems that cannot easily open WebSocket connections to arbitrary relays, and [NOSTR-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/NOSTR-01.md) defines the Nostr-relay transport for clients that can. At the medium layer, [WIFI-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/WIFI-01.md) describes how a captive-portal WiFi setup identifies and routes paying customers.
+
+Because the payment asset is a bearer token rather than a credential, the customer does not need prior internet access to produce it. A Cashu token sitting in a local wallet is sufficient on its own to buy the first minute of connectivity, at which point the customer can top up with more tokens as needed. TollGates may also buy uplink from each other, so reach extends beyond a single operator.
+
+## Why It Matters
+
+Conventional paid WiFi relies on accounts, captive portals, and payment cards, each of which creates friction and a data trail. TollGate's model turns connectivity into a commodity that any router can sell to any paying customer without knowing who they are. The abstraction lets independent operators set their own prices, accept their own preferred mints, and compete on coverage and quality rather than on lock-in.
+
+The [v0.1.0 release](https://github.com/OpenTollGate/tollgate/releases/tag/v0.1.0) is the first tagged snapshot of these specifications. It does not standardize every detail but fixes enough of the surface that router firmware, client wallets, and multi-hop resellers can start building against a stable reference.
+
+---
+
+**Primary sources:**
+- [TollGate v0.1.0 release](https://github.com/OpenTollGate/tollgate/releases/tag/v0.1.0)
+- [TIP-01: Base Events](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-01.md)
+- [TIP-02: Cashu payments](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/TIP-02.md)
+- [HTTP-01 through HTTP-03](https://github.com/OpenTollGate/tollgate/tree/v0.1.0)
+- [NOSTR-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/NOSTR-01.md)
+- [WIFI-01](https://github.com/OpenTollGate/tollgate/blob/v0.1.0/WIFI-01.md)
+- [TollGate repository](https://github.com/OpenTollGate/tollgate)
+
+**Mentioned in:**
+- [Newsletter #19: TollGate v0.1.0](/en/newsletters/2026-04-22-newsletter/#tollgate-v010-stabilizes-pay-per-use-internet-over-nostr-and-cashu)
+
+**See also:**
+- [Cashu](/en/topics/cashu/)
+- [NIP-60: Cashu Wallet](/en/topics/nip-60/)

--- a/data/nip34_tracked.yml
+++ b/data/nip34_tracked.yml
@@ -51,6 +51,41 @@ tracked_repos:
     in_projects_yml: false
     notes: Test/dev repo from Pleb5 (pubkey is in noise list but tracked explicitly)
 
+  - name: nostrability
+    d_tag: nostrability
+    pubkey: 17538dc2a62769d09443f18c37cbe358fab5bbf981173542aa7c5ff171ed77c4
+    relays: [wss://relay.ngit.dev, wss://relay.damus.io, wss://pyramid.fiatjaf.com]
+    in_projects_yml: false
+    notes: Nostr protocol compliance tracking (elsat@habla.news); migrated from github to ngit
+
+  - name: nostrability-MCP
+    d_tag: nostrability-MCP
+    pubkey: 17538dc2a62769d09443f18c37cbe358fab5bbf981173542aa7c5ff171ed77c4
+    relays: [wss://relay.ngit.dev, wss://relay.damus.io, wss://pyramid.fiatjaf.com]
+    in_projects_yml: false
+    notes: MCP server exposing Nostrability data (elsat)
+
+  - name: borkstr
+    d_tag: borkstr
+    pubkey: 17538dc2a62769d09443f18c37cbe358fab5bbf981173542aa7c5ff171ed77c4
+    relays: [wss://relay.ngit.dev, wss://relay.damus.io, wss://pyramid.fiatjaf.com]
+    in_projects_yml: false
+    notes: Borkstr interop reports (elsat)
+
+  - name: rummage
+    d_tag: rummage
+    pubkey: 17538dc2a62769d09443f18c37cbe358fab5bbf981173542aa7c5ff171ed77c4
+    relays: [wss://relay.ngit.dev, wss://relay.damus.io, wss://pyramid.fiatjaf.com]
+    in_projects_yml: false
+    notes: elsat tooling
+
+  - name: NipLock
+    d_tag: passwd
+    pubkey: 15249f1f976e8e29f1ce770aad2ef4a0c4d7b8879b4b8fd86f8e0ca56ddbcbe4
+    relays: [wss://relay.ngit.dev, wss://relay.damus.io, wss://nos.lol]
+    in_projects_yml: false
+    notes: NIP-17 DM-based password manager (nsec/nos2x/Amber signing)
+
 # Noise filtering is handled in scripts/fetch_nip34_repos.sh:
 #   - NOISE_PUBKEYS array: known noise pubkeys (hardcoded, with comments)
 #   - filter_noise() function: d_tag patterns, clone URL patterns


### PR DESCRIPTION
## Summary
- add Newsletter #19 for 2026-04-22 with tightened coverage across client, relay, protocol, and ecosystem developments
- add topic pages for NIP-21, NIP-67, NIP-75, and TollGate
- track additional NIP-34 repositories including Nostrability and NipLock, and update newsletter guidance for future runs