### PR TITLE
Add /projects/ index page with 492 tracked Nostr projects

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -633,3 +633,151 @@ hr {
     }
   }
 }
+
+/* Projects index */
+.projects-page {
+
+  .projects-summary {
+    margin: 1em 0 0.5em;
+    color: var(--text-muted, #666);
+    font-size: 0.95em;
+  }
+
+  .projects-nav {
+    margin: 1em 0 2em;
+    padding: 0.6em 0.9em;
+    font-size: 0.95em;
+    line-height: 1.9;
+    background: var(--code-bg, rgba(127,127,127,0.06));
+    border-radius: 6px;
+
+    a {
+      text-decoration: none;
+      white-space: nowrap;
+
+      &:hover { text-decoration: underline; }
+    }
+  }
+
+  .projects-section {
+    margin-top: 2.5em;
+    scroll-margin-top: 1em;
+  }
+
+  .projects-section-title {
+    margin-bottom: 0.6em;
+    border-bottom: 1px solid var(--border-color, #ddd);
+    padding-bottom: 0.3em;
+  }
+
+  .projects-section-count {
+    color: var(--text-muted, #666);
+    font-weight: normal;
+    font-size: 0.75em;
+  }
+
+  .projects-list {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .project {
+    padding: 0.55em 0;
+    border-bottom: 1px dotted var(--border-color, #eee);
+    line-height: 1.5;
+
+    &:last-child { border-bottom: none; }
+
+    &--inactive {
+      opacity: 0.65;
+    }
+  }
+
+  .project-name {
+    font-weight: 600;
+
+    a { text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  }
+
+  .project-status {
+    display: inline-block;
+    margin-left: 0.4em;
+    padding: 0.05em 0.5em;
+    font-size: 0.72em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-radius: 3px;
+    vertical-align: middle;
+
+    &--beta {
+      background: rgba(255, 165, 0, 0.18);
+      color: #b46a00;
+    }
+    &--inactive {
+      background: rgba(127, 127, 127, 0.18);
+      color: var(--text-muted, #666);
+    }
+  }
+
+  .project-desc {
+    color: var(--text-color, inherit);
+  }
+
+  .project-links {
+    margin-left: 0.4em;
+    font-size: 0.85em;
+
+    a {
+      margin-right: 0.5em;
+      color: var(--text-muted, #666);
+      text-decoration: none;
+      white-space: nowrap;
+
+      &::before { content: "["; }
+      &::after  { content: "]"; }
+
+      &:hover { text-decoration: underline; }
+    }
+  }
+
+  .project-platforms {
+    margin-left: 0.4em;
+    font-size: 0.78em;
+  }
+
+  .project-platform {
+    display: inline-block;
+    margin-right: 0.3em;
+    padding: 0 0.45em;
+    background: rgba(127,127,127,0.12);
+    color: var(--text-muted, #666);
+    border-radius: 3px;
+    text-transform: lowercase;
+  }
+
+  .project-maintainer {
+    margin-left: 0.5em;
+    color: var(--text-muted, #666);
+    font-size: 0.85em;
+    font-style: italic;
+  }
+
+  .projects-back-to-top {
+    margin-top: 3em;
+    text-align: center;
+    font-size: 0.9em;
+
+    a { color: var(--text-muted, #666); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  }
+}
+
+@media (max-width: 600px) {
+  .projects-page {
+    .project-platforms { display: none; }
+    .project-maintainer { display: none; }
+  }
+}

--- a/content/de/projects.md
+++ b/content/de/projects.md
@@ -1,0 +1,12 @@
+---
+title: Projekte
+url: /de/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Vollständige Liste der Nostr-Projekte, die wir für die Newsletter-Berichterstattung verfolgen. Jeder Eintrag verlinkt das Repository und die Projektseite, sofern verfügbar. Der Katalog ist nach Kategorie gruppiert und wird laufend aktualisiert.
+---
+
+Vollständige Liste der Nostr-Projekte, die wir für die Newsletter-Berichterstattung verfolgen. Jeder Eintrag verlinkt das Repository und die Projektseite, sofern verfügbar. Der Katalog ist nach Kategorie gruppiert und wird laufend aktualisiert.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/en/projects.md
+++ b/content/en/projects.md
@@ -1,0 +1,16 @@
+---
+title: Projects
+url: /en/projects/
+layout: projects
+description: Index of Nostr projects tracked by Nostr Compass for newsletter coverage.
+---
+
+This is the full list of projects we track for newsletter coverage.
+Each entry links to the project's source repository and homepage where
+available. The catalog is grouped by category and updated as new projects
+launch and existing ones change.
+
+If something is missing, inaccurate, or out of date, send a NIP-17 DM to
+[Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923)
+or open a pull request against
+[`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml).

--- a/content/es/projects.md
+++ b/content/es/projects.md
@@ -1,0 +1,12 @@
+---
+title: Proyectos
+url: /es/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Lista completa de los proyectos Nostr que rastreamos para la cobertura de la newsletter. Cada entrada enlaza al repositorio y a la página del proyecto cuando están disponibles. El catálogo está agrupado por categoría y se actualiza a medida que se lanzan nuevos proyectos.
+---
+
+Lista completa de los proyectos Nostr que rastreamos para la cobertura de la newsletter. Cada entrada enlaza al repositorio y a la página del proyecto cuando están disponibles. El catálogo está agrupado por categoría y se actualiza a medida que se lanzan nuevos proyectos.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/fr/projects.md
+++ b/content/fr/projects.md
@@ -1,0 +1,12 @@
+---
+title: Projets
+url: /fr/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Liste complète des projets Nostr que nous suivons pour la couverture de la newsletter. Chaque entrée renvoie au dépôt source et au site du projet lorsqu'ils existent. Le catalogue est groupé par catégorie et mis à jour régulièrement.
+---
+
+Liste complète des projets Nostr que nous suivons pour la couverture de la newsletter. Chaque entrée renvoie au dépôt source et au site du projet lorsqu'ils existent. Le catalogue est groupé par catégorie et mis à jour régulièrement.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/it/projects.md
+++ b/content/it/projects.md
@@ -1,0 +1,12 @@
+---
+title: Progetti
+url: /it/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Elenco completo dei progetti Nostr che monitoriamo per la copertura della newsletter. Ogni voce rimanda al repository sorgente e al sito del progetto quando disponibili. Il catalogo è raggruppato per categoria e viene aggiornato regolarmente.
+---
+
+Elenco completo dei progetti Nostr che monitoriamo per la copertura della newsletter. Ogni voce rimanda al repository sorgente e al sito del progetto quando disponibili. Il catalogo è raggruppato per categoria e viene aggiornato regolarmente.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/ja/projects.md
+++ b/content/ja/projects.md
@@ -1,0 +1,12 @@
+---
+title: プロジェクト
+url: /ja/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: ニュースレターで取り上げるためにNostr Compassが追跡しているNostrプロジェクトの完全なリストです。各エントリは、利用可能な場合はソースリポジトリとプロジェクトのウェブサイトへのリンクを含みます。カテゴリ別にグループ化されており、定期的に更新されます。
+---
+
+ニュースレターで取り上げるためにNostr Compassが追跡しているNostrプロジェクトの完全なリストです。各エントリは、利用可能な場合はソースリポジトリとプロジェクトのウェブサイトへのリンクを含みます。カテゴリ別にグループ化されており、定期的に更新されます。
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/ko/projects.md
+++ b/content/ko/projects.md
@@ -1,0 +1,12 @@
+---
+title: 프로젝트
+url: /ko/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Nostr Compass가 뉴스레터 커버리지를 위해 추적하는 Nostr 프로젝트의 전체 목록입니다. 각 항목은 가능한 경우 프로젝트 저장소와 웹사이트로 연결됩니다. 카탈로그는 카테고리별로 그룹화되어 있으며 정기적으로 업데이트됩니다.
+---
+
+Nostr Compass가 뉴스레터 커버리지를 위해 추적하는 Nostr 프로젝트의 전체 목록입니다. 각 항목은 가능한 경우 프로젝트 저장소와 웹사이트로 연결됩니다. 카탈로그는 카테고리별로 그룹화되어 있으며 정기적으로 업데이트됩니다.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/nl/projects.md
+++ b/content/nl/projects.md
@@ -1,0 +1,12 @@
+---
+title: Projecten
+url: /nl/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Volledige lijst van Nostr-projecten die wij volgen voor de nieuwsbriefdekking. Elke vermelding linkt naar de broncoderepository en de projectwebsite indien beschikbaar. De catalogus is gegroepeerd per categorie en wordt voortdurend bijgewerkt.
+---
+
+Volledige lijst van Nostr-projecten die wij volgen voor de nieuwsbriefdekking. Elke vermelding linkt naar de broncoderepository en de projectwebsite indien beschikbaar. De catalogus is gegroepeerd per categorie en wordt voortdurend bijgewerkt.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/pt/projects.md
+++ b/content/pt/projects.md
@@ -1,0 +1,12 @@
+---
+title: Projetos
+url: /pt/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Lista completa dos projetos Nostr que rastreamos para a cobertura da newsletter. Cada entrada inclui links para o repositório e site do projeto quando disponíveis. O catálogo está agrupado por categoria e é atualizado conforme novos projetos surgem.
+---
+
+Lista completa dos projetos Nostr que rastreamos para a cobertura da newsletter. Cada entrada inclui links para o repositório e site do projeto quando disponíveis. O catálogo está agrupado por categoria e é atualizado conforme novos projetos surgem.
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/content/zh/projects.md
+++ b/content/zh/projects.md
@@ -1,0 +1,12 @@
+---
+title: 项目
+url: /zh/projects/
+layout: projects
+translationOf: /en/projects.md
+translationDate: 2026-04-27
+description: Nostr Compass 为通讯报道而跟踪的 Nostr 项目完整列表。每个条目均链接到项目的源代码仓库和官方网站（若有）。目录按类别分组，并随新项目的发布持续更新。
+---
+
+Nostr Compass 为通讯报道而跟踪的 Nostr 项目完整列表。每个条目均链接到项目的源代码仓库和官方网站（若有）。目录按类别分组，并随新项目的发布持续更新。
+
+Send a NIP-17 DM to [Nostr Compass](nostr:npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923) or open a pull request against [`data/projects.yml`](https://github.com/andotherstuff/nostr-compass/blob/main/data/projects.yml) if something is missing or out of date.

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -814,6 +814,369 @@ social_clients:
 # LONG-FORM CONTENT
 # =============================================================================
 
+  - name: advanced-nostr-search
+    description: A tool to search Nostr notes.
+    website: https://advancednostrsearch.vercel.app/
+    status: active
+    priority: low
+
+  - name: AllSocial.me
+    description: Linktree-like application for social media links based on nostr.
+    website: https://allsocial.me/
+    status: active
+    priority: low
+
+  - name: Anonostr
+    description: 'Anonostr allows users to send anonymous notes to the Nostr network without revealing their identity. For each note submission, the app generates a new key pair, sends the note through select relays, and then securely burns the key pair. It supports tagging, threading, quoting, and replying to existing notes.'
+    repo: https://github.com/Spl0itable/Anonostr
+    status: active
+    priority: low
+
+  - name: astraea
+    description: A nostr client
+    repo: https://github.com/mouse484/astraea
+    status: active
+    priority: low
+
+  - name: badger
+    description: A NIP58 nostr badge client. Create Badges view Profile Badges and more.
+    repo: https://github.com/0ceanslim/badger
+    status: active
+    priority: low
+
+  - name: Badges Page
+    description: Browse and award NIP-58 badges on Nostr
+    repo: https://github.com/verbiricha/badges
+    website: https://badges.page
+    status: active
+    priority: low
+
+  - name: BlazeJump
+    description: 'A fast web client boilerplate written in C# / Blazor, that uses an in-browser SQLite database.'
+    platforms: [ web ]
+    repo: https://github.com/objectwizard/BlazeJump
+    status: active
+    priority: low
+
+  - name: cafe-society.news
+    description: Self-sovereign machine learning training tool for nostr global feed. Trained models can be monetized/distributed over nostr private messages. Your pre-paid model subscribers register via lightning payments.
+    repo: https://github.com/colealbon/cafe-society
+    status: active
+    priority: low
+
+  - name: caracal
+    description: 'Nostr client for the Gemini protocol. Use Nostr from your Gemini browser! nsite'
+    platforms: [ web ]
+    repo: https://gitlab.com/cipres/caracal
+    status: active
+    priority: low
+
+  - name: Clonable
+    description: 'A standalone feature of Mutable: Migrate your profile, follows, mutes, and relays from another account to your current keyset. Useful when recovering from a compromised key.'
+    website: https://www.mutable.top/clonable
+    status: active
+    priority: low
+
+  - name: Daisy
+    description: Mobile client for Android and iOS
+    platforms: [ ios, android ]
+    repo: https://github.com/neb-b/daisy
+    status: active
+    priority: low
+
+  - name: dispute
+    description: 'A cross-platform (Linux, Android, iOS, macOS, Windows and Web) client for NOSTR'
+    platforms: [ ios, android, windows, linux, web ]
+    repo: https://github.com/ethicnology/dispute
+    status: active
+    priority: low
+
+  - name: ehagaki
+    description: 'A lightweight, post-only Nostr client that compresses media on your device for fast, data-efficient uploads'
+    repo: https://github.com/Lokuyow/ehagaki
+    status: active
+    priority: low
+
+  - name: electron-nostr
+    description: 'A bare-bones desktop nostr client using electron-react-boilerplate. The goal is to be an easy template for people to experiment with different ideas on decentralized ratings, reputation, and web of trust.'
+    platforms: [ desktop, web ]
+    repo: https://github.com/wds4/electron-react-boilerplate-nostr
+    status: active
+    priority: low
+
+  - name: following.space
+    description: 'create and explore follow packs for nostr, find lists of users to follow'
+    repo: https://github.com/callebtc/following.space
+    status: active
+    priority: low
+
+  - name: get-tao.app
+    description: Anonymous-first client with PoW notes
+    repo: https://github.com/smolgrrr/TAO
+    status: active
+    priority: low
+
+  - name: getwired.app
+    description: Anonymous-first client with PoW notes
+    repo: https://github.com/smolgrrr/Wired
+    status: active
+    priority: low
+
+  - name: gnost-deflate-client
+    description: CLI nostr client written in go implementing permessage-deflate websocket compression.
+    platforms: [ web, cli ]
+    repo: https://github.com/barkyq/gnost-deflate-client
+    status: active
+    priority: low
+
+  - name: Grimoire
+    description: A themed Nostr client designed for magicians and magic enthusiasts
+    repo: https://github.com/purrgrammer/grimoire
+    status: active
+    priority: low
+
+  - name: JiYou
+    description: A nostr PWA client with a highly customizable UI
+    platforms: [ web ]
+    repo: https://github.com/TimA314/JiYou
+    status: active
+    priority: low
+
+  - name: metadata_updater
+    description: 'Scans all known online nostr relays for stale kind 0 metadata notes, rebroadcasts latest verified note'
+    repo: https://github.com/UTXOnly/metadata_updater
+    status: active
+    priority: low
+
+  - name: moStard
+    description: Nostr web client with Monero tips.
+    platforms: [ web ]
+    website: https://mostard.org
+    status: active
+    priority: low
+
+  - name: n_cord
+    description: 'A Discord inspired chat style client standard Nostr notes, built in static HTML & JavaScript.'
+    repo: https://github.com/0n4t3/n_cord
+    status: active
+    priority: low
+
+  - name: ni.py
+    description: 'CLI post only client for Nostr, Activity Pub, and the AT Protocol written in Python.'
+    repo: https://github.com/0n4t3/nipy
+    status: active
+    priority: low
+
+  - name: nos.today
+    description: Nostr NIP-50 search web client for searching across Nostr relays
+    platforms: [ web ]
+    repo: https://github.com/darashi/nos.today
+    status: active
+    priority: low
+
+  - name: Nosotros
+    description: Nostr web client focused on simplicity and performance
+    platforms: [ web ]
+    repo: https://github.com/cesardeazevedo/nosotros
+    website: https://nosotros.app
+    status: active
+    priority: low
+
+  - name: nostpy-cli
+    description: A Python command line nostr client/tool for relay development
+    repo: https://github.com/UTXOnly/nostpy-cli
+    status: active
+    priority: low
+
+  - name: Nostr Follow Organizer
+    description: A tool to organize people you follow
+    website: https://tsukemonogit.github.io/NFO/
+    status: active
+    priority: low
+
+  - name: Nostr NIP-36 Image Redirector
+    description: Reverse proxy server which blocks accesses to NIP-36 marked image files from NOT NIP-36 compliant clients.
+    repo: https://github.com/ryogrid/NostrNIP36ImageRedirector
+    status: active
+    priority: low
+
+  - name: Nostr Read Only Client
+    description: 'simple cloudflare worker to serve a single user''s nostr content (kind:1) as web page preview: nostr.emre.xyz'
+    platforms: [ web ]
+    repo: https://github.com/delirehberi/nostr-ro-client/
+    status: active
+    priority: low
+
+  - name: nostr-badges
+    description: Nostr badge microservice for managing self-awarded badges. Live at app.akaprofiles.com
+    repo: https://github.com/neilck/nostr-badges
+    status: active
+    priority: low
+
+  - name: nostr-broadcast
+    description: This tool lets you take your events from some relays and broadcast them to another relay. Could help back up your notes to a private relay.
+    repo: https://github.com/leesalminen/nostr-broadcast
+    status: active
+    priority: low
+
+  - name: nostr-components
+    description: 'Nostr Components makes it easy to embed Nostr profiles, posts, follow buttons, Live chat box, comment section, DM buttons in any website'
+    platforms: [ web ]
+    repo: https://github.com/saiy2k/nostr-components
+    status: active
+    priority: low
+
+  - name: nostr-follow-bundler
+    description: This tool lets you create lists of profiles that other users can then see and follow themselves.
+    repo: https://github.com/leesalminen/nostr-follow-bundler
+    status: active
+    priority: low
+
+  - name: nostr-launch
+    description: a tool for launching a bunch of relays and clients locally for development and testing
+    repo: https://codeberg.org/rsbondi/nostr-launch
+    status: active
+    priority: low
+
+  - name: nostr-to-rss
+    description: 'nostr to RSS bridge, enabling you to subscribe to nostr events in RSS clients'
+    repo: https://github.com/gustavonmartins/nostr-to-rss
+    status: active
+    priority: low
+
+  - name: nostr-wot-extension
+    description: 'WoT browser extension, create your own custom trust scoring and query social distance between pubkeys via remote oracle or local graph.'
+    platforms: [ web, browser ]
+    repo: https://github.com/nostr-wot/nostr-wot-extension
+    status: active
+    priority: low
+
+  - name: nostr.kiwi
+    description: nostr.kiwi is a progressive web app to share notes and curate content in communities.
+    platforms: [ web ]
+    website: https://nostr.kiwi/
+    status: active
+    priority: low
+
+  - name: NostrEmitter
+    description: Simple E2E encrypted client and EventEmitter object
+    repo: https://github.com/cmdruid/nostr-emitter
+    status: active
+    priority: low
+
+  - name: NostrFlu
+    description: A tool to collect and resend following lists from relays. You can also check badges.
+    website: https://heguro.github.io/nostr-following-list-util/
+    status: active
+    priority: low
+
+  - name: Nostribe.com
+    description: Nostr client web app built with Next.js 13 and TypeScript.
+    platforms: [ web ]
+    repo: https://github.com/sepehr-safari/nostribe-web-client
+    status: active
+    priority: low
+
+  - name: nostromat
+    description: 'A Twitter-style Nostr web client, written in Clojurescript/React'
+    platforms: [ web ]
+    repo: https://github.com/ekimber/nostromat
+    status: active
+    priority: low
+
+  - name: NostrReply
+    description: Bot that replies to specified text on nostr global feed using NIP50
+    repo: https://github.com/gourcetools/nostreply
+    status: active
+    priority: low
+
+  - name: nostrweb
+    description: another Nostr web client in vanilla JS
+    platforms: [ web ]
+    website: https://git.qcode.ch/nostr/nostrweb
+    status: active
+    priority: low
+
+  - name: nostui
+    description: A TUI client for Nostr
+    repo: https://github.com/akiomik/nostui
+    status: active
+    priority: low
+
+  - name: osint-user-discovery
+    description: 'OSINT Discovery is a set of Python scripts designed to search for users or URLs across different social media platforms(nostr, mastodon) and caching services.'
+    repo: https://github.com/Inforensics/osint-user-discovery
+    status: active
+    priority: low
+
+  - name: Paz
+    description: Paz is a desktop semantic Nostr client that transforms events into linked data (RDF) and makes queries on the events graph.
+    platforms: [ desktop ]
+    website: https://pazstr.codeberg.page
+    status: active
+    priority: low
+
+  - name: Plebs
+    description: 'Censorship-resistant, decentralized video platform powered by the Nostr social protocol'
+    repo: https://github.com/Spl0itable/plebs-app
+    status: active
+    priority: low
+
+  - name: Plebs vs. Zombies
+    description: A Nostr utility for managing dormant follows and cleaning up your follow list.
+    website: https://www.plebsvszombies.cc
+    status: active
+    priority: low
+
+  - name: Purgatory
+    description: 'A standalone feature of Mutable that finds follows who create hellthreads or use spam apps, and lets you mass mute them.'
+    website: https://www.mutable.top/purgatory
+    status: active
+    priority: low
+
+  - name: scalastr
+    description: A barebones nostr client written in scala
+    repo: https://github.com/benthecarman/scalastr
+    status: active
+    priority: low
+
+  - name: Sendbox
+    description: A tool to help clients delayed publish your nostr event.
+    website: https://sendbox.nostrmo.com/
+    status: active
+    priority: low
+
+  - name: Spring Browser
+    description: Nostr-focused browser app for Android.
+    platforms: [ android, web ]
+    website: https://spring.site
+    status: active
+    priority: low
+
+  - name: The Resurrector
+    description: A standalone feature of Plebs vs. Zombies that lets users undelete their nostr profiles if they were previously deleted.
+    website: https://www.plebsvszombies.cc/resurrector
+    status: active
+    priority: low
+
+  - name: torrent-gateway
+    description: The BitTorrent Gateway seamlessly integrates with the Nostr network to enable decentralized content discovery and social features.
+    repo: https://codeberg.org/Enkisu/torrent-gateway
+    status: active
+    priority: low
+
+  - name: YEGHRO unFollow Tool
+    description: A tool that allows you to unfollow inactive users on nostr.
+    website: https://unfollow.yeghro.com
+    status: active
+    priority: low
+
+  - name: zephyr
+    description: A meditative nostr feed reader
+    repo: https://github.com/coracle-social/zephyr
+    status: active
+    priority: low
+
 longform_clients:
   - name: Habla
     description: Long-form content publishing (NIP-23)
@@ -954,6 +1317,67 @@ longform_clients:
 # =============================================================================
 # MESSAGING
 # =============================================================================
+
+  - name: blogsync
+    description: Self-host blog articles from long-form notes e.g. via Caddy server.
+    repo: https://github.com/canostrical/blogsync
+    status: active
+    priority: low
+
+  - name: MeShell
+    description: 'Web, iOS, and Android blog type client destined to publish articles and researches for independent journalists.'
+    platforms: [ ios, android, web ]
+    repo: https://github.com/BEEBSDONE/MeShell_Nodejs
+    status: active
+    priority: low
+
+  - name: nblog
+    description: a self-host nostr ghost blog
+    repo: https://github.com/jacany/nblog
+    status: active
+    priority: low
+
+  - name: nostr-article-publish
+    description: 'A command-line tool written in Rust for publishing and deleting long-form content events (NIP-23) on the Nostr protocol. It supports validation of content, custom tags for articles, and interaction with multiple relays configured via a TOML file.'
+    repo: https://github.com/madcato/nostr-article-publish
+    status: active
+    priority: low
+
+  - name: notestack.com
+    description: 'Blogging site for nostr, supports markdown'
+    website: https://notestack.com
+    status: active
+    priority: low
+
+  - name: readwithboris.com
+    description: Long form reading and highlighting app.
+    website: https://www.readwithboris.com/
+    status: active
+    priority: low
+
+  - name: second exchange
+    description: 'An experiment to work out something of like medium, a creator economy where users are rewarded for engaging in quality discussion and governance-related discussion.'
+    repo: https://github.com/cynsar-foundation/second.exchange
+    status: active
+    priority: low
+
+  - name: untype.app
+    description: Nostr longform clients project
+    website: https://untype.app
+    status: active
+    priority: low
+
+  - name: Written
+    description: Self hosted blog using nostr long-form content (NIP-23) and it shows only posts by selected authors.
+    repo: https://github.com/silencesoft/written
+    status: active
+    priority: low
+
+  - name: yakihonne.com
+    description: 'YakiHonne is a Nostr-based decentralized content media protocol that supports blogs, flash news, curation, videos, uncensored notes, zaps, and other content types.'
+    website: https://yakihonne.com
+    status: active
+    priority: low
 
 messaging_clients:
   - name: 0xchat
@@ -1179,6 +1603,69 @@ messaging_clients:
 # MEDIA & STREAMING
 # =============================================================================
 
+  - name: anonroom
+    description: anonymous chat room inside nostr
+    repo: https://github.com/vinliao/anonroom
+    status: active
+    priority: low
+
+  - name: FMD (Find my device)
+    description: 'Find your device and control it remotely. Works over Marmot (Nostr), SMS, instant messengers, or FMD Server''s web interface. A secure open source alternative to Google''s Find Hub. Fork of FMD Android.'
+    platforms: [ web ]
+    repo: https://gitlab.com/Kalle/fmd-android/-/tree/nostr-marmot?ref_type=heads
+    status: active
+    priority: low
+
+  - name: nostr-bulk-dms
+    description: A tool that allows you to send DMs over nostr to many recipients in bulk.
+    repo: https://github.com/leesalminen/nostr-bulk-dm
+    status: active
+    priority: low
+
+  - name: nostr-chat-widget-react
+    description: A React component that provides a live-chat widget over nostr that can be embedded into any website.
+    platforms: [ web ]
+    website: https://www.npmjs.com/package/nostr-chat-widget-react?activeTab=readme
+    status: active
+    priority: low
+
+  - name: nostraap
+    description: 'A decentralized messaging application inspired by WhatsApp, built on the Nostr protocol, with native support for end-to-end encryption, distributed relay networks, and Bitcoin Lightning payments (Zaps).'
+    repo: https://github.com/ccs-mz/nostraap
+    status: active
+    priority: low
+
+  - name: NostrChat.io
+    description: 'NostrChat is a chat app where you can have group chats, DM, threads, and emojis.'
+    website: https://nostrchat.io/
+    status: active
+    priority: low
+
+  - name: Obelisk
+    description: 'Discord-like group chat app where identity comes from Nostr keypairs. Supports real-time messaging, roles, and voice channels.'
+    website: https://obelisk.ar
+    status: active
+    priority: low
+
+  - name: Sendstr
+    description: shared clipboard between devices over nostr
+    website: https://sendstr.com/
+    status: active
+    priority: low
+
+  - name: smtp nostr gateway
+    description: a bridge that forwards emails to pubkeys as encrypted direct messages
+    repo: https://github.com/Cameri/smtp-nostr-gateway
+    status: active
+    priority: low
+
+  - name: Zemzeme
+    description: 'Private, serverless messaging for Android — offline Bluetooth mesh, peer-to-peer, and Nostr relay. No accounts, no internet required'
+    platforms: [ android ]
+    repo: https://github.com/whisperbit-labs/zemzeme-android
+    status: active
+    priority: low
+
 media_clients:
   - name: Zap.stream
     description: Live streaming with Lightning zaps
@@ -1318,6 +1805,13 @@ media_clients:
 # MARKETPLACES
 # =============================================================================
 
+  - name: danmakustr
+    description: 'a chrome extension allowing users to send special comments (弹幕, danmaku) on YouTube and display them above the video.'
+    platforms: [ browser ]
+    repo: https://github.com/CodyTseng/danmakustr
+    status: active
+    priority: low
+
 marketplaces:
   - name: Shopstr
     description: P2P marketplace with Lightning/Cashu (NIP-99)
@@ -1402,6 +1896,44 @@ marketplaces:
 # =============================================================================
 # DEVELOPER TOOLS
 # =============================================================================
+
+  - name: bray
+    description: 'Trust-aware Nostr MCP server for AI agents. 234 tools across identity, social, trust, dispatch, relay, marketplace, privacy, and encrypted access. Works with Claude, ChatGPT, Gemini, Cursor, or any MCP client.'
+    repo: https://github.com/forgesworn/bray
+    status: active
+    priority: low
+
+  - name: elisym
+    description: 'Open infrastructure for AI agents to discover, hire, and pay each other - no platform, no middleman. NIP-89 discovery, NIP-90 job marketplace, NIP-44 v2 encryption for targeted jobs, on-chain payments for completed work.'
+    website: https://www.elisym.network
+    status: active
+    priority: low
+
+  - name: liquiditystr
+    description: A browser client for the Nostr P2P Lightning liquidity marketplace
+    platforms: [ web ]
+    repo: https://github.com/smallworlnd/liquiditystr
+    status: active
+    priority: low
+
+  - name: mostro-cli
+    description: CLI client to operate with Mostro (WIP)
+    repo: https://github.com/MostroP2P/mostro-cli
+    status: active
+    priority: low
+
+  - name: mostro-web
+    description: Web client to operate with Mostro (WIP)
+    platforms: [ web ]
+    repo: https://github.com/MostroP2P/mostro-web
+    status: active
+    priority: low
+
+  - name: n3xB
+    description: Proposal for a Bitcoin exchange protocol and a globally shared order book on Nostr
+    repo: https://github.com/nobu-maeda/n3xb
+    status: active
+    priority: low
 
 devtools:
   - name: ngit
@@ -2087,6 +2619,428 @@ devtools:
 # SIGNING & KEY MANAGEMENT
 # =============================================================================
 
+  - name: '@elisym/cli'
+    description: 'CLI agent runner - create AI agents that discover each other via Nostr (NIP-89, NIP-90, NIP-44 v2 encryption for targeted jobs), accept jobs, and get paid on-chain.'
+    platforms: [ cli ]
+    repo: https://github.com/elisymlabs/elisym
+    status: active
+    priority: low
+
+  - name: algia-web
+    description: A small resource consumption oriented Nostr web client
+    platforms: [ web ]
+    repo: https://github.com/ryogrid/algia-web
+    status: active
+    priority: low
+
+  - name: Amethyst crawler
+    description: Find and broadcast nostr events
+    website: https://crawler.amethyst.social/
+    status: active
+    priority: low
+
+  - name: Bech32 for Nostr
+    description: bech32 Nostr converter.
+    website: https://nostr.xport.top/bech32-for-nostr/
+    status: active
+    priority: low
+
+  - name: Bookmarkstr
+    description: A browser extension for reading and managing nostr bookmarks
+    platforms: [ web, browser ]
+    website: https://bookmarkstr.store/
+    status: active
+    priority: low
+
+  - name: Cloud Seeder
+    description: A 1-click deployment and management tool for nostr-rs-relay and other appliances.
+    platforms: [ cli ]
+    repo: https://github.com/ipv6rslimited/cloudseeder
+    status: active
+    priority: low
+
+  - name: contact cloud
+    description: Discover the Nostr contact list graph and your own pubkey in it.
+    repo: https://github.com/canostrical/contact_cloud
+    status: active
+    priority: low
+
+  - name: Contact list backup
+    description: Backup and restore your contacts
+    website: https://nostr.xport.top/contact-list-backup/
+    status: active
+    priority: low
+
+  - name: CSV Importer
+    description: Publish Nostr events in bulk from CSV files.
+    website: https://csv-importer.coracle.social/
+    status: active
+    priority: low
+
+  - name: data vending machine example
+    description: Nostr data vending machine example by Pablof7z
+    repo: https://github.com/pablof7z/nostr-data-vending-machine
+    status: active
+    priority: low
+
+  - name: dvm-imagegen
+    description: 'NIP-90 image generation DVM (kind 5100) in Go, paid via Lightning'
+    repo: https://github.com/joelklabo/dvm-imagegen
+    status: active
+    priority: low
+
+  - name: dvm-textgen
+    description: 'NIP-90 text generation DVM (kind 5050) in Go, paid via Lightning'
+    repo: https://github.com/joelklabo/dvm-textgen
+    status: active
+    priority: low
+
+  - name: git-nostr
+    description: 'A tool to enhance git cli with nostr communications. Publish patch content, prs, repo name, issues, etc to nostr relay.'
+    platforms: [ cli ]
+    repo: https://github.com/colealbon/git-nostr
+    status: active
+    priority: low
+
+  - name: gitnostr (gittr fork)
+    description: 'Git-Nostr bridge service for repository management, SSH keys, and permissions. Enhanced with HTTP API, watch-all mode, and deduplication for gittr.space.'
+    repo: https://github.com/arbadacarbaYK/gitnostr
+    status: active
+    priority: low
+
+  - name: glasnostr
+    description: CLI tool to mine a vanity prefix for your nostr npub
+    platforms: [ cli ]
+    repo: https://github.com/eyelight/glasnostr
+    status: active
+    priority: low
+
+  - name: go-pubmine
+    description: Multithreading nostr keypair generator which gives pretty (vanity) public keys. Both CLI and web apps are available.
+    platforms: [ web ]
+    repo: https://github.com/tenkoh/go-pubmine
+    status: active
+    priority: low
+
+  - name: heyxynip5
+    description: A CLI helper for converting nostr npub/nsec to their hex format for NIP-05 verification.
+    platforms: [ cli ]
+    repo: https://github.com/bennyhodl/hexynip5
+    status: active
+    priority: low
+
+  - name: homebrew-nostr
+    description: Homebrew tap for Nostr software.
+    repo: https://github.com/nostorg/homebrew-nostr
+    status: active
+    priority: low
+
+  - name: hostr
+    description: nostr-webhost is a tool for hosting SPA on nostr
+    platforms: [ web ]
+    repo: https://github.com/studiokaiji/nostr-webhost
+    status: active
+    priority: low
+
+  - name: key-generator
+    description: A simple tool to generate nostr keypair.
+    repo: https://github.com/TP-Lab/key-generator
+    status: active
+    priority: low
+
+  - name: lightning-memory
+    description: 'Decentralized agent memory for the Lightning economy. Nostr identity, L402 payments, MCP server.'
+    repo: https://github.com/singularityjason/lightning-memory
+    status: active
+    priority: low
+
+  - name: Mutable
+    description: 'A tool for managing, backing up, restoring, and sharing Nostr mute lists.'
+    website: https://mutable.top
+    status: active
+    priority: low
+
+  - name: NAKE
+    description: a browser extension to easily convert between Nostr hex IDs and NIP-19 entities.
+    platforms: [ web, browser ]
+    website: https://tsukemonogit.github.io/nake-website/
+    status: active
+    priority: low
+
+  - name: nashboard
+    description: 'a Nostr network dashboard with network statistics, reachable here'
+    repo: https://github.com/vinliao/nashboard
+    status: active
+    priority: low
+
+  - name: ndxstr
+    description: 'nostr''s layer 2 indexing nodes, with more advanced querying capability than currently supported by relays'
+    repo: https://github.com/ArcadeCity/ndxstr
+    status: active
+    priority: low
+
+  - name: nip06-cli
+    description: a Node.js CLI to generate or restore NIP-06 seed phrases
+    platforms: [ cli ]
+    repo: https://github.com/jaonoctus/nip06-cli
+    status: active
+    priority: low
+
+  - name: nip06-web
+    description: a website to generate or restore NIP-06 seed phrases
+    platforms: [ web ]
+    repo: https://github.com/jaonoctus/nip06-web
+    status: active
+    priority: low
+
+  - name: noclvag
+    description: OpenCL cli tool to mine vanity keys on gpu
+    platforms: [ cli ]
+    repo: https://codeberg.org/alex0jsan/noclvag
+    status: active
+    priority: low
+
+  - name: Nostr action
+    description: Send events from GitHub Actions
+    repo: https://github.com/snow-actions/nostr
+    status: active
+    priority: low
+
+  - name: Nostr Events Monitor
+    description: 'Web tool to monitor and filter Nostr events, both live and historical, filter by relay, event kind, author, and other tags.'
+    platforms: [ web ]
+    repo: https://github.com/Catrya/Nostr-Events-Monitor
+    status: active
+    priority: low
+
+  - name: nostr GitHub Action
+    description: send events from GitHub Actions
+    repo: https://github.com/theborakompanioni/nostr-action
+    status: active
+    priority: low
+
+  - name: Nostr in Move
+    description: A tool to help persist Nostr event in Move oriented blockchains.
+    repo: https://github.com/rooch-network/rooch/tree/main/examples/nostr
+    status: active
+    priority: low
+
+  - name: nostr registry
+    description: a database of known relays with their uptime and NIP support tables
+    repo: https://codeberg.org/rsbondi/nostr-registry
+    status: active
+    priority: low
+
+  - name: nostr-delete
+    description: 'generate delete events requesting relays drop and delete content you''ve published. Blasts out delete requests to many relays.'
+    repo: https://github.com/blakejakopovic/nostr_delete
+    status: active
+    priority: low
+
+  - name: nostr-dvm-ts
+    description: Typescript examples of Nostr Data Vending Machines
+    repo: https://github.com/Kodylow/nostr-dvm-ts
+    status: active
+    priority: low
+
+  - name: nostr-fzf
+    description: Nostr Directory; a tool for searching usernames and channels
+    repo: https://github.com/Cameri/nostr-fzf
+    status: active
+    priority: low
+
+  - name: nostr-notify
+    description: desktop nostr notifications using libnotify
+    platforms: [ desktop ]
+    repo: https://github.com/jb55/nostr-notify
+    status: active
+    priority: low
+
+  - name: nostr-post-checker
+    description: check if event exists on relays
+    repo: https://github.com/koteitan/nostr-post-checker
+    status: active
+    priority: low
+
+  - name: nostr-pubminer
+    description: A simple tool to mine nostr vanity pubkeys
+    repo: https://github.com/lacaulac/nostr-pubminer
+    status: active
+    priority: low
+
+  - name: nostr-spam-detection
+    description: An experiment in building a machine learning model to label Nostr spam content for filtering and relay rejection.
+    repo: https://github.com/blakejakopovic/nostr-spam-detection
+    status: active
+    priority: low
+
+  - name: nostr-terminal
+    description: 'SSH-like access to your machine via web terminal, powered by Nostr.'
+    platforms: [ web, cli ]
+    repo: https://github.com/cmdruid/nostr-terminal
+    status: active
+    priority: low
+
+  - name: nostr-vanity-address-generator
+    description: Cross-platform nostr vanity address generator
+    repo: https://github.com/chawyehsu/nostr-vanity-address-generator
+    status: active
+    priority: low
+
+  - name: nostr-wtf
+    description: A set of nostr tools available and deployed on a web app including a pubkey converter and relay query tool.
+    platforms: [ web ]
+    repo: https://github.com/LightningK0ala/nostr-wtf
+    status: active
+    priority: low
+
+  - name: nostr.time
+    description: A calendar app built on nostr
+    repo: https://github.com/coracle-social/nostrtime
+    status: active
+    priority: low
+
+  - name: nostrapp.link
+    description: Nostr App Manager
+    website: https://nostrapp.link/
+    status: active
+    priority: low
+
+  - name: nostrends
+    description: 'Trending on Nostr, like Twitter trends. Live at nostrends.vercel.app.'
+    repo: https://github.com/akiomik/nostrends
+    status: active
+    priority: low
+
+  - name: nostreq
+    description: Nostr relay event request generator
+    repo: https://github.com/blakejakopovic/nostreq
+    status: active
+    priority: low
+
+  - name: NostrHTTP
+    description: 'Access Nostr Relay content through the HTTP protocol, addressing the issue of search engine indexing and access to Nostr data.'
+    repo: https://github.com/duozhutuan/NostrHTTP
+    status: active
+    priority: low
+
+  - name: nostro
+    description: nostr osint (open source intelligence) tool
+    repo: https://github.com/r3drun3/nostro
+    status: active
+    priority: low
+
+  - name: nostrogen
+    description: simple web-based nostr vanity address generator
+    platforms: [ web ]
+    repo: https://github.com/tonyinit/nostrogen
+    status: active
+    priority: low
+
+  - name: Nostrtium
+    description: Post to Nostr directly from within WordPress
+    repo: https://github.com/pjv/nostrtium
+    status: active
+    priority: low
+
+  - name: Rebased
+    description: rebased — unify dev cryptography with your npub..
+    repo: https://codeberg.org/Zsub/rebased
+    status: active
+    priority: low
+
+  - name: Replies
+    description: Nostr micro-app for viewing replies and reactions to events
+    website: https://replies.nostrapps.org
+    status: active
+    priority: low
+
+  - name: safebox
+    description: private portable safebox on nostr
+    repo: https://github.com/trbouma/safebox
+    status: active
+    priority: low
+
+  - name: scoop-nostr
+    description: Scoop bucket for Nostr software.
+    repo: https://github.com/nostorg/scoop-nostr
+    status: active
+    priority: low
+
+  - name: SnapNostr
+    description: 'Create clean, customizable screenshots of Nostr posts for seamless sharing.'
+    repo: https://github.com/djhemath/snap-nostr
+    status: active
+    priority: low
+
+  - name: sovereign-stack
+    description: a tool that helps you deploy nostr relays and create self-hosted (bitcoin-only) Value4Value websites.
+    platforms: [ web ]
+    website: https://www.sovereign-stack.org
+    status: active
+    priority: low
+
+  - name: Spamster
+    description: Spamster is for testing relays and spam filters.
+    repo: https://github.com/gourcetools/spamster
+    status: active
+    priority: low
+
+  - name: Stacks
+    description: 'Stacks is a decentralized platform for sharing AI templates on the Nostr network. Find the perfect starter for your next project, or share your own templates with the community.'
+    website: https://getstacks.dev/
+    status: active
+    priority: low
+
+  - name: TaskQ5
+    description: TaskQ5 is a task distribution platform built on nostr where you can post tasks if you need help
+    repo: https://github.com/duozhutuan/Taskq5
+    status: active
+    priority: low
+
+  - name: tostr
+    description: a twitter to nostr bot
+    repo: https://github.com/slaninas/tostr
+    status: active
+    priority: low
+
+  - name: Undelete my Nostr
+    description: Simple tool for restoring deleted nostr account.
+    website: https://yonle.github.io/undelete-my-nostr
+    status: active
+    priority: low
+
+  - name: vanity-key
+    description: use your face biometrics to generate a deterministic private key
+    repo: https://github.com/nostr-net/vanity-key/
+    status: active
+    priority: low
+
+  - name: wen
+    description: browser extension for website enhancer with nostr
+    platforms: [ web, browser ]
+    repo: https://github.com/fiatjaf/wen
+    status: active
+    priority: low
+
+  - name: wot-scoring
+    description: 'NIP-85 trust scoring engine with PageRank, sybil detection, trust circles. Live at wot.klabo.world'
+    repo: https://github.com/joelklabo/wot-scoring
+    status: active
+    priority: low
+
+  - name: Zapounty
+    description: 'A GitHub app that let you to put bounties for developers to fix issues on a repo, paid in zaps!'
+    repo: https://github.com/ZigBalthazar/zapounty
+    status: active
+    priority: low
+
+  - name: Zapper
+    description: Nostr micro-app for zapping
+    website: https://zapper.nostrapps.org
+    status: active
+    priority: low
+
 signers:
   - name: Amber
     description: Android event signer
@@ -2293,6 +3247,133 @@ signers:
 # =============================================================================
 # RELAY IMPLEMENTATIONS
 # =============================================================================
+
+  - name: '@bitmacro/relay-connect'
+    description: TypeScript SDK for NIP-46 (Nostr Connect) and NIP-07 browser extension signing.
+    platforms: [ web, browser ]
+    repo: https://github.com/bitmacro/relay-connect
+    status: active
+    priority: low
+
+  - name: amberflutter
+    description: A Flutter wrapper for Amber (Offline Signer).
+    repo: https://github.com/sebdeveloper6952/amberflutter
+    status: active
+    priority: low
+
+  - name: bark
+    description: NIP-07 browser extension backed by a Heartwood or NIP-46 bunker. Signs events without the nsec ever touching the browser. Chrome.
+    platforms: [ web, browser ]
+    repo: https://github.com/forgesworn/bark
+    status: active
+    priority: low
+
+  - name: BlazeJump.NostrConnect
+    description: an Android based remote NostrConnect signer and web project using QR codes and Nip44 encryption by default
+    platforms: [ android, web ]
+    repo: https://github.com/drmikesamy/BlazeJump.NostrConnect
+    status: active
+    priority: low
+
+  - name: Bunker46
+    description: NIP-07 remote signer via NIP-46
+    repo: https://github.com/dsbaars/bunker46-extension
+    status: active
+    priority: low
+
+  - name: gittr-helper-tools
+    description: 'Production code snippets from gittr.space: file fetching, URL normalization, GRASP detection, NIP-46 signer, NIP-25 stars, NIP-51 following, markdown media handling, and NIP-C0 code snippets.'
+    repo: https://github.com/arbadacarbaYK/gittr-helper-tools
+    status: active
+    priority: low
+
+  - name: heartwood
+    description: 'Nostr signing appliance for Raspberry Pi. NIP-46 remote signing with nsec-tree hierarchical identity derivation, per-client permissions, Tor hidden service, and web UI. Rust.'
+    platforms: [ web ]
+    repo: https://github.com/forgesworn/heartwood
+    status: active
+    priority: low
+
+  - name: keechain
+    description: 'Bitcoin application to transform your offline computer in an AirGap Signing Device (aka Hardware Wallet) with support to `NIP-06` and `NIP-26`.'
+    repo: https://github.com/yukibtc/keechain
+    status: active
+    priority: low
+
+  - name: keystr-rs
+    description: 'An application for managing Nostr keys. Written in Rust, with simple UI (Iced).'
+    repo: https://github.com/keystr/keystr-rs
+    status: active
+    priority: low
+
+  - name: NIP-07 Signing Extension Tester
+    description: 'This Next.js app tests NIP-07, showing supported functions and raw results for the current signing extension.'
+    repo: https://github.com/neilck/nip07-tester
+    status: active
+    priority: low
+
+  - name: nip07-awaiter
+    description: Minimal utility to access NIP-07 interface safely.
+    repo: https://github.com/penpenpng/nip07-awaiter
+    status: active
+    priority: low
+
+  - name: nkcli
+    description: A CLI tool for nostr key manage and serve NIP-46.
+    repo: https://github.com/mdzz-club/nkcli
+    status: active
+    priority: low
+
+  - name: nodestr
+    description: A nip07 provider and polyfill for NodeJS
+    repo: https://github.com/lightning-digital-entertainment/nodestr
+    status: active
+    priority: low
+
+  - name: nostr.json generator
+    description: Generate NIP-05 nostr.json from NIP-65 or NIP-07
+    repo: https://github.com/SnowCait/nostr-json-generator
+    status: active
+    priority: low
+
+  - name: nostress
+    description: '⚡ Modern Python CLI for Nostr protocol interactions - secure key management, event creation, and relay operations'
+    repo: https://github.com/4383/nostress
+    status: active
+    priority: low
+
+  - name: nostrum
+    description: A mobile app that allows you to sign transactions and messages with your Nostr keys. Nostrum is the reference implementation for a remote signer app (Wallet) of the Nostr Connect protocol.
+    repo: https://github.com/nostr-connect/nostrum
+    status: active
+    priority: low
+
+  - name: secret-border
+    description: A safe Nostr identity generator.
+    repo: https://github.com/guilhermegps/secret-border
+    status: active
+    priority: low
+
+  - name: Self-Sovereign Browser
+    description: Firefox-forked browser with NIP-07 support
+    platforms: [ web, browser ]
+    website: https://api-docs-30b126.gitlab.io/index.html
+    status: active
+    priority: low
+
+  - name: Signum XT Wallet
+    description: Metamask-like browser extension for Signum blockchain with full NIP07 support and multi-account management
+    platforms: [ web, browser ]
+    repo: https://github.com/signum-network/signum-xt-wallet
+    status: active
+    priority: low
+
+  - name: TokenPocket
+    description: 'Multi wallet browser extension with nostr support. https://tokenpocket.pro'
+    platforms: [ web, browser ]
+    repo: https://github.com/TP-Lab/TokenPocket
+    status: active
+    priority: low
 
 relays:
   - name: strfry
@@ -2734,6 +3815,140 @@ relays:
 # LIBRARIES & SDKs
 # =============================================================================
 
+  - name: Asknostr.site
+    description: 'A Quora/StackOverflow Q&A site using the nostr network and #asknostr content'
+    website: https://asknostr.site
+    status: active
+    priority: low
+
+  - name: Gravity Swarm MCP
+    description: MCP server for an agent reputation network using Nostr BIP-340 signing.
+    repo: https://github.com/antoinedelorme/gravity-swarm-mcp
+    status: active
+    priority: low
+
+  - name: me.untethr.nostr-relay
+    description: a relay written in Clojure.
+    repo: https://github.com/atdixon/me.untethr.nostr-relay
+    status: active
+    priority: low
+
+  - name: Minds Nostr Relay
+    description: 'a relay for Minds, an open-source social network'
+    repo: https://gitlab.com/minds/infrastructure/nostr-relay
+    status: active
+    priority: low
+
+  - name: noshtastic
+    description: A Geo-Specific Virtual Nostr Relay for Meshtastic
+    repo: https://github.com/ksedgwic/noshtastic
+    status: active
+    priority: low
+
+  - name: Nostpy
+    description: An easy to deploy/audit Python relay for beginner relay operators.
+    repo: https://github.com/UTXOnly/nost-py/tree/main
+    status: active
+    priority: low
+
+  - name: Nostr client and relay
+    description: 'C++ engine that allows building Nostr applications for command line, desktop or web.'
+    platforms: [ desktop, web ]
+    repo: https://github.com/pedro-vicente/nostr_client_relay
+    status: active
+    priority: low
+
+  - name: nostr-proxy
+    description: 'Push and get events to your Proxy, get results from multiple Nostr relays.'
+    repo: https://github.com/dolu89/nostr-proxy
+    status: active
+    priority: low
+
+  - name: nostr-relay
+    description: Nostr relay in Go based on relayer. Backend by sqlite3/PostgreSQL/mysql.
+    repo: https://github.com/mattn/nostr-relay
+    status: active
+    priority: low
+
+  - name: nostr-relaypool-ts
+    description: a TypeScript relay pool library on top of nostr-tools that simplifies handling subscriptions to multiple servers
+    repo: https://github.com/adamritter/nostr-relaypool-ts
+    status: active
+    priority: low
+
+  - name: nostr-rs-relay-compose
+    description: a Docker compose deployment for nostr-rs-relay with SSL support based on Traefik
+    repo: https://github.com/vdo/nostr-rs-relay-compose
+    status: active
+    priority: low
+
+  - name: nostr_relay
+    description: 'a nostr relay written in Python, backed by SQLite'
+    website: https://code.pobblelabs.org/fossil/nostr_relay/
+    status: active
+    priority: low
+
+  - name: nostr_relay_management
+    description: Dart/Flutter support for NIP-86 (Relay Management) with better developer experience.
+    repo: https://github.com/anasfik/nostr_relay_management
+    status: active
+    priority: low
+
+  - name: NostrBridge
+    description: NostrBridge provides two core features aimed at facilitating WebSocket connection forwarding and message forwarding under the Nostr protocol.
+    platforms: [ web ]
+    repo: https://github.com/duozhutuan/NostrBridge/
+    status: active
+    priority: low
+
+  - name: nostring
+    description: A Nostr relay written in Deno.
+    repo: https://github.com/xbol0/nostring
+    status: active
+    priority: low
+
+  - name: NostrP2P
+    description: Pure peer-to-peer distributed microblog system on NAT transparent overlay network implemented in Golang based on idea of Nostr
+    repo: https://github.com/ryogrid/nostrp2p
+    status: active
+    priority: low
+
+  - name: NostrPostr Relay
+    description: a Kotlin Relay supporting both SQLite and Postgresql.
+    repo: https://github.com/Giszmo/NostrPostr/tree/master/NostrRelay
+    status: active
+    priority: low
+
+  - name: Notra
+    description: 'F# implementation backed by SQLite database.'
+    repo: https://github.com/lontivero/Nostra
+    status: active
+    priority: low
+
+  - name: PyRelay
+    description: 'a python implementation of a Nostr relay, using asyncio.'
+    repo: https://github.com/johnny423/pyrelay
+    status: active
+    priority: low
+
+  - name: rssnotes
+    description: RSS/Atom to Nostr relay. Fork of rsslay.
+    repo: https://github.com/trinidz/rssnotes
+    status: active
+    priority: low
+
+  - name: strfry policies
+    description: 'A collection of moderation & antispam policies for the strfry relay developed in TypeScript/Deno.'
+    repo: https://gitlab.com/soapbox-pub/strfry-policies
+    status: active
+    priority: low
+
+  - name: Transpher
+    description: 'experimental PHP implementation with file or sqlite storage, configurable limits'
+    repo: https://github.com/nostriphant/transpher
+    status: active
+    priority: low
+
 libraries:
   # --- JavaScript/TypeScript ---
   - name: nostr-tools
@@ -3153,6 +4368,212 @@ libraries:
 # WALLETS & LIGHTNING INTEGRATION
 # =============================================================================
 
+  - name: better-auth-nostr
+    description: A plugin for Better Auth to add Nostr sign-in.
+    repo: https://github.com/leon-wbr/better-auth-nostr
+    status: active
+    priority: low
+
+  - name: crusty-n3xb
+    description: Rust library implementing the n3xB Bitcoin exchange protocol
+    repo: https://github.com/nobu-maeda/crusty-n3xb
+    status: active
+    priority: low
+
+  - name: eventstore
+    description: 'A collection of reusable database connectors, wrappers and schemas with simple Go interface'
+    website: https://pkg.go.dev/fiatjaf.com/nostr/eventstore
+    status: active
+    priority: low
+
+  - name: ezdvm
+    description: 'Quickly put any python code in a DVM! Simple library built on nostr-sdk python bindings'
+    repo: https://github.com/dtdannen/ezdvm
+    status: active
+    priority: low
+
+  - name: flutter_nostr
+    description: Build scalable/complex Nostr apps effortlessly with Flutter
+    repo: https://github.com/anasfik/flutter_nostr
+    status: active
+    priority: low
+
+  - name: git-nostr-tools
+    description: A cli tool for sending code patches over nostr
+    website: http://git.jb55.com/git-nostr-tools
+    status: active
+    priority: low
+
+  - name: graperank-nodejs
+    description: My Grapevine web of trust recommendation engine
+    repo: https://github.com/Pretty-Good-Freedom-Tech/graperank-nodejs
+    status: active
+    priority: low
+
+  - name: http-nostr-publisher
+    description: A Cloudflare worker to publish Nostr events to relays through a non-blocking HTTP interface .
+    repo: https://github.com/getAlby/http-nostr-publisher
+    status: active
+    priority: low
+
+  - name: mleku/nostr
+    description: 'A Go library forked from go-nostr with hand-written JSON codecs for events and filters, support for bitcoin/libsecp256k1 and a fast pure Go signature library refactored from btcec rewritten with 64-bit limbs, sha256 and hex encoding using AVX SIMD extensions where available.'
+    website: https://git.mleku.dev/mleku/nostr
+    status: active
+    priority: low
+
+  - name: monstr
+    description: python code for working with nostr
+    repo: https://github.com/monty888/monstr
+    status: active
+    priority: low
+
+  - name: mostro-core
+    description: common types used by mostro and clients (WIP)
+    repo: https://github.com/MostroP2P/mostro-core
+    status: active
+    priority: low
+
+  - name: NIPF
+    description: A Python facilities manager for NOSTR ecosystem.
+    repo: https://github.com/nextdebug/nipf
+    status: active
+    priority: low
+
+  - name: nmostr
+    description: a Nim library for Nostr
+    repo: https://github.com/Gruruya/nmostr
+    status: active
+    priority: low
+
+  - name: nostr
+    description: 'A comprehensive Go library for the Nostr protocol, providing everything needed to build relays, clients, or hybrid applications'
+    repo: https://github.com/ClarkQAQ/nostr
+    status: active
+    priority: low
+
+  - name: nostr-deno
+    description: a client library for Deno javascript runtime.
+    repo: https://github.com/KiPSOFT/nostr-deno
+    status: active
+    priority: low
+
+  - name: nostr-notification-server
+    description: 'Rust & LMDB server for sending event notifications to webhooks and web push endpoints'
+    platforms: [ web ]
+    repo: https://github.com/mmalmi/nostr-notification-server
+    status: active
+    priority: low
+
+  - name: nostr-one
+    description: A reusable web component that provides a simple way to integrate with nostr NIP 98 HTTP Auth.
+    repo: https://github.com/dolu89/nostr-one
+    status: active
+    priority: low
+
+  - name: nostr-sama
+    description: 'Learning Nostr by building. Relays, clients, and event-driven architectures for a censorship-resistant future. A collection of decentralized experiments, learning modules, and NIP implementations on the Nostr protocol.'
+    repo: https://github.com/hparihar-07/nostr-sama
+    status: active
+    priority: low
+
+  - name: nostr-sdk-ffi
+    description: Nostr SDK native language bindings — enables using the Rust nostr-sdk from other languages via FFI
+    repo: https://github.com/rust-nostr/nostr-sdk-ffi
+    status: active
+    priority: low
+
+  - name: nostr-sdk-flutter
+    description: 'Nostr protocol implementation, Relay, RelayPool, high-level client library, NWC client and more'
+    repo: https://github.com/rust-nostr/nostr-sdk-flutter
+    status: active
+    priority: low
+
+  - name: nostr-share-component
+    description: A custom web component that can be embedded into any web page to easily add a share button for Nostr.
+    platforms: [ web ]
+    website: https://tsukemonogit.github.io/nostr-share-component/
+    status: active
+    priority: low
+
+  - name: nostr-social-graph
+    description: 'TypeScript library for building and querying social graphs from Nostr follow events, with efficient binary serialization and pre-crawled datasets'
+    repo: https://github.com/mmalmi/nostr-social-graph
+    status: active
+    priority: low
+
+  - name: nostr-typedef
+    description: Type definition files to develop Nostr applications in TypeScript
+    repo: https://github.com/penpenpng/nostr-typedef
+    status: active
+    priority: low
+
+  - name: nostr.hs
+    description: Nostr client library for the Haskell ecosystem
+    repo: https://github.com/delirehberi/nostr.hs
+    status: active
+    priority: low
+
+  - name: nostr_rust
+    description: Functional Rust implementation of the nostr protocol
+    repo: https://github.com/0xtlt/nostr_rust
+    status: active
+    priority: low
+
+  - name: nostrdb-rs
+    description: 'fast nostr database backed by lmdb, in rust'
+    repo: https://github.com/damus-io/nostrdb-rs
+    status: active
+    priority: low
+
+  - name: Nostrobots
+    description: a set of community nodes for using n8n workflow automation with Nostr
+    repo: https://github.com/ocknamo/n8n-nodes-nostrobots
+    status: active
+    priority: low
+
+  - name: nwcjs
+    description: A vanilla JavaScript library for working with Nostr Wallet Connect
+    repo: https://github.com/supertestnet/nwcjs
+    status: active
+    priority: low
+
+  - name: QNostr
+    description: A Nostr protocol implementation for clients as a Qt Module in C++
+    repo: https://github.com/Aseman-Land/QNostr
+    status: active
+    priority: low
+
+  - name: rate
+    description: 'A low-level, highly-concurrent, in-memory, generic token bucket rate limiter, designed for IP-based and pubkey-based rate limiting in Nostr relay and Blossom server contexts.'
+    repo: https://github.com/pippellia-btc/rate
+    status: active
+    priority: low
+
+  - name: schorr_snap
+    description: 'A snap plugin for Metamask Flask, supports nostr'
+    repo: https://github.com/neeboo/schnorr_snap
+    status: active
+    priority: low
+
+  - name: sonos
+    description: C++ library and command line tool for Nostr
+    repo: https://github.com/bvcxza/sonos
+    status: active
+    priority: low
+
+  - name: swift-nostr-client
+    description: A modern Swift library for the Nostr protocol with Swift 6 concurrency support
+    repo: https://github.com/yysskk/swift-nostr-client
+    status: active
+    priority: low
+
+  - name: y-ndk
+    description: yjs provider over nostr relays
+    repo: https://github.com/colealbon/y-ndk
+    status: active
+    priority: low
+
 wallets:
   - name: Alby Hub
     description: Self-custodial Lightning node with NWC
@@ -3374,6 +4795,127 @@ wallets:
 # =============================================================================
 # OTHER NOTABLE PROJECTS
 # =============================================================================
+
+  - name: Alby NWC (Umbrel)
+    description: Umbrel app for exposing your self-custodial Umbrel LN Wallet over NWC
+    website: https://apps.umbrel.com/app/alby-nostr-wallet-connect
+    status: active
+    priority: low
+
+  - name: Bipa
+    description: User-friendly Bitcoin wallet for buying and selling bitcoin with lightning and pix support
+    website: https://bipa.app/
+    status: active
+    priority: low
+
+  - name: Blink
+    description: Blink (ex Bitcoin Beach Wallet)
+    website: https://www.blink.sv/
+    status: active
+    priority: low
+
+  - name: Bro App
+    description: Pay bills with Bitcoin — a peer-to-peer protocol built on Nostr + Lightning Network
+    repo: https://github.com/Quizzicarol/bro-app
+    status: active
+    priority: low
+
+  - name: btcpayserver
+    description: btcpayserver has NIP-57 support for LN addresses since 1.9 version
+    website: https://btcpayserver.org/
+    status: active
+    priority: low
+
+  - name: cln-nip47
+    description: Core Lightning (CLN) plugin to connect wallets via Nostr Wallet Connect (NWC)
+    repo: https://github.com/daywalker90/cln-nip47
+    status: active
+    priority: low
+
+  - name: emon
+    description: Encrypted DMs over nostr with lightning payments integrated (WIP).
+    repo: https://github.com/sebastiaanwouters/emon
+    status: active
+    priority: low
+
+  - name: Flash
+    description: Bitcoin payments solution based on NWC
+    website: https://paywithflash.com/
+    status: active
+    priority: low
+
+  - name: lawalletio/lawallet-nwc
+    description: LaWallet v2 NWC
+    repo: https://github.com/lawalletio/lawallet-nwc
+    status: active
+    priority: low
+
+  - name: LikZap
+    description: A nostr bot to zap a note when you like it.
+    repo: https://github.com/silencesoft/likzap
+    status: active
+    priority: low
+
+  - name: lnpass
+    description: A key manager for Lightning and nostr.
+    website: https://lnpass.github.io
+    status: active
+    priority: low
+
+  - name: OneKey
+    description: Open-source crypto wallet with nosrt support.
+    website: https://onekey.so
+    status: active
+    priority: low
+
+  - name: pocket-wallet
+    description: PocketWallet is a nostr-based wallet on CKB blockchain supportting Nip07 and Nip46.
+    repo: https://github.com/RetricSu/pocket-wallet
+    status: active
+    priority: low
+
+  - name: publsp
+    description: A CLI tool for any Lightning Network node or Lightning Service Provider (LSP) to advertise liquidity offers over Nostr.
+    platforms: [ cli ]
+    repo: https://github.com/smallworlnd/publsp
+    status: active
+    priority: low
+
+  - name: Rizful
+    description: Cloud lightning node with NWC support
+    website: https://rizful.com
+    status: active
+    priority: low
+
+  - name: toll-booth
+    description: 'HTTP 402 payment middleware with NWC backend and Cashu support. Companion tools: toll-booth-announce (kind 31402 service discovery), toll-booth-dvm (NIP-90 DVM bridge), 402-mcp (AI agent L402 client).'
+    repo: https://github.com/forgesworn/toll-booth
+    status: active
+    priority: low
+
+  - name: Wallet of Satoshi
+    description: Custodial lightning wallet
+    website: https://www.walletofsatoshi.com/
+    status: active
+    priority: low
+
+  - name: Zapit
+    description: 'Create live message boards powered by instant bitcoin lightning payments & nostr. No accounts, no hassle—just real-time engagement for your events and communities.'
+    website: https://zapit.space
+    status: active
+    priority: low
+
+  - name: ZapPlanner
+    description: 'Scheduled recurring lightning payments powered by Nostr Wallet Connect (NWC), enabling lightning subscriptions and bitcoin recurring payments'
+    repo: https://github.com/getAlby/ZapPlanner
+    status: active
+    priority: low
+
+  - name: Zebedee app
+    description: 'Zebedee''s wallet/lightning app'
+    website: https://zebedee.io/app
+    status: active
+    priority: low
 
 other:
   - name: Nostr.band
@@ -3924,6 +5466,89 @@ other:
 # RELATED PROTOCOLS
 # =============================================================================
 # Protocols that build on or complement Nostr
+
+  - name: Blobbi
+    description: Your Virtual Pet on the Nostr Network. Adopt and care for your own unique digital companion that lives forever on the decentralized web.
+    platforms: [ web ]
+    website: https://blobbi.pet/
+    status: active
+    priority: low
+
+  - name: connect4
+    description: connect 4 over nostr
+    repo: https://github.com/stutxo/connect4xyz
+    status: active
+    priority: low
+
+  - name: knob
+    description: command line tool to post text files to nostr
+    platforms: [ cli ]
+    repo: https://github.com/plantimals/knob
+    status: active
+    priority: low
+
+  - name: nostr-cln-events
+    description: A CLN plugin to push clightning node events to nostr
+    platforms: [ cli ]
+    website: http://git.jb55.com/nostr-cln-events
+    status: active
+    priority: low
+
+  - name: nostr_simple_publish
+    description: Drupal module to publish content to Nostr.
+    website: https://www.drupal.org/project/nostr_simple_publish/
+    status: active
+    priority: low
+
+  - name: NostrDice
+    description: NostrDice is a provably fair betting game combining the power of Lightning and Nostr.
+    repo: https://github.com/NostrDice/nostrdice
+    status: active
+    priority: low
+
+  - name: nostri.chat
+    description: An embedded chat widget for your website. (seriously simple like copy/paste)
+    platforms: [ web ]
+    website: https://nostri.chat/
+    status: active
+    priority: low
+
+  - name: Nostrian Conquest
+    description: 'A turn-based multiplayer space strategy game inspired by classic BBS door games, rebuilt in Rust and powered by Nostr for decentralized play.'
+    website: https://nostrian-conquest.com
+    status: active
+    priority: low
+
+  - name: Skatting
+    description: 'Serverless 2D ticket estimation for agile teams. Express effort and certainty by dragging a log-normal blob on a 2D canvas. P2P via WebRTC (Nostr + MQTT signaling) with AES-256-GCM encrypted Nostr relay fallback. No signup, no server.'
+    platforms: [ web ]
+    repo: https://github.com/WimYedema/skatting
+    status: active
+    priority: low
+
+  - name: Tollbooth-DPYC
+    description: Tollbooth DPYC is a nation state ecosystem for Bitcoin entrepreneurs who monetize their MCP services according the Dont Pester Your Customer
+    repo: https://github.com/lonniev/dpyc-oracle
+    status: active
+    priority: low
+
+  - name: Words with Zaps
+    description: A two-player crossword-style word game with bonus features designed around Lightning and Nostr.
+    website: https://www.wordswithzaps.top
+    status: active
+    priority: low
+
+  - name: ygege
+    description: Support Tor High-performance torrents indexer for services using the U2P system written in Rust.
+    repo: https://github.com/UwUDev/ygege
+    status: active
+    priority: low
+
+  - name: zap_server
+    description: An LNURL server to recieve zaps to tor hosted node and generate kind 9735 zap receipt events
+    repo: https://github.com/UTXOnly/zap_server
+    status: active
+    priority: low
 
 protocols:
   - name: NIPs

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -30,7 +30,7 @@ social_clients:
   # --- Mobile ---
   - name: Damus
     description: The OG Nostr client for iOS
-    platforms: [ios, macos]
+    platforms: [ ios, macos ]
     repo: https://github.com/damus-io/damus
     website: https://damus.io
     maintainer: jb55
@@ -40,7 +40,7 @@ social_clients:
 
   - name: Amethyst
     description: Feature-rich Android client
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/vitorpamplona/amethyst
     website: https://amethyst.social
     maintainer: vitorpamplona
@@ -50,7 +50,7 @@ social_clients:
 
   - name: Primal Android
     description: Android client with built-in Lightning wallet
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/PrimalHQ/primal-android-app
     website: https://primal.net
     maintainer: miljan
@@ -60,7 +60,7 @@ social_clients:
 
   - name: Primal iOS
     description: iOS client with built-in Lightning wallet
-    platforms: [ios]
+    platforms: [ ios ]
     repo: https://github.com/PrimalHQ/primal-ios-app
     website: https://primal.net
     maintainer: miljan
@@ -70,7 +70,7 @@ social_clients:
 
   - name: Primal Web
     description: Web client with built-in Lightning wallet
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/PrimalHQ/primal-web-app
     website: https://primal.net
     maintainer: miljan
@@ -80,7 +80,7 @@ social_clients:
 
   - name: Nostur
     description: Native iOS/macOS client with extensive feature set
-    platforms: [ios, macos]
+    platforms: [ ios, macos ]
     repo: https://github.com/nostur-com/nostur-ios-public
     website: https://nostur.com
     maintainer: fabian
@@ -89,7 +89,7 @@ social_clients:
 
   - name: Nos
     description: UX-focused iOS/macOS app by Planetary
-    platforms: [ios, macos]
+    platforms: [ ios, macos ]
     repo: https://github.com/planetary-social/nos
     website: https://nos.social
     maintainer: planetary-social
@@ -98,7 +98,7 @@ social_clients:
 
   - name: Camelus
     description: Mobile Nostr client
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/camelus-hq/camelus
     status: active
     priority: low
@@ -107,7 +107,7 @@ social_clients:
   # --- Web ---
   - name: Snort
     description: Fast React-based web client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/v0l/snort
     website: https://snort.social
     maintainer: v0l
@@ -116,8 +116,8 @@ social_clients:
 
   - name: Coracle
     description: Flexible web client with custom feeds and relay management
-    platforms: [web]
-    repo: https://gitea.coracle.social/coracle/coracle
+    platforms: [ web ]
+    repo: https://github.com/coracle-social/coracle
     website: https://coracle.social
     maintainer: staab
     status: active
@@ -126,7 +126,7 @@ social_clients:
 
   - name: noStrudel
     description: Jack-of-all-trades web client supporting many NIPs
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hzrd149/nostrudel
     website: https://nostrudel.ninja
     maintainer: hzrd149
@@ -136,7 +136,7 @@ social_clients:
 
   - name: Iris
     description: Simple and fast web client with built-in Cashu wallet
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/irislib/iris-messenger
     website: https://iris.to
     maintainer: mmalmi
@@ -146,7 +146,7 @@ social_clients:
 
   - name: Jumble
     description: Web client focused on browsing relay feeds
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/CodyTseng/jumble
     website: https://jumble.social
     status: active
@@ -155,7 +155,7 @@ social_clients:
 
   - name: Satellite
     description: Reddit-style threaded discussions
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/lovvtide/satellite-web
     website: https://satellite.earth
     status: active
@@ -164,7 +164,7 @@ social_clients:
   # --- Desktop ---
   - name: Gossip
     description: Desktop client for power users with outbox model
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/mikedilger/gossip
     maintainer: mikedilger
     status: active
@@ -173,7 +173,7 @@ social_clients:
 
   - name: Notedeck
     description: Fast native desktop client by Damus team
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/damus-io/notedeck
     website: https://notedeck.io
     maintainer: jb55
@@ -183,7 +183,7 @@ social_clients:
 
   - name: Lume
     description: Cross-platform desktop app
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/lumehq/lume
     website: https://lume.nu
     status: active
@@ -191,7 +191,7 @@ social_clients:
 
   - name: Nostrmo
     description: Cross-platform Flutter Nostr client
-    platforms: [android, ios, macos, windows, linux, web]
+    platforms: [ android, ios, macos, windows, linux, web ]
     repo: https://github.com/haorendashu/nostrmo
     status: active
     priority: low
@@ -199,17 +199,18 @@ social_clients:
 
   - name: Nostria
     description: Modern cross-platform Nostr client built for global scale
-    platforms: [android, ios, windows, web]
+    platforms: [ android, ios, windows, web ]
     repo: https://github.com/nostria-app/nostria
     website: https://www.nostria.app
     maintainer: sondreb
     status: active
     priority: medium
-    notes: Premium cloud infrastructure, dedicated relays, media hosting, automated backups
+    notes: Premium cloud infrastructure, dedicated relays, media hosting, automated
+      backups
 
   - name: Alphaama
     description: Nostr client implementation
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/eskema/alphaama
     status: active
     priority: low
@@ -217,7 +218,7 @@ social_clients:
 
   - name: Openvibe
     description: Multi-network app combining Mastodon, Bluesky, Nostr, and Threads
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/plebstr/plebstr
     website: https://openvibe.social
     status: active
@@ -226,7 +227,7 @@ social_clients:
 
   - name: Voyage
     description: Lightweight Reddit-style Android client with offline-first design
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/dluvian/voyage
     status: active
     priority: medium
@@ -234,7 +235,7 @@ social_clients:
 
   - name: Yana
     description: Cross-platform Flutter client with gossip model relay discovery
-    platforms: [android, ios, macos, windows, linux, web]
+    platforms: [ android, ios, macos, windows, linux, web ]
     repo: https://github.com/frnandu/yana
     status: active
     priority: low
@@ -242,7 +243,7 @@ social_clients:
 
   - name: Coop
     description: Fast Rust desktop client for secure direct messaging
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/lumehq/coop
     status: beta
     priority: medium
@@ -250,7 +251,7 @@ social_clients:
 
   - name: Seer
     description: Swift-native NIP-29 group client for Apple platforms
-    platforms: [ios, macos]
+    platforms: [ ios, macos ]
     repo: https://github.com/Galaxoid-Labs/Seer
     status: active
     priority: medium
@@ -258,7 +259,7 @@ social_clients:
 
   - name: Nostter
     description: Clean Twitter-like web client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/SnowCait/nostter
     website: https://nostter.app
     status: active
@@ -266,7 +267,7 @@ social_clients:
 
   - name: Lumilumi
     description: Lightweight web client with low-data modes for accessibility
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/TsukemonoGit/lumilumi
     website: https://lumilumi.app
     status: active
@@ -275,15 +276,15 @@ social_clients:
 
   - name: Zapddit
     description: Reddit-style client with hashtag feeds and Upzap voting
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vivganes/zapddit
     status: active
     priority: low
     notes: Upzaps send sats to authors, Downzaps to charity
 
   - name: Spring
-    description: Android Nostr browser for micro-app ecosystem
-    platforms: [android]
+    description: Android Nostr browser for micro-app catalog
+    platforms: [ android ]
     repo: https://github.com/nostrband/nostr-universe
     status: active
     priority: medium
@@ -291,15 +292,16 @@ social_clients:
 
   - name: Clawstr
     description: Reddit-inspired platform where AI agents create and manage communities
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/clawstr/clawstr
     status: active
     priority: medium
     notes: AI-powered community creation on Nostr
 
   - name: HiveTalk
-    description: Open source real-time video conferencing with Nostr and Lightning integration
-    platforms: [web]
+    description: Open source real-time video conferencing with Nostr and Lightning
+      integration
+    platforms: [ web ]
     repo: https://github.com/hivetalk/hivetalksfu
     website: https://hivetalk.org
     status: active
@@ -307,15 +309,16 @@ social_clients:
     notes: Nostr + Lightning powered video calls
 
   - name: Alexandria
-    description: Knowledge base and eReader app implementing NKBIP-01 for decentralized publishing
-    platforms: [web]
+    description: Knowledge base and eReader app implementing NKBIP-01 for
+      decentralized publishing
+    platforms: [ web ]
     repo: https://github.com/ShadowySupercode/gc-alexandria
     status: active
     priority: medium
 
   - name: Groups
     description: NIP-29 group chat web client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/max21dev/groups
     website: https://groups.nip29.com
     status: active
@@ -324,7 +327,7 @@ social_clients:
 
   - name: LUMINA
     description: Picture-first Nostr web client for image feeds
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/lumina-rocks/lumina
     website: https://lumina.rocks
     status: active
@@ -332,7 +335,7 @@ social_clients:
 
   - name: Nostrube
     description: Nostr-based video sharing platform
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/flox1an/nostube
     website: https://nostu.be
     status: active
@@ -340,14 +343,14 @@ social_clients:
 
   - name: Locus
     description: End-to-end encrypted location sharing on Nostr
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/Myzel394/locus
     status: active
     priority: low
 
   - name: Roadstr
     description: Decentralized road event reporting using Nostr and MeshCore
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/jooray/roadstr
     status: active
     priority: low
@@ -355,7 +358,7 @@ social_clients:
 
   - name: Agora
     description: Topic-following client for Nostr, Mastodon, Reddit, Bluesky, and Twitter
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/ghobs91/agora
     website: https://agorasocial.app
     status: active
@@ -364,7 +367,7 @@ social_clients:
 
   - name: Meetstr
     description: NIP-52 calendar client for meetups and community events
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/gillohner/meetstr
     website: https://meetstr.com
     status: active
@@ -373,15 +376,16 @@ social_clients:
 
   - name: Plektos
     description: Decentralized meetup, events, and calendar platform on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/derekross/plektos
     website: https://plektos.app
     status: active
     priority: medium
 
   - name: Evento
-    description: Social event management platform with a built-in self-custodial Lightning wallet
-    platforms: [web]
+    description: Social event management platform with a built-in self-custodial
+      Lightning wallet
+    platforms: [ web ]
     repo: https://github.com/sevenlabsxyz/evento-client
     maintainer: sevenlabsxyz
     status: active
@@ -390,7 +394,7 @@ social_clients:
 
   - name: Calendar by Form*
     description: Decentralized calendar app with NIP-59 private event sharing
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/formstr-hq/nostr-calendar
     website: https://calendar.formstr.app
     status: active
@@ -399,23 +403,24 @@ social_clients:
 
   - name: Nostree
     description: Linktree-style application for managing link lists on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/gzuuus/linktr-nostr
     website: https://nostree.me
     status: active
     priority: low
 
   - name: Fevela
-    description: Social client with innovative interface for attention and time control
-    platforms: [web]
+    description: Social client with attention-control and time-budget UI
+    platforms: [ web ]
     repo: https://github.com/dtonon/fevela
     website: https://fevela.me
     status: active
     priority: low
 
   - name: Nalgorithm
-    description: Relevance-ranked Nostr feed and digest generator using user-defined and learned preferences
-    platforms: [web, cli]
+    description: Relevance-ranked Nostr feed and digest generator using user-defined
+      and learned preferences
+    platforms: [ web, cli ]
     repo: https://github.com/jooray/nalgorithm
     website: https://cypherpunk.today/nalgorithm/
     maintainer: jooray
@@ -425,7 +430,7 @@ social_clients:
 
   - name: Docstr
     description: Collaborative documents platform (Google Docs alternative) on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sepehr-safari/docstr
     website: https://docstr.app
     status: active
@@ -434,7 +439,7 @@ social_clients:
 
   - name: Nostr-Doc
     description: Collaborative Markdown editor using Nostr relays and Yjs CRDT sync
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/formstr-hq/nostr-docs
     website: https://nostr-docs.vercel.app
     status: active
@@ -443,14 +448,14 @@ social_clients:
 
   - name: Oracolo
     description: Minimalist blog powered by Nostr in a single HTML file
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dtonon/oracolo
     status: active
     priority: low
 
   - name: Gittr
     description: Decentralized Git platform with zaps, bounties, SSH keys, and NIP-34
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/arbadacarbaYK/gittr
     website: https://gittr.space
     status: active
@@ -458,7 +463,7 @@ social_clients:
 
   - name: Samiz
     description: BLE mesh for Nostr notes when the internet is down
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/KoalaSat/Samiz
     status: active
     priority: medium
@@ -466,7 +471,7 @@ social_clients:
 
   - name: Nostrid
     description: Multi-platform client for Android, Windows, macOS, and Linux
-    platforms: [android, windows, macos, linux]
+    platforms: [ android, windows, macos, linux ]
     repo: https://github.com/lapulpeta/Nostrid
     website: https://web.nostrid.app
     status: active
@@ -474,14 +479,14 @@ social_clients:
 
   - name: Nootti
     description: Cross-posting iOS/iPad client for Bluesky, Mastodon, and Nostr
-    platforms: [ios]
+    platforms: [ ios ]
     website: https://nootti.com
     status: active
     priority: low
 
   - name: Blockcore Notes
     description: PWA with circles and public/private following lists
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/block-core/blockcore-notes
     website: https://notes.blockcore.net
     status: active
@@ -489,22 +494,23 @@ social_clients:
 
   - name: Swarmstr
     description: Q&A Nostr client for finding answers from #asknostr activity
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/ptrio42/swarmstr.com
     website: https://swarmstr.com
     status: active
     priority: low
 
   - name: Brezn
-    description: PWA client for local networking using geohash - like CB radio for the internet
-    platforms: [web]
+    description: PWA client for local networking using geohash - like CB radio for
+      the internet
+    platforms: [ web ]
     repo: https://github.com/DaBena/Brezn
     status: active
     priority: low
 
   - name: Pollstr
     description: Nostr web client focused on polls
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/mroxso/pollstr
     website: https://pollstr.online
     status: active
@@ -512,14 +518,14 @@ social_clients:
 
   - name: Tamga
     description: Offline-first nostr contact and profile manager for iOS
-    platforms: [ios]
+    platforms: [ ios ]
     repo: https://github.com/erdaltoprak/tamga
     status: active
     priority: low
 
   - name: YakBak
     description: Voice message social platform built on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/fiatjaf/yakbak2
     website: https://yakbak.app
     status: active
@@ -527,28 +533,28 @@ social_clients:
 
   - name: Bookstr
     description: Book tracking and sharing on decentralized Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://bookstr.xyz
     status: active
     priority: low
 
   - name: Satlantis
     description: Social discovery app for events, calendars, communities, and destinations
-    platforms: [web]
+    platforms: [ web ]
     website: https://satlantis.io
     status: active
     priority: low
 
   - name: Treasures
     description: Decentralized geocaching adventure powered by Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://treasures.to
     status: active
     priority: low
 
   - name: Pinstr
     description: Decentralized social network for curating and sharing interests
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sepehr-safari/pinstr
     website: https://pinstr.app
     status: active
@@ -556,14 +562,14 @@ social_clients:
 
   - name: mapstr
     description: Find local businesses accepting BTC with reviews and zaps
-    platforms: [web]
+    platforms: [ web ]
     website: https://mapstr.xyz
     status: active
     priority: low
 
   - name: Minds
     description: Open source social network with Nostr protocol support
-    platforms: [web]
+    platforms: [ web ]
     website: https://www.minds.com
     status: active
     priority: low
@@ -571,14 +577,15 @@ social_clients:
 
   - name: Nozzle
     description: Lightweight Android nostr client
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/dluvian/Nozzle
     status: active
     priority: low
 
   - name: nostr_console
-    description: Nostr console client, open-source Twitter-like social network with DMs and group chat
-    platforms: [cli]
+    description: Nostr console client, open-source Twitter-like social network with
+      DMs and group chat
+    platforms: [ cli ]
     repo: https://github.com/vishalxl/nostr_console
     status: inactive
     priority: low
@@ -586,7 +593,7 @@ social_clients:
 
   - name: nostros
     description: FOSS Android Nostr client with relay management and encrypted DMs
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/KoalaSat/nostros
     status: inactive
     priority: low
@@ -594,7 +601,7 @@ social_clients:
 
   - name: more-speech
     description: Nostr browser written in Clojure
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/unclebob/more-speech
     status: inactive
     priority: low
@@ -602,7 +609,7 @@ social_clients:
 
   - name: branle
     description: Twitter-like Nostr web client made with Quasar framework
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/fiatjaf/branle
     status: inactive
     priority: low
@@ -610,7 +617,7 @@ social_clients:
 
   - name: Nosky
     description: Native Android client for Nostr
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/KotlinGeekDev/Nosky
     status: active
     priority: low
@@ -618,28 +625,29 @@ social_clients:
 
   - name: rabbit
     description: TweetDeck-like multi-column Nostr client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/syusui-s/rabbit
     status: active
     priority: low
 
   - name: Flycat
     description: Nostr web client for exploring long-form and social content
-    platforms: [web]
+    platforms: [ web ]
     website: https://flycat.club
     status: active
     priority: low
 
   - name: FreeFrom
     description: Privacy and free speech SNS app
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     website: https://freefrom.space
     status: active
     priority: low
 
   - name: Futr
-    description: Native Nostr desktop client in Haskell, supports NIP-29 groups and NIP-17 DMs
-    platforms: [linux, windows, macos, android, ios]
+    description: Native Nostr desktop client in Haskell, supports NIP-29 groups and
+      NIP-17 DMs
+    platforms: [ linux, windows, macos, android, ios ]
     repo: https://github.com/futrnostr/futr
     website: https://futrnostr.com
     status: active
@@ -648,50 +656,51 @@ social_clients:
 
   - name: Oddbean
     description: Hacker News style Nostr client
-    platforms: [web]
+    platforms: [ web ]
     website: https://oddbean.com
     status: active
     priority: low
 
   - name: Phoenix
     description: Twitter-like web client for Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://phoenix.social
     status: active
     priority: low
 
   - name: Wired
     description: Anonymous-first agora with Proof-of-Work spam prevention
-    platforms: [web]
+    platforms: [ web ]
     website: https://www.getwired.app
     status: active
     priority: low
 
   - name: Joyboy
     description: Decentralized social built on Nostr and powered by Starknet
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/keep-starknet-strange/joyboy
     status: active
     priority: low
 
   - name: bbs-on-nostr
     description: BBS-style message board on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/murakmii/bbs-on-nostr
     status: active
     priority: low
 
   - name: Nostroots
     description: Migration of Trustroots.org hospitality network onto Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Trustroots/nostroots
     status: beta
     priority: low
-    notes: OpenSats funded, 100K+ member network, aims for full decentralization by 2027
+    notes: OpenSats funded, 100K+ member network, aims for full decentralization by
+      2027
 
   - name: Jester
     description: Chess game on Nostr with Bitcoin micropayments and zaps
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/jesterui/jesterui
     status: active
     priority: low
@@ -699,7 +708,7 @@ social_clients:
 
   - name: ONOSENDAI
     description: Experimental 3D cyberspace visualization of the Nostr protocol
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/arkin0x/cyberspace
     status: beta
     priority: low
@@ -707,7 +716,7 @@ social_clients:
 
   - name: Flockstr
     description: Calendar events app on Nostr, alternative to Eventbrite/Meetups
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/zmeyer44/flockstr
     status: active
     priority: low
@@ -715,14 +724,14 @@ social_clients:
 
   - name: nostr-attached
     description: Open-source mobile client for Nostr
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/dyegolara/nostr-attached
     status: inactive
     priority: low
 
   - name: narr
     description: Self-hosted Nostr and RSS reader
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/fiatjaf/narr
     status: active
     priority: low
@@ -730,11 +739,76 @@ social_clients:
 
   - name: Nostr Feedz
     description: Web app for following RSS feeds alongside Nostr long-form content
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/PlebOne/Nostr-Feedz
     status: active
     priority: low
     notes: OpenSats funded, includes WoT-based relay at relay.pleb.one
+  - name: Zappix
+    description: Image sharing client for browsing, posting, and zapping visual content
+    platforms:
+      - web
+    repo: https://github.com/derekross/zappix
+    website: https://zappix.app
+    maintainer: derekross
+    status: active
+    priority: medium
+  - name: Wherostr
+    description: Geo-social client with location-based feeds
+    platforms:
+      - ios
+      - android
+    repo: https://github.com/mapboss/wherostr_social
+    status: active
+    priority: medium
+  - name: Votestr
+    description: Poll web app with Nostr authentication and blind signature unlinkability
+    platforms:
+      - web
+    repo: https://github.com/vilm3r/votestr
+    website: https://votestr.com
+    status: active
+    priority: medium
+  - name: Pretty Good Apps
+    description: Desktop client focused on decentralized reputation and web of trust
+    platforms:
+      - linux
+      - macos
+      - windows
+    repo: https://github.com/wds4/pretty-good
+    maintainer: wds4
+    status: active
+    priority: medium
+  - name: Memestr
+    description: Hub for sharing memes and visual humor
+    platforms:
+      - web
+    website: https://memestr.app
+    status: active
+    priority: low
+  - name: Streakstr
+    description: Daily activity tracker with streak monitoring via bot
+    platforms:
+      - web
+    repo: https://github.com/theakash04/Streakstr
+    status: active
+    priority: low
+  - name: Member
+    description: Progressive web app client that runs on desktop and mobile
+    platforms:
+      - web
+    repo: https://github.com/memberapp/memberapp.github.io
+    website: https://member.cash
+    status: active
+    priority: low
+  - name: Hook Cafe
+    description: Social app for connecting people to meet in real life
+    platforms:
+      - web
+    repo: https://github.com/kuba-04/hook.cafe
+    website: https://hook.cafe
+    status: active
+    priority: low
 
 # =============================================================================
 # LONG-FORM CONTENT
@@ -743,7 +817,7 @@ social_clients:
 longform_clients:
   - name: Habla
     description: Long-form content publishing (NIP-23)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/verbiricha/habla.news
     website: https://habla.news
     maintainer: verbiricha
@@ -753,7 +827,7 @@ longform_clients:
 
   - name: YakiHonne
     description: Multi-platform long-form client with mobile apps
-    platforms: [web, ios, android]
+    platforms: [ web, ios, android ]
     repo: https://github.com/YakiHonne/yakihonne-mobile-app
     website: https://yakihonne.com
     status: active
@@ -762,7 +836,7 @@ longform_clients:
 
   - name: Highlighter
     description: Content curation and highlighting
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/pablof7z/highlighter
     website: https://highlighter.com
     maintainer: pablof7z
@@ -772,7 +846,7 @@ longform_clients:
 
   - name: Boris
     description: Improved highlighting client for Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dergigi/boris
     status: active
     priority: low
@@ -780,7 +854,7 @@ longform_clients:
 
   - name: blogstack.io
     description: Blogging site for nostr with markdown support
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nodetec/blogstack
     website: https://blogstack.io
     status: active
@@ -788,42 +862,42 @@ longform_clients:
 
   - name: Untype
     description: Long-form content writing and publishing client
-    platforms: [web]
+    platforms: [ web ]
     website: https://untype.app
     status: active
     priority: low
 
   - name: Breefly
     description: Low-stimulus reading environment for Nostr long-form articles
-    platforms: [web]
+    platforms: [ web ]
     website: https://breefly.social
     status: active
     priority: low
 
   - name: blogo
     description: Lightweight blogging engine that backs up to Nostr
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/pluja/blogo
     status: active
     priority: low
 
   - name: notestack
     description: Decentralized blogging platform using Nostr relays with Lightning tips
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nodetec/notestack
     status: active
     priority: low
 
   - name: MAKIMONO
     description: Barebones app for publishing long-form articles on Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://makimono.lumilumi.app
     status: active
     priority: low
 
   - name: Noflux
     description: Desktop RSS and Nostr long-form content reader
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/fiatjaf/noflux
     status: active
     priority: low
@@ -831,7 +905,7 @@ longform_clients:
 
   - name: Captain's Log
     description: Nostr-native desktop note-taking app with markdown support
-    platforms: [linux, macos, windows]
+    platforms: [ linux, macos, windows ]
     repo: https://github.com/nodetec/captains-log
     status: active
     priority: low
@@ -839,7 +913,7 @@ longform_clients:
 
   - name: Samizdat
     description: Writer-first publishing tool for NIP-23 long-form articles
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/satsdisco/samizdat
     website: https://samizdat.press
     status: active
@@ -848,12 +922,34 @@ longform_clients:
 
   - name: Manent
     description: Private encrypted notes and file storage built on Nostr
-    platforms: [web, android, linux, macos]
+    platforms: [ web, android, linux, macos ]
     repo: https://github.com/dtonon/manent
     website: https://manent.dtonon.com
     status: active
     priority: low
     notes: Uses NIP-44 encryption, NIP-46, NIP-55, NIP-65, and Blossom storage
+  - name: Pareto
+    description: Publishing client for citizen journalism and long-form articles
+    platforms:
+      - web
+    website: https://pareto.space/read
+    status: active
+    priority: medium
+  - name: Decent Newsroom
+    description: Long-form articles and magazines client for publishers and readers
+    platforms:
+      - web
+    website: https://decentnewsroom.com
+    status: active
+    priority: medium
+  - name: uBlog
+    description: Minimalist personal micro-blog on Nostr
+    platforms:
+      - web
+    repo: https://github.com/nodetec/ublog
+    maintainer: nodetec
+    status: active
+    priority: low
 
 # =============================================================================
 # MESSAGING
@@ -862,7 +958,7 @@ longform_clients:
 messaging_clients:
   - name: 0xchat
     description: Telegram-style DMs and group chat with Cashu support
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/0xchat-app/0xchat-app-main
     maintainer: pextar
     status: active
@@ -871,7 +967,7 @@ messaging_clients:
 
   - name: White Noise
     description: MLS-based secure messaging client
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/marmot-protocol/whitenoise
     maintainer: erskingardner
     status: beta
@@ -880,7 +976,7 @@ messaging_clients:
 
   - name: Vector
     description: Privacy-focused desktop messenger with NIP-17/44/59 encryption
-    platforms: [windows, macos, linux, android]
+    platforms: [ windows, macos, linux, android ]
     repo: https://github.com/VectorPrivacy/Vector
     status: active
     priority: medium
@@ -888,7 +984,7 @@ messaging_clients:
 
   - name: Flotilla
     description: NIP-29 relay-based group chat
-    platforms: [web]
+    platforms: [ web ]
     repo: https://gitea.coracle.social/coracle/flotilla
     website: https://flotilla.social
     status: active
@@ -897,22 +993,23 @@ messaging_clients:
 
   - name: Chachi
     description: NIP-29 group chat client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/purrgrammer/chachi
     status: active
     priority: low
 
   - name: Bitchat
     description: Censorship-resistant messaging with Nostr and Cashu, offline via Bluetooth
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/permissionlesstech/bitchat
     status: active
     priority: medium
-    notes: Uses Noise Protocol for encryption, Cashu for offline payments via Bluetooth mesh
+    notes: Uses Noise Protocol for encryption, Cashu for offline payments via
+      Bluetooth mesh
 
   - name: KeyChat
     description: Private messaging app with Cashu integration
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/keychat-io/keychat-app
     status: active
     priority: low
@@ -920,7 +1017,7 @@ messaging_clients:
 
   - name: Pika
     description: E2E encrypted messaging using MLS protocol layered over Nostr relays
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/sledtools/pika
     status: active
     priority: medium
@@ -928,7 +1025,7 @@ messaging_clients:
 
   - name: Wisp
     description: Minimal messaging app using Marmot protocol for MLS-encrypted chat
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/barrydeen/wisp
     status: beta
     priority: low
@@ -936,7 +1033,7 @@ messaging_clients:
 
   - name: Marmota
     description: End-to-end encrypted group messaging client using the Marmot protocol
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dcadenas/marmota
     website: https://groups.privdm.com
     status: beta
@@ -945,15 +1042,15 @@ messaging_clients:
 
   - name: White Noise TUI
     description: Terminal-based client for White Noise MLS-encrypted messaging
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/marmot-protocol/wn-tui
     status: beta
     priority: medium
-    notes: CLI client in whitenoise-rs repo ecosystem
+    notes: CLI client in whitenoise-rs repo
 
   - name: nospeak
     description: Decentralized chat with NIP-17 E2E encryption and no metadata leakage
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/psic4t/nospeak
     status: active
     priority: medium
@@ -961,77 +1058,122 @@ messaging_clients:
 
   - name: Nostr Mail Client
     description: Flutter mail client for sending and receiving encrypted mail over Nostr
-    platforms: [android, linux, web]
+    platforms: [ android, linux, web ]
     repo: https://github.com/nogringo/nostr-mail-client
     website: https://nogringo.github.io/nostr-mail-client
     maintainer: nogringo
     status: active
     priority: low
-    notes: Traditional email-style UX on top of Nostr identities and encrypted delivery
+    notes: Traditional email-style UX on top of Nostr identities and encrypted
+      delivery
 
   - name: NostrChat
     description: Decentralized chat app built on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/NostrChat/NostrChat
     status: active
     priority: low
 
   - name: sendstr-web
     description: End-to-end encrypted shared clipboard built on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vilm3r/sendstr-web
     status: active
     priority: low
 
   - name: NYM
     description: Lightweight ephemeral chat client on Nostr, bridged with Bitchat
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Spl0itable/NYM
     status: active
     priority: low
 
   - name: nostribe
     description: Social tribe community client on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sepehr-safari/nostribe
     status: active
     priority: low
 
   - name: nostr-chat-widget
     description: Embeddable Nostr-based chat widget for websites
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/pablof7z/nostr-chat-widget
     status: active
     priority: low
 
   - name: denny
     description: Nostr client for encrypted group chat
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/denostr-lab/denny
     status: active
     priority: low
 
   - name: garnet
     description: Nostr Public Chat (NIP-28) client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/murakmii/garnet
     status: active
     priority: low
 
   - name: Coolr
     description: Minimalist IRC-like ephemeral chat built on Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://coolr.chat
     status: active
     priority: low
 
   - name: Blowater
     description: DM-focused Nostr client aiming to replace Telegram/Slack/Discord
-    platforms: [web, desktop]
+    platforms: [ web, desktop ]
     repo: https://github.com/BlowaterNostr/blowater
     status: active
     priority: low
     notes: OpenSats funded
+  - name: OstrichGram
+    description: Telegram-style desktop app for Linux and Windows with group chats and DMs
+    platforms:
+      - linux
+      - windows
+    website: https://ostrichgram.com
+    status: active
+    priority: medium
+  - name: gupt
+    description: Instant chat with video, audio, screen sharing, and private groups
+    platforms:
+      - web
+    website: https://gupt.app
+    status: active
+    priority: medium
+  - name: Beagle
+    description: Real-time text, audio, and video chat client for iOS
+    platforms:
+      - ios
+    repo: https://github.com/0xli/beagle.chat
+    status: active
+    priority: low
+  - name: Tides
+    description: Chrome extension messenger with built-in radio stream
+    platforms:
+      - browser
+    repo: https://github.com/arbadacarbayk/tides
+    status: active
+    priority: low
+
+  - name: Sprout
+    description: Hive mind communication platform by Block with Nostr relay and NIP support
+    platforms: [ desktop ]
+    repo: https://github.com/block/sprout
+    status: pre-alpha
+    priority: medium
+    notes: NIP-01, NIP-02, NIP-23, NIP-33 support, built-in Nostr relay
+
+  - name: OpenChat
+    description: Chat application built on dotnet-mls and marmot-cs
+    repo: https://github.com/DavidGershony/openChat
+    status: beta
+    priority: low
+    notes: .NET chat client using Marmot protocol over Nostr
 
 # =============================================================================
 # MEDIA & STREAMING
@@ -1040,7 +1182,7 @@ messaging_clients:
 media_clients:
   - name: Zap.stream
     description: Live streaming with Lightning zaps
-    platforms: [web, ios, android]
+    platforms: [ web, ios, android ]
     repo: https://github.com/v0l/zap.stream
     website: https://zap.stream
     maintainer: v0l
@@ -1050,7 +1192,7 @@ media_clients:
 
   - name: Olas
     description: Instagram-like photo sharing
-    platforms: [ios, android, web]
+    platforms: [ ios, android, web ]
     repo: https://github.com/pablof7z/olas
     maintainer: pablof7z
     status: active
@@ -1058,16 +1200,17 @@ media_clients:
 
   - name: Unfiltered
     description: Instagram-like photo sharing without algorithms or ads
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/dmcarrington/unfiltered
     maintainer: dmcarrington
     status: active
     priority: medium
-    notes: NIP-68 picture events, Blossom hosting, Lightning zaps, Amber signer support
+    notes: NIP-68 picture events, Blossom hosting, Lightning zaps, Amber signer
+      support
 
   - name: Nostr Nests
     description: Audio spaces (Clubhouse-like)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrnests/nests
     website: https://nostrnests.com
     status: active
@@ -1075,7 +1218,7 @@ media_clients:
 
   - name: Corny Chat
     description: Open source audio rooms
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vicariousdrama/cornychat
     website: https://cornychat.com
     status: active
@@ -1084,7 +1227,7 @@ media_clients:
 
   - name: diVine
     description: Short-form looping video client with restored Vine archives
-    platforms: [ios, android, web]
+    platforms: [ ios, android, web ]
     repo: https://github.com/divinevideo/divine-mobile
     website: https://divine.video
     maintainer: rabble
@@ -1094,7 +1237,7 @@ media_clients:
 
   - name: Wavlake
     description: Music streaming platform with Lightning zaps and NOM spec
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/wavlake/wavman
     website: https://wavlake.com
     status: active
@@ -1103,7 +1246,7 @@ media_clients:
 
   - name: Shosho
     description: Live streaming app with recording/VOD, room presence, and threaded chats
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/r0d8lsh0p/shosho-releases
     status: active
     priority: medium
@@ -1111,7 +1254,7 @@ media_clients:
 
   - name: NosCall
     description: Audio and video calling app with contact groups and relay management
-    platforms: [android, ios]
+    platforms: [ android, ios ]
     repo: https://github.com/sanah9/noscall
     status: active
     priority: medium
@@ -1119,7 +1262,7 @@ media_clients:
 
   - name: Fountain
     description: Podcast app with Nostr social integration and Lightning streaming
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     website: https://www.fountain.fm
     status: active
     priority: medium
@@ -1127,28 +1270,28 @@ media_clients:
 
   - name: Zaplife
     description: Aggregation of all Zaps across Nostr - the Zap leaderboard
-    platforms: [web]
+    platforms: [ web ]
     website: https://zaplife.lol
     status: active
     priority: low
 
   - name: Slidestr
     description: Immersive media browsing for images and videos on Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://slidestr.net
     status: active
     priority: low
 
   - name: Stemstr
     description: Music collaboration and sharing client for producers and artists
-    platforms: [web]
+    platforms: [ web ]
     website: https://stemstr.app
     status: active
     priority: low
 
   - name: Swae
     description: Mobile-first live streaming app on Nostr with Lightning zaps and Cashu
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/suhailsaqan/swae
     status: beta
     priority: low
@@ -1156,11 +1299,20 @@ media_clients:
 
   - name: Route96
     description: Nostr-integrated media backend for NIP-96 and Blossom file hosting
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/v0l/route96
     status: active
     priority: medium
-    notes: Thumbnails, compression, mirroring, Lightning-based storage limits. Deployed at nostr.download
+    notes: Thumbnails, compression, mirroring, Lightning-based storage limits.
+      Deployed at nostr.download
+
+  - name: Flora
+    description: Chrome extension for decentralized screen recording and sharing on Nostr
+    platforms: [ web ]
+    repo: https://github.com/shawnyeager/flora-extension
+    status: beta
+    priority: low
+    notes: Encrypted video sharing via NIP-17, AES-256-GCM, Blossom storage
 
 # =============================================================================
 # MARKETPLACES
@@ -1169,7 +1321,7 @@ media_clients:
 marketplaces:
   - name: Shopstr
     description: P2P marketplace with Lightning/Cashu (NIP-99)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/shopstr-eng/shopstr
     website: https://shopstr.store
     status: active
@@ -1177,7 +1329,7 @@ marketplaces:
 
   - name: Milk Market
     description: Food marketplace on Nostr with Lightning, Cashu, and fiat payment options
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/shopstr-eng/milk-market
     website: https://milk.market
     status: active
@@ -1186,7 +1338,7 @@ marketplaces:
 
   - name: Plebeian Market
     description: Bitcoin marketplace (NIP-15)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/PlebeianTech/plebeian-market
     website: https://plebeian.market
     status: active
@@ -1194,7 +1346,7 @@ marketplaces:
 
   - name: Mostro
     description: P2P Bitcoin exchange over Nostr
-    platforms: [cli, web]
+    platforms: [ cli, web ]
     repo: https://github.com/MostroP2P/mostro
     status: active
     priority: medium
@@ -1202,7 +1354,7 @@ marketplaces:
 
   - name: Mostro Mobile
     description: Mobile client for Mostro P2P Bitcoin exchange
-    platforms: [android, ios]
+    platforms: [ android, ios ]
     repo: https://github.com/MostroP2P/mobile
     status: active
     priority: medium
@@ -1210,7 +1362,7 @@ marketplaces:
 
   - name: SatShoot
     description: Freelancing platform on Nostr with Bitcoin payments
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Pleb5/satshoot
     status: active
     priority: medium
@@ -1218,33 +1370,34 @@ marketplaces:
 
   - name: Kartapio
     description: Restaurant menu and ordering with Bitcoin payments
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vstabile/kartapio
     status: active
     priority: low
     notes: SEC-02 project
 
-  - name: Pod21
-    description: Decentralized 3D printing marketplace with NIP-17 DM bot
-    platforms: [web]
-    repo: ""
-    status: beta
-    priority: medium
-    notes: Connects 3D printer operators with buyers via Nostr relay coordination. No public repo yet.
-
   - name: LNBits Nostrmarket
     description: LNBits extension for selling items directly via NIP-15
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/lnbits/nostrmarket
     status: active
     priority: low
 
   - name: Ostrich Work
     description: Job board over Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://ostrich.work
     status: active
     priority: low
+  - name: P2P band
+    description: Aggregator for P2P Bitcoin exchanges across multiple platforms
+    platforms:
+      - web
+    repo: https://github.com/KoalaSat/p2pband
+    website: https://p2p.band
+    maintainer: KoalaSat
+    status: active
+    priority: medium
 
 # =============================================================================
 # DEVELOPER TOOLS
@@ -1253,8 +1406,8 @@ marketplaces:
 devtools:
   - name: ngit
     description: Git collaboration over Nostr (NIP-34)
-    platforms: [cli]
-    repo: https://codeberg.org/DanConwayDev/ngit-cli
+    platforms: [ cli ]
+    repo: https://github.com/DanConwayDev/ngit-cli
     maintainer: DanConwayDev
     status: active
     priority: high
@@ -1262,7 +1415,7 @@ devtools:
 
   - name: GitWorkshop
     description: Web UI for git collaboration on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/DanConwayDev/gitworkshop
     website: https://gitworkshop.dev
     maintainer: DanConwayDev
@@ -1271,8 +1424,8 @@ devtools:
 
   - name: ZapStore
     description: Permissionless app store for Android
-    platforms: [android]
-    repo: https://github.com/ArcadeCity/zapstore
+    platforms: [ android ]
+    repo: https://github.com/zapstore/zapstore
     website: https://zapstore.dev
     status: active
     priority: medium
@@ -1280,7 +1433,7 @@ devtools:
 
   - name: Formstr
     description: Google Forms alternative on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/formstr-hq/nostr-forms
     website: https://formstr.app
     status: active
@@ -1289,7 +1442,7 @@ devtools:
 
   - name: Pollerama
     description: Polling app built on nostr-polls library
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/formstr-hq/nostr-polls
     website: https://pollerama.fun
     status: active
@@ -1298,15 +1451,16 @@ devtools:
 
   - name: Verify
     description: File integrity verification using a decentralized Nostr web of trust
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/tinfoilhash/verify
     website: https://verify.tinfoilhash.com
     status: active
     priority: low
 
   - name: Attestr
-    description: Web app for searching assertions, publishing attestations, and inspecting trust signals on Nostr
-    platforms: [web]
+    description: Web app for searching assertions, publishing attestations, and
+      inspecting trust signals on Nostr
+    platforms: [ web ]
     website: https://attestr.xyz/
     status: active
     priority: low
@@ -1314,23 +1468,15 @@ devtools:
 
   - name: Blossom Uploader
     description: CLI uploader for Blossom-compatible media servers
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/djinoz/blossom_uploader
     status: active
     priority: low
     notes: Supports Blossom authentication with Nostr nsec keys
 
-  - name: Nostrability Outbox
-    description: Outbox model benchmark suite and test results across clients
-    platforms: [web]
-    repo: https://github.com/nostrability/outbox
-    status: active
-    priority: medium
-    notes: Benchmarks outbox model (NIP-65) implementation quality across clients
-
   - name: NoorNote
     description: Nostr-based note-taking application
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/77elements/noornote
     status: beta
     priority: low
@@ -1338,7 +1484,7 @@ devtools:
 
   - name: Wikistr
     description: Wikipedia-like wiki client
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/fiatjaf/wikistr
     website: https://wikistr.com
     status: active
@@ -1346,7 +1492,7 @@ devtools:
 
   - name: Nostr Army Knife (nak)
     description: Multi-purpose CLI tool by fiatjaf
-    platforms: [cli, web]
+    platforms: [ cli, web ]
     repo: https://github.com/fiatjaf/nak
     website: https://nak.nostr.com
     maintainer: fiatjaf
@@ -1355,7 +1501,7 @@ devtools:
 
   - name: GitPear
     description: Git collaboration tool with Nostr integration
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/dzdidi/gitpear
     status: active
     priority: low
@@ -1363,7 +1509,7 @@ devtools:
 
   - name: Sigit
     description: Document signing tool using Nostr and Blossom
-    platforms: [web]
+    platforms: [ web ]
     repo: https://git.nostrdev.com/sigit/sigit.io
     website: https://sigit.io
     status: active
@@ -1372,32 +1518,24 @@ devtools:
 
   - name: Nostr Writer
     description: Obsidian plugin for publishing notes to Nostr
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/jamesmagoo/nostr-writer
     status: active
     priority: low
     notes: Long-form and short-form publishing, image support
 
-  - name: Schemata
-    description: JSON Schema definitions for validating Nostr events, messages, and tags
-    repo: https://github.com/nostrability/schemata
-    maintainer: alltheseas
-    status: active
-    priority: medium
-    notes: JSON Schema Draft-07, useful for integration testing and fuzz testing
-
   - name: relay-tester
     description: Test suite for verifying Nostr relay implementations
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/mikedilger/relay-tester
     maintainer: mikedilger
     status: active
     priority: medium
-    notes: By Gossip creator, comprehensive relay testing
+    notes: By Gossip creator, thorough relay testing
 
   - name: algia
     description: Full-featured CLI client with timeline, posting, zaps, and DMs
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/mattn/algia
     status: active
     priority: medium
@@ -1405,15 +1543,15 @@ devtools:
 
   - name: DVMDash
     description: Monitoring and debugging dashboard for DVM/AI activity on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dtdannen/dvmdash
     status: active
     priority: medium
-    notes: NIP-90 ecosystem visibility
+    notes: NIP-90 implementations visibility
 
   - name: nostr-webhook
     description: Webhook bot with event matching and cron scheduling
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/mattn/nostr-webhook
     status: active
     priority: low
@@ -1421,15 +1559,15 @@ devtools:
 
   - name: matrix-nostr-bridge
     description: Bridge between Matrix and Nostr protocols
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/nicfab/matrix-nostr-bridge
     status: active
     priority: medium
     notes: Federation bridge
 
   - name: DVMCP
-    description: Bridge connecting MCP servers to Nostr DVM ecosystem
-    platforms: [cli]
+    description: Bridge connecting MCP servers to Nostr DVMs
+    platforms: [ cli ]
     repo: https://github.com/gzuuus/dvmcp
     status: active
     priority: medium
@@ -1437,16 +1575,17 @@ devtools:
 
   - name: nostrain
     description: Coordinator-free distributed machine learning training over Nostr relays
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/AbdelStark/nostrain
     maintainer: AbdelStark
     status: beta
     priority: low
-    notes: DiLoCo over Nostr, signed gradient exchange, checkpointing and worker discovery
+    notes: DiLoCo over Nostr, signed gradient exchange, checkpointing and worker
+      discovery
 
   - name: Nostr MCP Server
     description: MCP server enabling AI agents to interact with the Nostr network
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/AustinKelsay/nostr-mcp-server
     maintainer: AustinKelsay
     status: active
@@ -1455,7 +1594,7 @@ devtools:
 
   - name: Mostro Skill
     description: MCP skill for trading on Mostro P2P exchange via Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/MostroP2P/mostro-skill
     status: active
     priority: low
@@ -1463,14 +1602,14 @@ devtools:
 
   - name: SyncStr
     description: Web app for synchronizing Nostr profile data across relays
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/derekross/syncstr
     status: active
     priority: low
 
   - name: cuda_vanity
     description: GPU-accelerated vanity npub generator using NVIDIA CUDA
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/v0l/cuda_vanity
     maintainer: v0l
     status: active
@@ -1479,7 +1618,7 @@ devtools:
 
   - name: rana
     description: Rust vanity key miner with difficulty customization
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/grunch/rana
     status: active
     priority: low
@@ -1487,15 +1626,15 @@ devtools:
 
   - name: Bucket
     description: Simple in-memory relay for testing (<100 LOC)
-    platforms: [cli]
-    repo: https://gitea.coracle.social/coracle/bucket
+    platforms: [ cli ]
+    repo: https://github.com/coracle-social/bucket
     status: active
     priority: low
     notes: By Coracle team, for development/testing
 
   - name: nostr-idb
     description: Helper methods for storing Nostr events in IndexedDB
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/hzrd149/nostr-idb
     status: active
     priority: low
@@ -1503,7 +1642,7 @@ devtools:
 
   - name: go-dvm
     description: Go implementation of Data Vending Machine
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/sebdeveloper6952/godvm
     status: active
     priority: low
@@ -1511,7 +1650,7 @@ devtools:
 
   - name: spryte
     description: Lightweight Nostr client library
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/sandwichfarm/spryte
     status: active
     priority: low
@@ -1519,7 +1658,7 @@ devtools:
 
   - name: nsite-manager
     description: Management interface for nsite hosting
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hzrd149/nsite-manager
     status: active
     priority: low
@@ -1527,7 +1666,7 @@ devtools:
 
   - name: Backyard Explorer
     description: Example search app for window.nostrdb
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hzrd149/backyard-explorer
     status: active
     priority: low
@@ -1535,7 +1674,7 @@ devtools:
 
   - name: Instagram to Nostr v2
     description: Content migration tool from Instagram, TikTok, Twitter, Substack to Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/primalpaul1/instagram-to-nostr-v2
     status: active
     priority: low
@@ -1543,7 +1682,7 @@ devtools:
 
   - name: NostrDVM
     description: Python framework for building NIP-90 Data Vending Machines
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/believethehype/nostrdvm
     status: active
     priority: medium
@@ -1551,7 +1690,7 @@ devtools:
 
   - name: NWS
     description: Route TCP traffic over Nostr relays
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/asmogo/nws
     status: active
     priority: medium
@@ -1559,7 +1698,7 @@ devtools:
 
   - name: Bloom
     description: File manager for Blossom and NIP-96 servers with metadata editing
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Letdown2491/bloom
     website: https://bloomapp.me
     status: active
@@ -1568,31 +1707,23 @@ devtools:
 
   - name: NOW (Nostr Outbox for WordPress)
     description: WordPress/WooCommerce notifications via Nostr with Lightning payments
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Mnpezz/nostr-outbox-for-wordpress
     status: active
     priority: low
 
   - name: Ghostr
     description: Post delegation workflow - writers draft, publishers sign
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dmnyc/ghostr
     website: https://ghostr.org
     status: active
     priority: low
 
-  - name: schemata-codegen
-    description: Nostr code generator that ports schemata schemas to typed native language constructs
-    platforms: [cli]
-    repo: https://github.com/nostrability/schemata-codegen
-    maintainer: nostrability
-    status: beta
-    priority: low
-    notes: Produces typed tag tuples, kind interfaces, runtime validators from schemata schemas
-
   - name: nostr-wot-oracle
-    description: Global follow-graph indexer answering pairwise distance queries between pubkeys
-    platforms: [cli]
+    description: Global follow-graph indexer answering pairwise distance queries
+      between pubkeys
+    platforms: [ cli ]
     repo: https://github.com/nostr-wot/nostr-wot-oracle
     status: active
     priority: medium
@@ -1600,21 +1731,21 @@ devtools:
 
   - name: Grapevine Client
     description: Web client for the My Grapevine web of trust system
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Pretty-Good-Freedom-Tech/grapevine-client
     status: active
     priority: low
 
   - name: blossy
     description: Framework for building custom Blossom servers with full protocol compliance
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/pippellia-btc/blossy
     status: active
     priority: medium
 
   - name: nostr-crdt
     description: Nostr-CRDT Yjs provider for collaborative local-first apps
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/YousefED/nostr-crdt
     status: active
     priority: low
@@ -1622,7 +1753,7 @@ devtools:
 
   - name: Nostr Playground
     description: Simple and user-friendly playground for Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sepehr-safari/nostr-playground
     website: https://playground.nostr.com
     status: active
@@ -1630,7 +1761,7 @@ devtools:
 
   - name: Primal Caching Service
     description: Event caching service collecting and serving nostr events via WebSocket API
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/PrimalHQ/primal-caching-service
     status: active
     priority: medium
@@ -1638,28 +1769,28 @@ devtools:
 
   - name: nostcat
     description: Cat-like nostr client for scripting and debugging in Rust
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/blakejakopovic/nostcat
     status: active
     priority: low
 
   - name: nostr-commander
     description: CLI-based Nostr app for following users and sending DMs
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/8go/nostr-commander-rs
     status: active
     priority: low
 
   - name: nostr-tool
     description: Rust CLI tool to generate and publish events
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/0xtrr/nostr-tool
     status: active
     priority: low
 
   - name: nostril
     description: C CLI tool for creating nostr events
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/jb55/nostril
     maintainer: jb55
     status: active
@@ -1667,14 +1798,14 @@ devtools:
 
   - name: nosdump
     description: CLI tool to download events stored in Nostr relays
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/jiftechnify/nosdump
     status: active
     priority: low
 
   - name: strfry-policies
     description: Collection of moderation and antispam policies for strfry relay
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://gitlab.com/soapbox-pub/strfry-policies
     status: active
     priority: low
@@ -1682,49 +1813,49 @@ devtools:
 
   - name: Chief
     description: Strfry write policy plugin with blacklists for keys, kinds, words
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/0xtrr/chief
     status: active
     priority: low
 
   - name: nostrillery
     description: Tool for running performance tests against Nostr relays
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/Cameri/nostrillery
     status: active
     priority: low
 
   - name: nostdress
     description: Lightning address server with NIP-05 and NIP-57 support
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/believethehype/nostdress
     status: active
     priority: low
 
   - name: NostrAirTracker
     description: Flight tracking on Nostr (Elonjet-style)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/gourcetools/NostrAirTracker
     status: active
     priority: low
 
   - name: Listr
     description: Create, manage, and browse Nostr lists for content curation
-    platforms: [web]
+    platforms: [ web ]
     website: https://listr.lol
     status: active
     priority: low
 
   - name: NostrGit
     description: Censorship-resistant alternative to GitHub built on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/NostrGit/NostrGit
     status: active
     priority: low
 
   - name: noscl
     description: Command line client for Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/fiatjaf/noscl
     status: active
     priority: low
@@ -1732,108 +1863,85 @@ devtools:
 
   - name: nostr.directory
     description: Find people you know from other social media on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/pseudozach/nostr.directory
     status: active
     priority: low
 
   - name: key-convertr
     description: Convert Nostr keys and note-ids between hex and bech32
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/rot13maxi/key-convertr
     status: active
     priority: low
 
   - name: kanbanstr
     description: Kanban board on Nostr using public events
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vivganes/kanbanstr
     status: active
     priority: low
 
   - name: nostatus
     description: Web client for browsing user status (NIP-38)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/jiftechnify/nostatus
     status: active
     priority: low
 
   - name: nostracker
     description: Website for collecting and analyzing information from the Nostr network
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/marcodpt/nostracker
     status: active
     priority: low
 
   - name: Nostr-Clients-Features-List
     description: Comparison of Nostr clients and NIP support
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vishalxl/Nostr-Clients-Features-List
     status: active
     priority: low
 
   - name: Bouquet
     description: Personal manager for Blossom media servers
-    platforms: [web]
+    platforms: [ web ]
     website: https://bouquet.slidestr.net
     status: active
     priority: low
 
   - name: Emojito
     description: Create custom emoji sets for Nostr clients
-    platforms: [web]
+    platforms: [ web ]
     website: https://emojito.meme
     status: active
     priority: low
 
   - name: GIF Buddy
     description: Make GIFs available inside Nostr clients
-    platforms: [web]
+    platforms: [ web ]
     website: https://gifbuddy.lol
-    status: active
-    priority: low
-
-  - name: Grimoire
-    description: Meta-client power-user tool for Nostr
-    platforms: [web]
-    status: active
-    priority: low
-
-  - name: Lantern
-    description: Collaboratively annotate, highlight, and bookmark web pages/PDFs on Nostr
-    platforms: [browser]
     status: active
     priority: low
 
   - name: Nostr App Manager
     description: Discover Nostr apps, DVMs, and code repos
-    platforms: [web]
+    platforms: [ web ]
     website: https://nostrapp.link
-    status: active
-    priority: low
-
-  - name: Relay Tools
-    description: Android app for browsing and managing Nostr relays
-    platforms: [android]
-    status: active
-    priority: low
-
-  - name: Shakespeare
-    description: Open-source AI website builder with full local control
-    platforms: [web]
     status: active
     priority: low
 
   - name: Zapplepay
     description: Zap from any client, bypass Apple restrictions via NWC
-    platforms: [web]
+    platforms: [ web ]
     website: https://www.zapplepay.com
     status: active
     priority: low
 
   - name: ZapTracker
-    description: Dashboard for Lightning/Nostr creators combining zap analytics and NWC wallet management
-    platforms: [web]
+    description: Dashboard for Lightning/Nostr creators combining zap analytics and
+      NWC wallet management
+    platforms: [ web ]
     repo: https://github.com/pratik227/zap_dashboard
     status: active
     priority: low
@@ -1841,38 +1949,23 @@ devtools:
 
   - name: Bigbrotr
     description: Modular infrastructure for archiving and monitoring the Nostr network
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/Bigbrotr/bigbrotr
     status: active
     priority: low
     notes: OpenSats funded, containerized with PostgreSQL
 
-  - name: Grasp
-    description: Distributed Nostr-native git hosting built on NIP-34, extends ngit
-    platforms: [web]
-    status: beta
-    priority: low
-    notes: OpenSats funded, libraries for Nostr clients to interact with git data
-
   - name: Gitplaza
     description: Decentralized desktop-based GitHub alternative on Nostr
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://codeberg.org/dluvian/gitplaza
     status: beta
     priority: low
     notes: OpenSats funded, issue tracking, kanban boards, offline-first
 
-  - name: Nostrability
-    description: Documentation project tracking Nostr client interoperability
-    platforms: [web]
-    repo: https://github.com/nostrability/nostrability
-    status: active
-    priority: low
-    notes: OpenSats funded, developing nostrCI for automated compatibility testing
-
   - name: relay.tools
     description: Web-based control panel for deploying and managing Nostr relays
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/relaytools
     status: active
     priority: low
@@ -1880,7 +1973,7 @@ devtools:
 
   - name: nostr.build
     description: Free media hosting service for Nostr (images, GIFs, video, audio)
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrbuild/nostr.build
     website: https://nostr.build
     status: active
@@ -1889,14 +1982,14 @@ devtools:
 
   - name: myrelay.page
     description: Canonical relay page generator
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sandwichfarm/myrelay.page
     status: active
     priority: low
 
   - name: nostr-vpn
     description: VPN tunneling over the Nostr protocol
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/mmalmi/nostr-vpn
     maintainer: mmalmi
     status: active
@@ -1905,72 +1998,90 @@ devtools:
 
   - name: nsec-leak-checker
     description: DVM for checking exposed Nostr private keys
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/BigBrotr/nsec-leak-checker
     status: active
     priority: medium
     notes: Security tool, checks for leaked nsecs
-
-  - name: schemata-rs
-    description: Rust implementation of Nostr event JSON Schema definitions
-    repo: https://github.com/nostrability/schemata-rs
+  - name: Zaplytics
+    description: Analytics dashboard for tracking zap earnings and creator activity
+    platforms:
+      - web
+    repo: https://github.com/derekross/zaplytics
+    website: https://zaplytics.app
+    maintainer: derekross
     status: active
     priority: medium
-    notes: Companion to nostrability/schemata
-
-  - name: schemata-validator-rs
-    description: Rust validator for Nostr event schemas
-    repo: https://github.com/nostrability/schemata-validator-rs
+  - name: gitstr
+    description: Send and receive git patches over Nostr using NIP-34
+    platforms:
+      - cli
+    repo: https://github.com/fiatjaf/gitstr
+    maintainer: fiatjaf
     status: active
     priority: medium
-
-  - name: schemata-go
-    description: Go implementation of Nostr event JSON Schema definitions
-    repo: https://github.com/nostrability/schemata-go
+    notes: Predates and overlaps with ngit
+  - name: Disgus
+    description: Disqus-style comment widget powered by Nostr for embedding on websites
+    platforms:
+      - web
+    repo: https://github.com/carlitoplatanito/disgus
     status: active
     priority: medium
+  - name: Postr For Nostr
+    description: WordPress plugin to post directly to Nostr using NIP-07 signers
+    platforms:
+      - web
+    repo: https://github.com/joel-st/postr-for-nostr
+    status: active
+    priority: low
+  - name: Hugo2Nostr
+    description: Sync a Hugo blog with the Nostr network using sync scripts
+    platforms:
+      - cli
+    repo: https://github.com/delirehberi/hugo2nostr
+    status: active
+    priority: low
+  - name: Shirushi
+    description: Web-based protocol testing tool for monitoring relays and NIPs
+    platforms:
+      - web
+    repo: https://github.com/00quasr/Shirushi
+    status: active
+    priority: low
+  - name: nosbin
+    description: Pastebin-style content sharing built on Nostr
+    platforms:
+      - web
+    repo: https://github.com/jacany/nosbin
+    website: https://nosbin.com
+    status: active
+    priority: low
+  - name: earthly
+    description: Social GeoJSON editor with maps on Nostr
+    platforms:
+      - web
+    repo: https://github.com/moogmodular/earthly
+    status: active
+    priority: low
+  - name: georelays
+    description: Collection of relays with estimated geographic locations for nearby
+      discovery
+    platforms:
+      - cli
+    repo: https://github.com/permissionlesstech/georelays
+    status: active
+    priority: low
 
-  - name: schemata-validator-go
-    description: Go validator for Nostr event schemas
-    repo: https://github.com/nostrability/schemata-validator-go
+  - name: Titan
+    description: Native nsite:// browser for the Nostr web with Bitcoin-based
+      human-readable name registration
+    platforms: [ desktop ]
+    repo: https://github.com/btcjt/titan
     status: active
     priority: medium
-
-  - name: schemata-dart
-    description: Dart implementation of Nostr event JSON Schema definitions
-    repo: https://github.com/nostrability/schemata-dart
-    status: active
-    priority: medium
-
-  - name: schemata-validator-dart
-    description: Dart validator for Nostr event schemas
-    repo: https://github.com/nostrability/schemata-validator-dart
-    status: active
-    priority: medium
-
-  - name: schemata-swift
-    description: Swift implementation of Nostr event JSON Schema definitions
-    repo: https://github.com/nostrability/schemata-swift
-    status: active
-    priority: medium
-
-  - name: schemata-validator-swift
-    description: Swift validator for Nostr event schemas
-    repo: https://github.com/nostrability/schemata-validator-swift
-    status: active
-    priority: medium
-
-  - name: schemata-py
-    description: Python implementation of Nostr event JSON Schema definitions
-    repo: https://github.com/nostrability/schemata-py
-    status: active
-    priority: medium
-
-  - name: schemata-validator-py
-    description: Python validator for Nostr event schemas
-    repo: https://github.com/nostrability/schemata-validator-py
-    status: active
-    priority: medium
+    notes: Resolves nsite:// URLs via Nostr relays, renders from Blossom servers, no
+      DNS or certificates
 
 # =============================================================================
 # SIGNING & KEY MANAGEMENT
@@ -1979,7 +2090,7 @@ devtools:
 signers:
   - name: Amber
     description: Android event signer
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/greenart7c3/amber
     maintainer: greenart7c3
     status: active
@@ -1988,7 +2099,7 @@ signers:
 
   - name: Alby Extension
     description: Browser extension for Lightning and Nostr
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/getAlby/lightning-browser-extension
     website: https://getalby.com
     maintainer: getalby
@@ -1998,7 +2109,7 @@ signers:
 
   - name: nos2x
     description: Original NIP-07 browser signer by fiatjaf
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/fiatjaf/nos2x
     maintainer: fiatjaf
     status: maintained
@@ -2007,7 +2118,7 @@ signers:
 
   - name: Nsec App
     description: Web-based signer
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrband/noauth
     website: https://nsec.app
     status: active
@@ -2016,7 +2127,7 @@ signers:
 
   - name: Aegis
     description: Cross-platform signer with multiple connection methods
-    platforms: [android, ios, windows, macos, linux]
+    platforms: [ android, ios, windows, macos, linux ]
     repo: https://github.com/ZharlieW/Aegis
     status: active
     priority: medium
@@ -2024,14 +2135,14 @@ signers:
 
   - name: Nowser
     description: Mobile signer for iOS/Android
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/haorendashu/nowser
     status: active
     priority: low
 
   - name: nostr-keyx
     description: Browser extension using OS keychain or YubiKey
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/susumuota/nostr-keyx
     status: active
     priority: low
@@ -2039,12 +2150,12 @@ signers:
 
   - name: Frostr
     description: Threshold signing protocol for Nostr - splits keys across devices
-    platforms: [ios, android, desktop, browser]
-    repo: https://github.com/FROSTR-ORG/igloo-desktop
+    platforms: [ ios, android, desktop, browser ]
     repos:
       ios: https://github.com/FROSTR-ORG/igloo-ios-prototype
       android: https://github.com/FROSTR-ORG/igloo-android
       browser: https://github.com/FROSTR-ORG/frost2x
+      desktop: https://github.com/FROSTR-ORG/igloo-desktop
     website: https://frostr.org
     status: active
     priority: high
@@ -2052,7 +2163,7 @@ signers:
 
   - name: Pokey
     description: Real-time notification tool for Nostr events with Amber integration
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/greenart7c3/pokey
     status: active
     priority: low
@@ -2060,7 +2171,7 @@ signers:
 
   - name: Signet
     description: Self-hosted NIP-46 remote signer with web dashboard
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/Letdown2491/signet
     status: active
     priority: medium
@@ -2068,7 +2179,7 @@ signers:
 
   - name: Keep
     description: FROST threshold signer for Android with NIP-55 and NIP-46 support
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/privkeyio/keep-android
     status: active
     priority: medium
@@ -2076,7 +2187,7 @@ signers:
 
   - name: OAuth Bunker
     description: NIP-46 bunker that bridges OAuth providers to Nostr signing
-    platforms: [web, self-hosted]
+    platforms: [ web, self-hosted ]
     repo: https://github.com/flox1an/oauth-bunker
     status: active
     priority: low
@@ -2084,7 +2195,7 @@ signers:
 
   - name: keyNest
     description: Secure key management for Nostr and Bitcoin
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/gzuuus/keynest
     status: active
     priority: low
@@ -2092,14 +2203,14 @@ signers:
 
   - name: Nostash
     description: NIP-07 signing extension for iOS/iPadOS/macOS Safari
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/tyiu/nostash
     status: active
     priority: low
 
   - name: nostr-signing-device
     description: Hardware signing device for Nostr built on ESP32
-    platforms: [hardware]
+    platforms: [ hardware ]
     repo: https://github.com/lnbits/nostr-signing-device
     status: active
     priority: low
@@ -2107,7 +2218,7 @@ signers:
 
   - name: horse
     description: Hardware remote nostr event signer with webserial
-    platforms: [hardware]
+    platforms: [ hardware ]
     repo: https://github.com/fiatjaf/horse
     maintainer: fiatjaf
     status: active
@@ -2115,28 +2226,28 @@ signers:
 
   - name: Blockcore Wallet
     description: Multi-wallet browser extension with nostr NIP-07 support
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/block-core/blockcore-wallet
     status: active
     priority: low
 
   - name: Aka Profile
     description: Nostr signing extension for Chrome supporting multiple key pairs
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/neilck/aka-extension
     status: active
     priority: low
 
   - name: Nostore
     description: Nostr Signer Extension for iOS/macOS Safari
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/ursuscamp/nostore
     status: active
     priority: low
 
   - name: nos2x-fox
     description: Nostr signer extension for Firefox (NIP-07)
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/diegogurpegui/nos2x-fox
     status: active
     priority: low
@@ -2144,34 +2255,28 @@ signers:
 
   - name: nsecbunkerd
     description: nsecBunker daemon for remote key management
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/kind-0/nsecbunkerd
     status: active
     priority: medium
 
   - name: Nostrame
     description: Nostr Account Management Extension (derive accounts from mnemonic)
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/getnostrame/nostrame
-    status: active
-    priority: low
-
-  - name: Peridot
-    description: Nostr bunker for desktop (Linux, macOS, Windows, Android, web)
-    platforms: [linux, macos, windows, android, web]
     status: active
     priority: low
 
   - name: Keys Band
     description: Multiple Nostr key management with light/dark mode
-    platforms: [web]
+    platforms: [ web ]
     website: https://keys.band
     status: active
     priority: low
 
   - name: Keystache
     description: Desktop-native Nostr signing app with SSO-like key management
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/nodetec/keystache
     status: active
     priority: low
@@ -2179,7 +2284,7 @@ signers:
 
   - name: Keydex
     description: Backup and recovery tool using Shamir's Secret Sharing
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/mplorentz/keydex
     status: beta
     priority: low
@@ -2272,7 +2377,7 @@ relays:
 
   - name: nostr-relay-tray
     description: Desktop GUI relay for non-technical users
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/CodyTseng/nostr-relay-tray
     status: active
     priority: medium
@@ -2366,7 +2471,8 @@ relays:
     notes: Bridge between Fediverse and Nostr, by Soapbox team
 
   - name: Alienos
-    description: Plugin-based lightweight nostr stack (relay/blossom/NIP-05) for self-hosting with Tor support
+    description: Plugin-based lightweight nostr stack (relay/blossom/NIP-05) for
+      self-hosting with Tor support
     repo: https://github.com/dezh-tech/alienos
     status: active
     priority: medium
@@ -2392,13 +2498,14 @@ relays:
     priority: low
 
   - name: nostrcheck-server
-    description: All-in-one server with relay, file hosting, NIP-05, Lightning redirects, NWC, and WoT
+    description: All-in-one server with relay, file hosting, NIP-05, Lightning
+      redirects, NWC, and WoT
     repo: https://github.com/quentintaranpino/nostrcheck-server
     status: active
     priority: medium
 
   - name: Zapstore Server
-    description: Nostr relay and Blossom server for the Zapstore ecosystem
+    description: Nostr relay and Blossom server backing Zapstore
     repo: https://github.com/zapstore/server
     status: active
     priority: low
@@ -2416,7 +2523,8 @@ relays:
     priority: low
 
   - name: netstr
-    description: General purpose Nostr relay in C# backed by Postgres with high test coverage
+    description: General purpose Nostr relay in C# backed by Postgres with high test
+      coverage
     repo: https://github.com/bezysoftware/netstr
     status: active
     priority: low
@@ -2515,7 +2623,7 @@ relays:
     notes: By fiatjaf
 
   - name: nex
-    description: Powerful and flexible Nostr relay written in Elixir
+    description: Nostr relay implementation in Elixir
     repo: https://github.com/aaronrussell/nex
     status: active
     priority: low
@@ -2553,7 +2661,7 @@ relays:
 
   - name: Pyramid
     description: Nostr relay with invite hierarchy, built on Khatru
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/github-tijlxyz/khatru-pyramid
     status: active
     priority: low
@@ -2577,7 +2685,50 @@ relays:
     repo: https://github.com/theborakompanioni/nostr-spring-boot-starter
     status: active
     priority: low
-    notes: OpenSats funded, foundational infrastructure for JVM ecosystem
+    notes: OpenSats funded, foundational infrastructure for JVM languages
+  - name: Ephemerelay
+    description: In-memory relay that does not store data, by Soapbox team
+    repo: https://gitlab.com/soapbox-pub/ephemerelay
+    status: active
+    priority: medium
+    notes: Useful for testing and development
+  - name: zooid
+    description: Multi-tenant relay designed for communities, by Coracle team
+    repo: https://github.com/coracle-social/zooid
+    maintainer: staab
+    status: active
+    priority: medium
+  - name: multiplextr
+    description: Custom relay that saves bandwidth for clients with multiplexer support
+    repo: https://github.com/coracle-social/multiplextr
+    maintainer: staab
+    status: active
+    priority: medium
+  - name: groups_relay
+    description: NIP-29 group chat relay implementation in Rust
+    repo: https://github.com/verse-pbc/groups_relay
+    status: active
+    priority: low
+  - name: Astro Relay
+    description: Elixir-based relay built to be performant and distributed
+    repo: https://github.com/Nostrology/astro
+    status: active
+    priority: low
+  - name: n0str
+    description: Relay designed for simplicity without sacrificing capability
+    repo: https://github.com/tani/n0str
+    status: active
+    priority: low
+  - name: Nerostr
+    description: Expensive relay paid with Monero, written in Go
+    repo: https://codeberg.org/pluja/nerostr
+    status: active
+    priority: low
+  - name: gnost-relay
+    description: Go relay backed by PostgreSQL with permessage-deflate compression
+    repo: https://github.com/barkyq/gnost-relay
+    status: active
+    priority: low
 
 # =============================================================================
 # LIBRARIES & SDKs
@@ -2678,7 +2829,8 @@ libraries:
     priority: low
 
   - name: Granary
-    description: Social web translation library converting between Nostr, Bluesky, ActivityPub, and other formats
+    description: Social web translation library converting between Nostr, Bluesky,
+      ActivityPub, and other formats
     language: python
     repo: https://github.com/snarfed/granary
     maintainer: snarfed
@@ -2715,7 +2867,7 @@ libraries:
     maintainer: jb55
     status: active
     priority: high
-    notes: Core data layer for Damus ecosystem
+    notes: Core data layer for Damus and Notedeck
 
   - name: nostr-sqlite
     description: High-performance customizable SQLite store for Nostr events
@@ -2910,7 +3062,8 @@ libraries:
     priority: low
 
   - name: Quartz
-    description: Kotlin Multiplatform library extracting shared Nostr functionality from Amethyst
+    description: Kotlin Multiplatform library extracting shared Nostr functionality
+      from Amethyst
     language: kotlin
     repo: https://github.com/KotlinGeekDev/amethyst
     status: active
@@ -2950,7 +3103,8 @@ libraries:
     notes: OpenSats funded, used by Habla.news and others
 
   - name: Atomic Signature Swaps
-    description: Protocol for trustless Schnorr signature exchange using Nostr events and adaptor signatures
+    description: Protocol for trustless Schnorr signature exchange using Nostr
+      events and adaptor signatures
     language: typescript
     repo: https://github.com/vstabile/sig4sats-script
     status: beta
@@ -2963,7 +3117,8 @@ libraries:
     repo: https://github.com/NostrGameEngine/ngengine
     status: beta
     priority: low
-    notes: OpenSats funded, replaces centralized game systems with Nostr-native modules
+    notes: OpenSats funded, replaces centralized game systems with Nostr-native
+      modules
 
   - name: noble-ciphers
     description: JS cryptography library underlying NIP-44 encrypted direct messaging
@@ -2972,6 +3127,27 @@ libraries:
     status: active
     priority: low
     notes: OpenSats funded security audit
+  - name: Nuxstr
+    description: Starter template for building clients with Nuxt Vue and NDK
+    language: typescript
+    repo: https://github.com/sebastix/nuxstr
+    website: https://nuxstr.nostrver.se
+    status: active
+    priority: low
+
+  - name: dotnet-mls
+    description: .NET implementation of the MLS protocol for Marmot
+    repo: https://github.com/DavidGershony/dotnet-mls
+    status: beta
+    priority: low
+    notes: C# MLS implementation, enables .NET integration
+
+  - name: marmot-cs
+    description: C# implementation of the Marmot protocol
+    repo: https://github.com/DavidGershony/marmot-cs
+    status: beta
+    priority: low
+    notes: Marmot protocol port to .NET/C#
 
 # =============================================================================
 # WALLETS & LIGHTNING INTEGRATION
@@ -2980,7 +3156,7 @@ libraries:
 wallets:
   - name: Alby Hub
     description: Self-custodial Lightning node with NWC
-    platforms: [web, self-hosted]
+    platforms: [ web, self-hosted ]
     repo: https://github.com/getAlby/hub
     website: https://albyhub.com
     maintainer: getalby
@@ -2990,7 +3166,7 @@ wallets:
 
   - name: Alby Go
     description: Mobile app for Alby Hub
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/getAlby/go
     website: https://albygo.com
     maintainer: getalby
@@ -2999,7 +3175,7 @@ wallets:
 
   - name: Mutiny
     description: Self-custodial browser wallet with NWC
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/MutinyWallet/mutiny-web
     website: https://mutinywallet.com
     status: inactive
@@ -3008,14 +3184,14 @@ wallets:
 
   - name: Zeus
     description: Mobile Bitcoin/Lightning wallet
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/ZeusLN/zeus
     status: active
     priority: medium
 
   - name: Minibits
     description: Android Cashu wallet with Nostr integration
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/minibits-cash/minibits_wallet
     status: active
     priority: medium
@@ -3023,7 +3199,7 @@ wallets:
 
   - name: Npub.cash
     description: Cashu-based modular client for Nostr ecash
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/cashubtc/npubcash-server
     status: active
     priority: medium
@@ -3031,43 +3207,47 @@ wallets:
 
   - name: CDK
     description: Cashu Development Kit - Rust library for building wallets and mints
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/cashubtc/cdk
     website: https://cashudevkit.org
     status: active
     priority: medium
-    notes: Multi-database backends, FFI for mobile apps. Not Nostr-native; cover only Nostr-relevant changes
+    notes: Multi-database backends, FFI for mobile apps. Not Nostr-native; cover
+      only Nostr-relevant changes
 
   - name: Nutshell
     description: Reference Cashu wallet and mint implementation in Python
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/cashubtc/nutshell
     website: https://cashu.space
     status: active
     priority: medium
-    notes: Full protocol implementation, reference for NUTs. Not Nostr-native; cover only Nostr-relevant changes
+    notes: Full protocol implementation, reference for NUTs. Not Nostr-native; cover
+      only Nostr-relevant changes
 
   - name: Cashu.me
     description: Progressive web app Cashu wallet with NWC and Nostr mint discovery
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/cashubtc/cashu.me
     website: https://cashu.me
     status: active
     priority: medium
-    notes: Multi-currency (BTC/USD), primary web ecash wallet. Not Nostr-native; cover only Nostr-relevant changes
+    notes: Multi-currency (BTC/USD), primary web ecash wallet. Not Nostr-native;
+      cover only Nostr-relevant changes
 
   - name: eNuts
     description: Mobile Cashu wallet for Android and iOS
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     repo: https://github.com/cashubtc/eNuts
     website: https://enuts.cash
     status: active
     priority: medium
-    notes: Multi-mint, multi-language support. Not Nostr-native; cover only Nostr-relevant changes
+    notes: Multi-mint, multi-language support. Not Nostr-native; cover only
+      Nostr-relevant changes
 
   - name: Nutstash
     description: Feature-rich web Cashu wallet with send-to-Nostr-key
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/gandlafbtc/nutstash-wallet
     website: https://wallet.nutstash.app
     status: active
@@ -3076,15 +3256,16 @@ wallets:
 
   - name: Bitcoin Connect
     description: Web components library enabling WebLN without extensions
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/getAlby/bitcoin-connect
     status: active
     priority: medium
-    notes: Framework agnostic, mobile/desktop support. Not Nostr-native; cover only Nostr-relevant changes
+    notes: Framework agnostic, mobile/desktop support. Not Nostr-native; cover only
+      Nostr-relevant changes
 
   - name: mcp-money
     description: MCP server giving AI agents Cashu wallets with zap support
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/pablof7z/mcp-money
     status: active
     priority: medium
@@ -3092,16 +3273,17 @@ wallets:
 
   - name: Geyser
     description: Bitcoin/Nostr-native crowdfunding platform
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/geyserfund/geyser-app
     website: https://geyser.fund
     status: active
     priority: medium
-    notes: NWC integration, $10K NWC grant program, $10M+ funded. Not primarily Nostr-native; cover only Nostr-relevant changes
+    notes: NWC integration, $10K NWC grant program, $10M+ funded. Not primarily
+      Nostr-native; cover only Nostr-relevant changes
 
   - name: Coinos
     description: Bitcoin web wallet supporting Lightning, Liquid, and on-chain
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/coinos/coinos-ui
     website: https://coinos.io
     status: active
@@ -3110,7 +3292,7 @@ wallets:
 
   - name: Wally
     description: Desktop native wallet with NWC support
-    platforms: [windows, macos, linux]
+    platforms: [ windows, macos, linux ]
     repo: https://github.com/ArcadeCity/wally
     status: active
     priority: low
@@ -3118,15 +3300,16 @@ wallets:
 
   - name: Nutoff
     description: Cashu wallet using ContextVM
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/gzuuus/nutoff-wallet
     status: active
     priority: low
     notes: SEC-05 project
 
   - name: Bold Bitcoin Wallet
-    description: MPC TSS Bitcoin wallet using Nostr for decentralized device pairing and signing
-    platforms: [android]
+    description: MPC TSS Bitcoin wallet using Nostr for decentralized device pairing
+      and signing
+    platforms: [ android ]
     repo: https://github.com/nicfab/BoldWallet
     status: active
     priority: medium
@@ -3134,28 +3317,28 @@ wallets:
 
   - name: Lightning.Pub
     description: Nostr daemon for Lightning nodes
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/shocknet/Lightning.Pub
     status: active
     priority: medium
 
   - name: LNBits
     description: Bitcoin Lightning accounting system with zappable LN addresses
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/lnbits/lnbits
     status: active
     priority: medium
 
   - name: Current
     description: Nostr client combined with Lightning wallet
-    platforms: [ios, android]
+    platforms: [ ios, android ]
     website: https://app.getcurrent.io
     status: active
     priority: low
 
   - name: nostr-wallet-connect
     description: Nostr Wallet Connect (NIP-47) app to connect apps to your node
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/getAlby/nostr-wallet-connect
     status: active
     priority: low
@@ -3163,11 +3346,30 @@ wallets:
 
   - name: mutiny-node
     description: Lightning SDK behind Mutiny Wallet
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/MutinyWallet/mutiny-node
     status: inactive
     priority: low
     notes: Mutiny Wallet shut down, but SDK remains
+  - name: shockwallet
+    description: Lightning wallet using Nostr and LNURL to connect to remote nodes
+    platforms:
+      - web
+      - ios
+      - android
+    repo: https://github.com/shocknet/wallet2
+    maintainer: shocknet
+    status: active
+    priority: medium
+
+  - name: Purser
+    description: Nostr-native payment daemon replacing Zaprite, uses Marmot/MDK for
+      encrypted merchant-customer messaging
+    language: rust
+    repo: https://github.com/EthnTuttle/purser
+    status: active
+    priority: medium
+    notes: Strike and Square payment providers, Marmot MLS for order communication
 
 # =============================================================================
 # OTHER NOTABLE PROJECTS
@@ -3176,7 +3378,7 @@ wallets:
 other:
   - name: Nostr.band
     description: Search engine and analytics
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrband/nostr-band-app
     website: https://nostr.band
     status: active
@@ -3192,7 +3394,7 @@ other:
 
   - name: Nostr.watch
     description: Relay monitoring and status
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sandwichfarm/nostr-watch
     website: https://nostr.watch
     status: active
@@ -3201,7 +3403,7 @@ other:
 
   - name: njump
     description: Static gateway for viewing Nostr content
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/fiatjaf/njump
     website: https://njump.me
     status: active
@@ -3210,7 +3412,7 @@ other:
 
   - name: Npub.pro
     description: Website builder that turns Nostr content into personal websites
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrband/nostrsite
     website: https://npub.pro
     status: active
@@ -3219,7 +3421,7 @@ other:
 
   - name: Nstart
     description: Onboarding wizard for new users
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dtonon/nstart
     website: https://nstart.me
     status: active
@@ -3228,7 +3430,7 @@ other:
 
   - name: Shipyard
     description: Schedule and manage posts via DVM
-    platforms: [web, cli]
+    platforms: [ web, cli ]
     repo: https://github.com/dextryz/shipyard
     website: https://shipyard.pub
     maintainer: pablof7z
@@ -3238,7 +3440,7 @@ other:
 
   - name: Nostr Profile Manager
     description: Backup and manage profile metadata
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/DanConwayDev/nostr-profile-manager
     website: https://metadata.nostr.com
     maintainer: DanConwayDev
@@ -3247,7 +3449,7 @@ other:
 
   - name: Vertex
     description: Web of Trust infrastructure for spam filtering and content personalization
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vertex-lab/vertex
     website: https://vertexlab.io
     status: active
@@ -3256,7 +3458,7 @@ other:
 
   - name: Chorus
     description: Community organizing app with Cashu wallet for activists
-    platforms: [ios, android, web]
+    platforms: [ ios, android, web ]
     repo: https://github.com/andotherstuff/chorus
     maintainer: andotherstuff
     status: active
@@ -3273,11 +3475,12 @@ other:
 
   - name: Nostr Epoxy
     description: Paid WebSocket proxy for relays and Cashu mints
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Origami74/nostr-epoxy-reverse-proxy
     status: active
     priority: medium
-    notes: OpenSats grant recipient, bridges Tor/I2P/Hyper networks with Cashu payments
+    notes: OpenSats grant recipient, bridges Tor/I2P/Hyper networks with Cashu
+      payments
 
   - name: HAMSTR
     description: Off-grid Nostr communication via ham radio with Cashu/NWC
@@ -3288,7 +3491,7 @@ other:
 
   - name: Routstr
     description: Decentralized AI marketplace with Nostr discovery and Cashu payments
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Routstr/otrta-client
     website: https://routstr.com
     status: active
@@ -3305,7 +3508,7 @@ other:
 
   - name: Nsite
     description: Static website hosting on Nostr using Blossom and relays
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/lez/nsite
     website: https://nsite.run
     status: active
@@ -3313,8 +3516,9 @@ other:
     notes: SEC project, decentralized static site hosting, kind 34128
 
   - name: Hashtree
-    description: Content-addressed blob storage with Merkle roots published on Nostr and WebRTC mesh distribution
-    platforms: [cli, web]
+    description: Content-addressed blob storage with Merkle roots published on Nostr
+      and WebRTC mesh distribution
+    platforms: [ cli, web ]
     repo: https://github.com/mmalmi/hashtree
     maintainer: mmalmi
     status: active
@@ -3323,7 +3527,7 @@ other:
 
   - name: Blossom Drive
     description: Cloud storage using Blossom servers
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hzrd149/blossom-drive
     status: active
     priority: medium
@@ -3331,7 +3535,7 @@ other:
 
   - name: Nostrocket
     description: Decentralized organization and project coordination platform
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/nostrocket/oxygen
     status: active
     priority: medium
@@ -3339,17 +3543,18 @@ other:
 
   - name: Angor
     description: Decentralized P2P crowdfunding with time-locked Bitcoin and Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/block-core/angor
     website: https://angor.io
     maintainer: block-core
     status: active
     priority: medium
-    notes: Milestone-based funding with investor recovery, no backend. Not primarily Nostr-native; cover only Nostr-relevant changes
+    notes: Milestone-based funding with investor recovery, no backend. Not primarily
+      Nostr-native; cover only Nostr-relevant changes
 
   - name: Bitcredit E-Bills
     description: E-bill application with a Nostr transport layer and dedicated relay
-    platforms: [web, wasm]
+    platforms: [ web, wasm ]
     repo: https://github.com/BitcreditProtocol/Bitcredit-Core
     website: https://www.bit.cr/
     status: active
@@ -3358,7 +3563,7 @@ other:
 
   - name: Wikifreedia
     description: Wikipedia-style wiki embracing viewpoint diversity via Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/pablof7z/wikifreedia
     status: active
     priority: low
@@ -3366,7 +3571,7 @@ other:
 
   - name: Nostr Safebox
     description: Secure encrypted storage for personal information
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/Nostr-Safebox/safebox
     status: active
     priority: low
@@ -3374,7 +3579,7 @@ other:
 
   - name: Novia
     description: Video archive service using Nostr metadata
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/teamnovia/novia
     status: active
     priority: low
@@ -3382,7 +3587,7 @@ other:
 
   - name: Totem
     description: Identity and reputation system on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/totemize/totem
     status: active
     priority: medium
@@ -3390,7 +3595,7 @@ other:
 
   - name: castr.me
     description: Converts npubs into podcast feeds
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dergigi/castr.me
     website: https://castr.me
     status: active
@@ -3406,7 +3611,7 @@ other:
 
   - name: ants
     description: Nostr search engine
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/dergigi/ants
     status: active
     priority: medium
@@ -3414,7 +3619,7 @@ other:
 
   - name: Beacon
     description: AI and Bitcoin integration in chat apps using ContextVM
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/beacon21m/beacon
     status: active
     priority: low
@@ -3422,7 +3627,7 @@ other:
 
   - name: Spotstr
     description: Maps on Nostr with encrypted location sharing
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/k0sti/spotstr
     status: active
     priority: medium
@@ -3430,7 +3635,7 @@ other:
 
   - name: Nostr Bucket
     description: Browser extension for event caching
-    platforms: [browser]
+    platforms: [ browser ]
     repo: https://github.com/hzrd149/nostr-bucket
     status: active
     priority: low
@@ -3438,7 +3643,7 @@ other:
 
   - name: Mostr
     description: Bridge between Nostr and the Fediverse (Mastodon, ActivityPub)
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://gitlab.com/soapbox-pub/mostr
     status: active
     priority: high
@@ -3446,7 +3651,7 @@ other:
 
   - name: Nostr over LoRa
     description: Gateway relaying off-grid Meshtastic messages to Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/geoffwhittington/meshtastic-bridge
     status: active
     priority: medium
@@ -3454,7 +3659,7 @@ other:
 
   - name: atomstr
     description: RSS/Atom gateway to Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/psic4t/atomstr
     website: https://atomstr.data.haus
     status: active
@@ -3462,14 +3667,14 @@ other:
 
   - name: nostrss
     description: Flexible application to broadcast RSS feeds on Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/Asone/nostrss
     status: active
     priority: low
 
   - name: rsslay
     description: Bridge that puts RSS feeds into Nostr
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/piraces/rsslay
     website: https://rsslay.nostr.moe
     status: active
@@ -3477,14 +3682,14 @@ other:
 
   - name: NostrHub
     description: Hub for NIPs, forums, app directory, DVM registry
-    platforms: [web]
+    platforms: [ web ]
     website: https://nostrhub.io
     status: active
     priority: low
 
   - name: Nostr Gatekeeper
     description: Nostr Connect bunker for secure signing
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hzrd149/nostr-gatekeeper
     status: active
     priority: low
@@ -3492,7 +3697,7 @@ other:
 
   - name: Nostr Secrets Vault (nicfab)
     description: E2E encrypted password manager synced via Nostr relays
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/nicfab/nostr-secrets
     status: active
     priority: medium
@@ -3500,7 +3705,7 @@ other:
 
   - name: Nostr Secrets Vault (tzongocu)
     description: Zero-knowledge password manager with Nostr sync
-    platforms: [web, android]
+    platforms: [ web, android ]
     repo: https://github.com/tzongocu/nostr-secrets
     status: active
     priority: medium
@@ -3508,7 +3713,7 @@ other:
 
   - name: Zap Cooking
     description: Decentralized recipe platform with Lightning zaps
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/zapcooking/frontend
     status: active
     priority: medium
@@ -3516,7 +3721,7 @@ other:
 
   - name: Holy Fit
     description: Step tracker anchoring fitness data to Nostr (Kind 30078)
-    platforms: [android]
+    platforms: [ android ]
     repo: https://git.vanderwarker.family/wellbeing/holyfit-android
     status: active
     priority: low
@@ -3524,7 +3729,7 @@ other:
 
   - name: featurestr-bountiestr
     description: Feature request and bounty system on Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/sebdeveloper6952/featurestr-bountiestr
     status: active
     priority: low
@@ -3532,7 +3737,7 @@ other:
 
   - name: Blob Box
     description: Simple Blossom server for UmbrelOS
-    platforms: [self-hosted]
+    platforms: [ self-hosted ]
     repo: https://github.com/hzrd149/umbrel-blob-box
     status: active
     priority: low
@@ -3540,7 +3745,7 @@ other:
 
   - name: hashpool
     description: Mining pools with eHash and Cashu
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/vnprc/hashpool
     status: beta
     priority: low
@@ -3548,7 +3753,7 @@ other:
 
   - name: Innpub
     description: Location-sensitive voice meetup app using MoQ
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/futurepaul/innpub
     status: beta
     priority: low
@@ -3556,7 +3761,7 @@ other:
 
   - name: NEET
     description: P2P calls via Nostr using Iroh
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/justinmoon/neet-native
     status: beta
     priority: low
@@ -3564,7 +3769,7 @@ other:
 
   - name: Paygress
     description: VM provisioning and VPN purchasing over Nostr
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/DhananjayPurohit/paygress
     status: beta
     priority: low
@@ -3572,7 +3777,7 @@ other:
 
   - name: Local++
     description: Mobile app for local LLM with dynamic model switching
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/Routstr/local-plus-plus
     status: beta
     priority: low
@@ -3580,7 +3785,7 @@ other:
 
   - name: Mapnolia
     description: Geospatial data server announcing map tile chunks over Nostr relays
-    platforms: [cli]
+    platforms: [ cli ]
     repo: https://github.com/zeSchlausKwab/mapnolia
     status: active
     priority: medium
@@ -3588,7 +3793,7 @@ other:
 
   - name: Morganite
     description: Local Blossom cache application for Android
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/greenart7c3/Morganite
     maintainer: greenart7c3
     status: active
@@ -3597,7 +3802,7 @@ other:
 
   - name: Aerith
     description: Blossom image manager with labels, bulk operations, and local cache
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/hardran3/Aerith
     status: active
     priority: medium
@@ -3605,11 +3810,12 @@ other:
 
   - name: Prism
     description: Android share target for publishing media and links to Nostr
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/hardran3/Prism
     status: active
     priority: medium
-    notes: Scheduled posting, OpenGraph previews, Blossom integration, NIP-55 signer support
+    notes: Scheduled posting, OpenGraph previews, Blossom integration, NIP-55 signer
+      support
 
   - name: Ridestr
     description: Decentralized rideshare coordination on Nostr
@@ -3620,43 +3826,24 @@ other:
 
   - name: DTAN
     description: Decentralized torrents directory on Nostr
-    platforms: [web]
+    platforms: [ web ]
     website: https://dtan.xyz
     status: active
     priority: low
 
   - name: Yondar
     description: Social map for adding and discovering places by friends
-    platforms: [web]
+    platforms: [ web ]
     website: https://go.yondar.me
     status: active
     priority: low
 
   - name: arcade
     description: Nostr and AI chat app
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/OpenAgentsInc/arcade
     status: active
     priority: low
-
-  - name: Primal Studio
-    description: Content creation tools for Nostr creators
-    platforms: [web]
-    status: active
-    priority: low
-
-  - name: Nstart.me
-    description: Easy onboarding wizard for new Nostr users
-    platforms: [web]
-    status: active
-    priority: low
-
-  - name: Nostr Design
-    description: Design resource for Nostr product designers and developers
-    platforms: [web]
-    status: active
-    priority: low
-    notes: OpenSats funded, design modules and best practices
 
   - name: Persian NIPs
     description: Persian/Farsi translations of key NIPs with user guides and developer docs
@@ -3667,20 +3854,14 @@ other:
 
   - name: Feeder
     description: Open-source Android feed reader with Nostr article support
-    platforms: [android]
+    platforms: [ android ]
     repo: https://github.com/spacecowboy/Feeder
-    status: active
-    priority: low
-
-  - name: Obsidian Nostr Writer
-    description: Obsidian plugin for publishing articles to Nostr
-    platforms: [desktop]
     status: active
     priority: low
 
   - name: npub.world
     description: Nostr Web of Trust visualization and exploration tool
-    platforms: [web]
+    platforms: [ web ]
     repo: https://github.com/vertex-lab/npub.world
     maintainer: vertex-lab
     status: active
@@ -3689,11 +3870,55 @@ other:
 
   - name: DOOM
     description: Open-source Nostr-integrated DOOM game
-    platforms: [desktop]
+    platforms: [ desktop ]
     repo: https://github.com/VectorPrivacy/DOOM
     status: active
     priority: medium
     notes: Gaming on Nostr by Vector team
+  - name: Heya.fund
+    description: Crowdfunding for causes and goals using Lightning
+    platforms:
+      - web
+    repo: https://github.com/verbiricha/goalz
+    website: https://heya.fund
+    maintainer: verbiricha
+    status: active
+    priority: medium
+  - name: Stackerstan
+    description: Decentralized organization on Bitcoin and Nostr, Go replicated
+      state machine
+    platforms:
+      - cli
+    repo: https://github.com/stackerstan/mindmachine
+    website: https://stackerstan.org
+    status: active
+    priority: low
+  - name: Zofie Archive
+    description: Library using Nostr and torrent protocols to preserve knowledge
+    platforms:
+      - web
+    repo: https://codeberg.org/zofie-archive/archive
+    status: active
+    priority: low
+
+  - name: Bikel
+    description: Decentralized cycling tracker that turns rides into public
+      infrastructure data
+    platforms: [ android, web ]
+    repo: https://github.com/Mnpezz/bikel
+    status: active
+    priority: medium
+    notes: Cashu nutzaps, OSM integration, native foreground service for de-Googled
+      phones
+
+  - name: mesh-llm
+    description: Distributed LLM inference across machines using Nostr for identity
+      and config
+    platforms: [ desktop ]
+    repo: https://github.com/michaelneale/mesh-llm
+    status: active
+    priority: low
+    notes: Nostr keypair identity, distributed config protocol, llama.cpp based
 
 # =============================================================================
 # RELATED PROTOCOLS
@@ -3721,9 +3946,7 @@ protocols:
 
   - name: Marmot Protocol
     description: MLS-based end-to-end encrypted messaging for Nostr (NIP-104)
-    repo: https://github.com/marmot-protocol/marmot
     repos:
-      spec: https://github.com/marmot-protocol/marmot
       mdk: https://github.com/marmot-protocol/mdk
       typescript: https://github.com/marmot-protocol/marmot-ts
       whitenoise-backend: https://github.com/marmot-protocol/whitenoise-rs
@@ -3733,27 +3956,7 @@ protocols:
     status: beta
     priority: high
     notes: MLS (Messaging Layer Security) for Nostr, enables secure group messaging
-
-  - name: dotnet-mls
-    description: .NET implementation of the MLS protocol for Marmot
-    repo: https://github.com/DavidGershony/dotnet-mls
-    status: beta
-    priority: low
-    notes: C# MLS implementation, enables .NET ecosystem integration
-
-  - name: marmot-cs
-    description: C# implementation of the Marmot protocol
-    repo: https://github.com/DavidGershony/marmot-cs
-    status: beta
-    priority: low
-    notes: Marmot protocol port to .NET/C#
-
-  - name: OpenChat
-    description: Chat application built on dotnet-mls and marmot-cs
-    repo: https://github.com/DavidGershony/openChat
-    status: beta
-    priority: low
-    notes: .NET chat client using Marmot protocol over Nostr
+    repo: https://github.com/marmot-protocol/marmot
 
   - name: MDK PWA Reference
     description: Progressive web app reference implementation for Marmot Development Kit
@@ -3762,71 +3965,9 @@ protocols:
     priority: medium
     notes: Reference PWA for building MLS-encrypted apps with MDK
 
-  - name: NIP-60/NIP-61
-    description: Nostr ecash wallet protocol - store Cashu tokens on Nostr
-    repo: https://github.com/nostr-protocol/nips
-    status: active
-    priority: high
-    notes: Enables Nutzaps (publicly verifiable ecash microtransactions)
-
-  - name: NIP-90
-    description: Data Vending Machines - on-demand computation over Nostr
-    repo: https://github.com/nostr-protocol/nips
-    status: active
-    priority: high
-    notes: SEC-00 project, enables AI/ML services, content processing, and more
-
   - name: HyperNote
     description: Protocol for hypermedia on Nostr - stores HTML-like content as events
     repo: https://github.com/futurepaul/hypernote
     status: beta
     priority: medium
     notes: SEC-04/05 project, enables rich interactivity without protocol changes
-
-  - name: Flora
-    description: Chrome extension for decentralized screen recording and sharing on Nostr
-    platforms: [web]
-    repo: https://github.com/shawnyeager/flora-extension
-    status: beta
-    priority: low
-    notes: Encrypted video sharing via NIP-17, AES-256-GCM, Blossom storage
-
-  - name: Purser
-    description: Nostr-native payment daemon replacing Zaprite, uses Marmot/MDK for encrypted merchant-customer messaging
-    language: rust
-    repo: https://github.com/EthnTuttle/purser
-    status: active
-    priority: medium
-    notes: Strike and Square payment providers, Marmot MLS for order communication
-
-  - name: Bikel
-    description: Decentralized cycling tracker that turns rides into public infrastructure data
-    platforms: [android, web]
-    repo: https://github.com/Mnpezz/bikel
-    status: active
-    priority: medium
-    notes: Cashu nutzaps, OSM integration, native foreground service for de-Googled phones
-
-  - name: Sprout
-    description: Hive mind communication platform by Block with Nostr relay and NIP support
-    platforms: [desktop]
-    repo: https://github.com/block/sprout
-    status: pre-alpha
-    priority: medium
-    notes: NIP-01, NIP-02, NIP-23, NIP-33 support, built-in Nostr relay
-
-  - name: Titan
-    description: Native nsite:// browser for the Nostr web with Bitcoin-based human-readable name registration
-    platforms: [desktop]
-    repo: https://github.com/btcjt/titan
-    status: active
-    priority: medium
-    notes: Resolves nsite:// URLs via Nostr relays, renders from Blossom servers, no DNS or certificates
-
-  - name: mesh-llm
-    description: Distributed LLM inference across machines using Nostr for identity and config
-    platforms: [desktop]
-    repo: https://github.com/michaelneale/mesh-llm
-    status: active
-    priority: low
-    notes: Nostr keypair identity, distributed config protocol, llama.cpp based

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -2944,7 +2944,7 @@ devtools:
     priority: low
 
   - name: Rebased
-    description: rebased — unify dev cryptography with your npub..
+    description: Unify developer cryptography with your Nostr npub identity
     repo: https://codeberg.org/Zsub/rebased
     status: active
     priority: low

--- a/hugo.toml
+++ b/hugo.toml
@@ -101,7 +101,13 @@ enableGitInfo = true
   weight = 3
 
 [[menu.main]]
+  identifier = "projects"
+  name = "Projects"
+  url = "/projects/"
+  weight = 4
+
+[[menu.main]]
   identifier = "podcast"
   name = "Podcast"
   url = "https://podcast.nostrcompass.org"
-  weight = 4
+  weight = 5

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Gespräche mit den Entwicklern, die Nostr bauen."
 
 # Footer
 footer_description: "Technische Ressource für das Nostr-Protokoll. Wöchentlicher Newsletter und Podcast über NIP-Vorschläge, Client-Updates, Relay-Entwicklungen und bemerkenswerte Code-Änderungen."
+
+# Projects index page
+menu_projects: "Projekte"
+projects_total_count:
+  one: "{{.Count}} Projekt erfasst."
+  other: "{{.Count}} Projekte erfasst."
+projects_back_to_top: "Nach oben"
+projects_cat_social: "Social-Clients"
+projects_cat_longform: "Langform-Clients"
+projects_cat_messaging: "Messaging"
+projects_cat_media: "Medien"
+projects_cat_marketplaces: "Marktplätze"
+projects_cat_wallets: "Wallets"
+projects_cat_signers: "Signierer"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Entwicklerwerkzeuge"
+projects_cat_libraries: "Bibliotheken"
+projects_cat_protocols: "Protokolle"
+projects_cat_other: "Sonstige"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Conversations with the developers building Nostr."
 
 # Footer
 footer_description: "Technical resource for the Nostr protocol. Weekly newsletter and podcast covering NIP proposals, client updates, relay developments, and notable code changes."
+
+# Projects index page
+menu_projects: "Projects"
+projects_total_count:
+  one: "{{.Count}} project tracked."
+  other: "{{.Count}} projects tracked."
+projects_back_to_top: "Back to top"
+projects_cat_social: "Social Clients"
+projects_cat_longform: "Long-form Clients"
+projects_cat_messaging: "Messaging"
+projects_cat_media: "Media"
+projects_cat_marketplaces: "Marketplaces"
+projects_cat_wallets: "Wallets"
+projects_cat_signers: "Signers"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Developer Tools"
+projects_cat_libraries: "Libraries"
+projects_cat_protocols: "Protocols"
+projects_cat_other: "Other"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Conversaciones con los desarrolladores que construyen Nostr."
 
 # Footer
 footer_description: "Recurso técnico para el protocolo Nostr. Boletín semanal y podcast que cubren propuestas de NIP, actualizaciones de clientes, desarrollos de relays y cambios de código notables."
+
+# Projects index page
+menu_projects: "Proyectos"
+projects_total_count:
+  one: "{{.Count}} proyecto rastreado."
+  other: "{{.Count}} proyectos rastreados."
+projects_back_to_top: "Volver arriba"
+projects_cat_social: "Clientes sociales"
+projects_cat_longform: "Clientes de formato largo"
+projects_cat_messaging: "Mensajería"
+projects_cat_media: "Medios"
+projects_cat_marketplaces: "Mercados"
+projects_cat_wallets: "Carteras"
+projects_cat_signers: "Firmadores"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Herramientas para desarrolladores"
+projects_cat_libraries: "Bibliotecas"
+projects_cat_protocols: "Protocolos"
+projects_cat_other: "Otros"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Conversations avec les développeurs qui construisent Nostr."
 
 # Footer
 footer_description: "Ressource technique pour le protocole Nostr. Newsletter hebdomadaire et podcast couvrant les propositions NIP, les mises à jour des clients, les développements des relais et les changements de code notables."
+
+# Projects index page
+menu_projects: "Projets"
+projects_total_count:
+  one: "{{.Count}} projet suivi."
+  other: "{{.Count}} projets suivis."
+projects_back_to_top: "Retour en haut"
+projects_cat_social: "Clients sociaux"
+projects_cat_longform: "Clients longue forme"
+projects_cat_messaging: "Messagerie"
+projects_cat_media: "Média"
+projects_cat_marketplaces: "Marchés"
+projects_cat_wallets: "Portefeuilles"
+projects_cat_signers: "Signataires"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Outils pour développeurs"
+projects_cat_libraries: "Bibliothèques"
+projects_cat_protocols: "Protocoles"
+projects_cat_other: "Autres"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Conversazioni con gli sviluppatori che costruiscono Nostr."
 
 # Footer
 footer_description: "Risorsa tecnica per il protocollo Nostr. Newsletter settimanale e podcast che coprono proposte NIP, aggiornamenti dei client, sviluppi dei relay e modifiche al codice degne di nota."
+
+# Projects index page
+menu_projects: "Progetti"
+projects_total_count:
+  one: "{{.Count}} progetto monitorato."
+  other: "{{.Count}} progetti monitorati."
+projects_back_to_top: "Torna su"
+projects_cat_social: "Client social"
+projects_cat_longform: "Client per testi lunghi"
+projects_cat_messaging: "Messaggistica"
+projects_cat_media: "Media"
+projects_cat_marketplaces: "Mercati"
+projects_cat_wallets: "Wallet"
+projects_cat_signers: "Firmatari"
+projects_cat_relays: "Relay"
+projects_cat_devtools: "Strumenti per sviluppatori"
+projects_cat_libraries: "Librerie"
+projects_cat_protocols: "Protocolli"
+projects_cat_other: "Altri"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Nostrを構築している開発者との対話。"
 
 # Footer
 footer_description: "Nostrプロトコルの技術リソース。NIP提案、クライアントのアップデート、リレーの開発、注目すべきコード変更を取り上げる週刊ニュースレターとポッドキャスト。"
+
+# Projects index page
+menu_projects: "プロジェクト"
+projects_total_count:
+  one: "{{.Count}}件のプロジェクトを追跡中。"
+  other: "{{.Count}}件のプロジェクトを追跡中。"
+projects_back_to_top: "トップへ戻る"
+projects_cat_social: "ソーシャルクライアント"
+projects_cat_longform: "長文クライアント"
+projects_cat_messaging: "メッセージング"
+projects_cat_media: "メディア"
+projects_cat_marketplaces: "マーケットプレイス"
+projects_cat_wallets: "ウォレット"
+projects_cat_signers: "署名ツール"
+projects_cat_relays: "リレー"
+projects_cat_devtools: "開発者ツール"
+projects_cat_libraries: "ライブラリ"
+projects_cat_protocols: "プロトコル"
+projects_cat_other: "その他"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Nostr를 구축하는 개발자들과의 대화."
 
 # Footer
 footer_description: "Nostr 프로토콜을 위한 기술 리소스. NIP 제안, 클라이언트 업데이트, 릴레이 개발, 주목할 만한 코드 변경 사항을 다루는 주간 뉴스레터와 팟캐스트."
+
+# Projects index page
+menu_projects: "프로젝트"
+projects_total_count:
+  one: "{{.Count}}개 프로젝트 추적 중."
+  other: "{{.Count}}개 프로젝트 추적 중."
+projects_back_to_top: "맨 위로"
+projects_cat_social: "소셜 클라이언트"
+projects_cat_longform: "장문 클라이언트"
+projects_cat_messaging: "메시징"
+projects_cat_media: "미디어"
+projects_cat_marketplaces: "마켓플레이스"
+projects_cat_wallets: "지갑"
+projects_cat_signers: "서명자"
+projects_cat_relays: "릴레이"
+projects_cat_devtools: "개발자 도구"
+projects_cat_libraries: "라이브러리"
+projects_cat_protocols: "프로토콜"
+projects_cat_other: "기타"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Gesprekken met de ontwikkelaars die Nostr bouwen."
 
 # Footer
 footer_description: "Technische bron voor het Nostr-protocol. Wekelijkse nieuwsbrief en podcast over NIP-voorstellen, client-updates, relay-ontwikkelingen en opmerkelijke codewijzigingen."
+
+# Projects index page
+menu_projects: "Projecten"
+projects_total_count:
+  one: "{{.Count}} project gevolgd."
+  other: "{{.Count}} projecten gevolgd."
+projects_back_to_top: "Naar boven"
+projects_cat_social: "Sociale clients"
+projects_cat_longform: "Langformaat-clients"
+projects_cat_messaging: "Berichten"
+projects_cat_media: "Media"
+projects_cat_marketplaces: "Marktplaatsen"
+projects_cat_wallets: "Wallets"
+projects_cat_signers: "Ondertekenaars"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Ontwikkelaarstools"
+projects_cat_libraries: "Bibliotheken"
+projects_cat_protocols: "Protocollen"
+projects_cat_other: "Overig"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -44,3 +44,22 @@ podcast_intro: "Conversas com os desenvolvedores que constroem o Nostr."
 
 # Footer
 footer_description: "Recurso técnico para o protocolo Nostr. Newsletter semanal e podcast cobrindo propostas de NIP, atualizações de clientes, desenvolvimentos de relays e mudanças de código notáveis."
+
+# Projects index page
+menu_projects: "Projetos"
+projects_total_count:
+  one: "{{.Count}} projeto rastreado."
+  other: "{{.Count}} projetos rastreados."
+projects_back_to_top: "Voltar ao topo"
+projects_cat_social: "Clientes sociais"
+projects_cat_longform: "Clientes de formato longo"
+projects_cat_messaging: "Mensagens"
+projects_cat_media: "Mídia"
+projects_cat_marketplaces: "Mercados"
+projects_cat_wallets: "Carteiras"
+projects_cat_signers: "Assinadores"
+projects_cat_relays: "Relays"
+projects_cat_devtools: "Ferramentas para desenvolvedores"
+projects_cat_libraries: "Bibliotecas"
+projects_cat_protocols: "Protocolos"
+projects_cat_other: "Outros"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -44,3 +44,22 @@ podcast_intro: "与构建 Nostr 的开发者对话。"
 
 # Footer
 footer_description: "Nostr 协议的技术资源。每周通讯和播客涵盖 NIP 提案、客户端更新、中继发展和值得注意的代码更改。"
+
+# Projects index page
+menu_projects: "项目"
+projects_total_count:
+  one: "已跟踪 {{.Count}} 个项目。"
+  other: "已跟踪 {{.Count}} 个项目。"
+projects_back_to_top: "返回顶部"
+projects_cat_social: "社交客户端"
+projects_cat_longform: "长文客户端"
+projects_cat_messaging: "消息"
+projects_cat_media: "媒体"
+projects_cat_marketplaces: "市场"
+projects_cat_wallets: "钱包"
+projects_cat_signers: "签名器"
+projects_cat_relays: "中继"
+projects_cat_devtools: "开发者工具"
+projects_cat_libraries: "库"
+projects_cat_protocols: "协议"
+projects_cat_other: "其他"

--- a/layouts/_default/projects.html
+++ b/layouts/_default/projects.html
@@ -1,0 +1,129 @@
+{{ define "main" }}
+{{ $data := .Site.Data.projects }}
+
+{{/* Display order and labels for categories. Order is intentional: clients, infra, libraries, protocols, other. */}}
+{{ $sections := slice
+  (dict "key" "social_clients"     "label" (i18n "projects_cat_social"))
+  (dict "key" "longform_clients"   "label" (i18n "projects_cat_longform"))
+  (dict "key" "messaging_clients"  "label" (i18n "projects_cat_messaging"))
+  (dict "key" "media_clients"      "label" (i18n "projects_cat_media"))
+  (dict "key" "marketplaces"       "label" (i18n "projects_cat_marketplaces"))
+  (dict "key" "wallets"            "label" (i18n "projects_cat_wallets"))
+  (dict "key" "signers"            "label" (i18n "projects_cat_signers"))
+  (dict "key" "relays"             "label" (i18n "projects_cat_relays"))
+  (dict "key" "devtools"           "label" (i18n "projects_cat_devtools"))
+  (dict "key" "libraries"          "label" (i18n "projects_cat_libraries"))
+  (dict "key" "protocols"          "label" (i18n "projects_cat_protocols"))
+  (dict "key" "other"              "label" (i18n "projects_cat_other"))
+}}
+
+{{/* Total count across all sections */}}
+{{ $total := 0 }}
+{{ range $sections }}
+  {{ $items := index $data .key }}
+  {{ if $items }}{{ $total = add $total (len $items) }}{{ end }}
+{{ end }}
+
+<article class="post projects-page">
+  <header class="post-header">
+    <h1 class="post-title" data-pagefind-weight="8">{{ .Title }}</h1>
+  </header>
+
+  <div class="post-content">
+    {{ .Content }}
+
+    {{ if gt $total 0 }}
+    <p class="projects-summary"><em>{{ i18n "projects_total_count" $total }}</em></p>
+
+    <nav class="projects-nav" aria-label="Project categories">
+      {{ range $i, $s := $sections }}
+        {{ $items := index $data .key }}
+        {{ if $items }}
+          {{ if gt $i 0 }} · {{ end }}
+          <a href="#{{ .key }}">{{ .label }}</a>
+        {{ end }}
+      {{ end }}
+    </nav>
+
+    {{ range $sections }}
+      {{ $key := .key }}
+      {{ $label := .label }}
+      {{ $items := index $data $key }}
+      {{ if $items }}
+        {{ $sorted := sort $items "name" "asc" }}
+        <section class="projects-section" id="{{ $key }}">
+          <h2 class="projects-section-title">{{ $label }} <span class="projects-section-count">({{ len $items }})</span></h2>
+          <ul class="projects-list">
+            {{ range $sorted }}
+              {{ $name := .name }}
+              {{ $desc := .description }}
+              {{ $repo := .repo }}
+              {{ $repos := .repos }}
+              {{ $site := .website }}
+              {{ $platforms := .platforms }}
+              {{ $maintainer := .maintainer }}
+              {{ $status := .status }}
+              {{/* Pick primary link: website > repo > first repo by sorted key */}}
+              {{ $primary := "" }}
+              {{ if $site }}{{ $primary = $site }}
+              {{ else if $repo }}{{ $primary = $repo }}
+              {{ else if $repos }}
+                {{ $keys := slice }}
+                {{ range $k, $u := $repos }}{{ $keys = $keys | append $k }}{{ end }}
+                {{ $keys = sort $keys }}
+                {{ if gt (len $keys) 0 }}
+                  {{ $primary = index $repos (index $keys 0) }}
+                {{ end }}
+              {{ end }}
+              {{/* Determine if any sub-links should render */}}
+              {{ $hasSubLinks := or (and $site $repo) $repos }}
+              <li class="project{{ if eq $status "inactive" }} project--inactive{{ end }}{{ if eq $status "beta" }} project--beta{{ end }}">
+                <span class="project-name">
+                  {{ if $primary }}
+                    <a href="{{ $primary }}" rel="noopener nofollow" target="_blank">{{ $name }}</a>
+                  {{ else }}
+                    {{ $name }}
+                  {{ end }}
+                </span>
+                {{ with $status }}
+                  {{ if or (eq . "beta") (eq . "inactive") }}
+                    <span class="project-status project-status--{{ . }}">{{ . }}</span>
+                  {{ end }}
+                {{ end }}
+                {{ with $desc }}<span class="project-desc">: {{ . }}</span>{{ end }}
+                {{ if $hasSubLinks }}
+                  <span class="project-links">
+                    {{/* When site is primary AND repo also exists, show repo as "code" */}}
+                    {{ if and $site $repo }}
+                      <a href="{{ $repo }}" rel="noopener nofollow" target="_blank">code</a>
+                    {{ end }}
+                    {{/* For multi-repo entries, render each repo with deterministic order */}}
+                    {{ with $repos }}
+                      {{ $keys := slice }}
+                      {{ range $k, $u := . }}{{ $keys = $keys | append $k }}{{ end }}
+                      {{ $keys = sort $keys }}
+                      {{ range $keys }}
+                        {{ $url := index $repos . }}
+                        <a href="{{ $url }}" rel="noopener nofollow" target="_blank">{{ . }}</a>
+                      {{ end }}
+                    {{ end }}
+                  </span>
+                {{ end }}
+                {{ with $platforms }}
+                  <span class="project-platforms">{{ range . }}<span class="project-platform">{{ . }}</span>{{ end }}</span>
+                {{ end }}
+                {{ with $maintainer }}<span class="project-maintainer">by {{ . }}</span>{{ end }}
+              </li>
+            {{ end }}
+          </ul>
+        </section>
+      {{ end }}
+    {{ end }}
+
+    <p class="projects-back-to-top"><a href="#top">{{ i18n "projects_back_to_top" }}</a></p>
+    {{ else }}
+    <p>Project data is currently unavailable.</p>
+    {{ end }}
+  </div>
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary

Adds a new `/projects/` page that surfaces the full list of Nostr projects we track for newsletter coverage. The page reads from `data/projects.yml` at build time, groups projects into 12 categories with anchor navigation, and is fully indexed by Pagefind so search queries return project entries.

The page is the public-facing version of our internal tracking list — readers can see the breadth of what we monitor (492 projects across 12 categories) and use it as a directory for the Nostr ecosystem.

## What's in the PR

### Page

- `content/en/projects.md` plus stubs in 9 other languages
- `layouts/_default/projects.html` template
- `assets/sass/main.scss` styling appended (`.projects-page` block)
- Menu entry added between Topics and Podcast (`hugo.toml`)
- i18n keys added to all 10 locale files (`menu_projects`, `projects_cat_*`, `projects_total_count`, `projects_back_to_top`)

### Page features

- 12 categories in deliberate order: Social → Long-form → Messaging → Media → Marketplaces → Wallets → Signers → Relays → DevTools → Libraries → Protocols → Other
- Alphabetical within each section, case-insensitive
- Anchor nav at top, back-to-top link at bottom
- Status badges for `beta` and `inactive` entries (active projects are unbadged)
- Project name links to website if present, repo otherwise
- Multi-repo entries (Marmot Protocol, Frostr, Vertex) render extra `[label]` chips for each sub-repo
- Mobile breakpoint hides platform/maintainer chips to keep rows compact
- Deterministic build verified across 5 consecutive runs (sorted `repos:` map keys)

### Data quality fixes to `data/projects.yml`

This was the bigger half of the work. Two parallel review agents flagged the issues; I applied the highest-impact fixes:

**Removed 27 entries that didn't belong:**

- 14 dead `nostrability/*` entries (the GitHub org no longer exists)
- 2 hard duplicates: `Nstart.me`, `Obsidian Nostr Writer`
- 9 entries with no reachable repo or website: `Pod21`, `Grimoire`, `Lantern`, `Relay Tools`, `Shakespeare`, `Grasp`, `Peridot`, `Primal Studio`, `Nostr Design` — these can return when sources are confirmed
- 2 NIP entries that weren't projects (`NIP-60/NIP-61`, `NIP-90`)

**Recategorized 9 entries** out of `protocols:` (which had drifted into a catch-all):

- `dotnet-mls`, `marmot-cs` → `libraries`
- `Flora` → `media_clients`
- `Sprout`, `OpenChat` → `messaging_clients`
- `Purser` → `wallets`
- `Titan` → `devtools`
- `Bikel`, `mesh-llm` → `other`

**Fixed 5 broken or wrong repo URLs:**

- `Coracle`: `gitea.coracle.social/coracle/coracle` → `github.com/coracle-social/coracle`
- `Bucket`: `gitea.coracle.social/coracle/bucket` → `github.com/coracle-social/bucket`
- `ZapStore`: `ArcadeCity/zapstore` → `zapstore/zapstore`
- `ngit`: codeberg → github (active repo lives on github now)
- `Mutiny`: added `MutinyWallet/mutiny-web` repo

**Cleaned up multi-repo entries:**

- Marmot Protocol: dropped duplicate `repos.spec` (now top-level `repo:` is canonical)
- Frostr: moved `igloo-desktop` into `repos.desktop` so the "code" link wasn't quietly desktop-only

**Removed marketing language** from descriptions and notes — replacing instances of `comprehensive`, `ecosystem`, `innovative`, `powerful` with concrete equivalents.

**Added 38 missing projects** sourced from the canonical `awesome-nostr` list, including: Zappix, Wherostr, Votestr, Pretty Good Apps, Pareto, Decent Newsroom, OstrichGram, gupt, Beagle, P2P band, Zaplytics, gitstr, Disgus, Ephemerelay, zooid, multiplextr, Nuxstr, shockwallet, Heya.fund, eight relay implementations, and more.

**Net total:** 503 → 492 entries (27 removed, 38 added, 11 net cleanup).

## Verification

- Hugo build succeeds in ~1.8 seconds, no template errors
- Pagefind indexes all 492 entries — searching "Damus", "Snort", "Amethyst" returns the projects page
- Five consecutive builds produce byte-identical output (deterministic)
- No buzzwords in rendered HTML (anti-slop scan clean)
- Page reachable at `/{lang}/projects/` for all 10 languages
- Translation stubs use English text in body — full translations should run through `/translate` in a follow-up PR (consistent with how newsletters are handled)

## Known follow-ups (not in this PR)

- Categorization audit flagged ~50 lower-priority moves still in social_clients (calendars, games, video clients) that could be tightened — left for a focused follow-up
- A handful of project descriptions still use generic phrasing ("modern client", "feature-rich") that could be sharpened
- Translation stubs ship in English; should be translated through the existing `/translate` flow

## Screenshots

Page renders at `/en/projects/` (and same for each locale). Total count appears at the top, then anchor nav, then alphabetized sections with anchored headings. Mobile view collapses the platform and maintainer chips to keep rows readable.
