### PR TITLE
add Nostru - Nostr social client + Bitcoin Silent Payment Chrome extension

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -821,6 +821,17 @@ social_clients:
     status: active
     priority: low
 
+  # --- Browser Extensions ---
+  - name: Nostru
+    description: Nostr social client and Bitcoin Silent Payment receiver as a Chrome browser extension
+    platforms: [ browser-extension ]
+    repo: https://github.com/i2dor/nostru
+    website: https://github.com/i2dor/nostru/releases/latest
+    maintainer: i2dor
+    status: beta
+    priority: low
+    notes: Derives BIP-352 Silent Payment addresses from any Nostr keypair (NSP); publishes and discovers SP addresses via NIP-352 (kind:30352); NWC zaps; local ECDH scanning via native host; scan key never leaves device
+
 # =============================================================================
 # LONG-FORM CONTENT
 # =============================================================================


### PR DESCRIPTION
**Nostru** is a Chrome MV3 browser extension that combines a Nostr social client with a Bitcoin Silent Payment receiver.

**Category:** social_clients (browser-extension)

**What it does:**
- Nostr feed, profiles, threads, reactions, reposts
- One-click Lightning zaps via NWC
- Derives a BIP-352 Silent Payment address (`sp1...`) from any Nostr public key (NSP protocol) - computable by anyone from the npub alone
- Publishes and discovers SP addresses via NIP-352 (kind:30352 addressable event) - receiver-controlled announcement
- Scans for incoming Silent Payments via a local native host (scan key never leaves the device)
- Builds and signs P2TR sweep transactions entirely locally
- NIP-07 signer bridge for web dApps

**Links:**
- Repo: https://github.com/i2dor/nostru
- Release: https://github.com/i2dor/nostru/releases/latest
- NIP-352 draft: https://github.com/nostr-protocol/nips/pull/2392