### PR TITLE
Newsletter #29 (2026-07-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,22 +205,35 @@ When working on newsletter updates:
 1. **ALWAYS check for existing PR first** - Newsletter branches typically have an open PR already
 2. **Update existing PR** - Force push changes to the existing newsletter branch
 3. **Never create duplicate PRs** - One PR per newsletter issue
+4. **ALWAYS keep the PR at exactly one commit.** No multi-commit history. Every push after the first must be a force-push that squashes all local commits into a single "Newsletter #N (YYYY-MM-DD)" commit. Reviewers should see one clean diff, not a chain of amendments.
 
 ### Workflow
 ```bash
 # Check for existing PR
 gh pr list --head newsletter/YYYY-MM-DD
 
-# If PR exists, update it
+# If PR exists, update it (SQUASH-AND-FORCE-PUSH REQUIRED)
 git checkout newsletter/YYYY-MM-DD
 # Make changes
 git add .
-git commit --amend
-git push --force
+BASE=$(git merge-base HEAD origin/main)
+git reset --soft "$BASE"
+git commit -m "Newsletter #N (YYYY-MM-DD)"
+git push --force-with-lease
 
 # If no PR exists (rare), create one
-gh pr create --title "Newsletter #X (YYYY-MM-DD)" ...
+gh pr create --title "Newsletter #N (YYYY-MM-DD)" ...
 ```
+
+### Why squash-and-force-push, always
+
+Multi-commit PR history for a newsletter is noise. Every commit after the first is a "fix a review comment" or "audit addendum" or "user feedback pass," none of which matter to a future reader. The final PR should contain exactly one commit that IS the newsletter, so that:
+- `git log content/en/newsletters/*.md` reads as one row per issue
+- PR review pulls up one diff, not four
+- Reverting a bad issue is one revert, not a rebase
+- Reviewers waste zero energy on intermediate state
+
+Use `git reset --soft $(git merge-base HEAD origin/main)` to collapse everything into a single staged change, then commit once, then `push --force-with-lease`. Never `--force` without `--with-lease` (protects against someone else's push racing yours).
 
 ## Common Newsletter Fixes
 
@@ -234,19 +247,22 @@ gh pr create --title "Newsletter #X (YYYY-MM-DD)" ...
 **NEVER ask for an nsec. NEVER use `nak` directly. Always use the pipeline.**
 
 ```bash
-# Full pipeline (all stages)
-COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage all --really-broadcast
+# Full pipeline (all stages: parse → sign → announce-sign → broadcast → merge)
+COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage all --really-broadcast --really-merge
 
 # Individual stages (run in order)
 COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage parse
 COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage sign
 COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage announce-sign
 COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage broadcast --really-broadcast
+COMPASS_PUBLISH_INVOCATION=manual bun ~/compass/publish/publish.ts <N> --stage merge --really-merge
 
 # Or use the wrapper (same thing, shorter)
 compass-publish <N>
 compass-publish <N> --stage sign
 ```
+
+**Always pass `--really-merge` with `--really-broadcast`.** Broadcast posts the newsletter to Nostr but leaves the GitHub PR open; the website only updates when the PR is merged and Hugo deploy runs from main. The merge stage refuses to run unless the broadcast ledger shows at least one ok relay, so the two stages are safe to chain. This was the cause of Newsletter #27 being on Nostr but missing from the website for ~19 hours on 2026-06-17.
 
 **Config:**
 - Bunker URI: `~/.config/compass-publish/bunker.json`

--- a/content/en/newsletters/2026-07-01-newsletter.md
+++ b/content/en/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+Welcome back to Nostr Compass, your weekly guide to Nostr.
+
+**This week:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) ships a Nym mixnet transport, opt-in mDNS LAN discovery, hitless rekey under loss, and a data-plane overhaul, wire-compatible with v0.3.0. [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) surfaces as a desktop Marmot client in Rust and Slint with a protocol proposal to move message effects to a dedicated kind-9 event. [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) launches as a hardware-backed mobile identity vault acting as a NIP-46 remote signer and answering physical access challenges over NFC. [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) launches peer-to-peer nsite sharing over the FIPS mesh with a new BLE L2CAP transport in v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) launches as an Android control surface for a local Codex coding-assistant over encrypted Nostr DMs. [Amethyst's unreleased line](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) adds NIP-89 app-handler parsing, a Git Repositories feed for NIP-34, and a Discover section for nSites and napplets. [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) lands NIP-37, NIP-52, and NIP-22 in one week. [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) cuts 12 sub-package releases with nbunksec NIP-46 helpers and a Cashu-ts v4 wallet upgrade. [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) ships Shared-Key Collaborative Lists on addressable kind-35000. The NIPs repository merged five PRs including a relay roles event, the NIP-44 65,535-byte limit removal, NIP-34 fork semantics, NIP-46 client metadata, and a NIP-86 signevent method. Deep dives cover [NIP-86 (Relay Management API)](#nip-deep-dive-nip-86-relay-management-api) and [NIP-89 (Recommended Application Handlers)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Lead stories
+
+### FIPS v0.4.0 ships Nym mixnet transport, mDNS discovery, and a data-plane overhaul
+
+[FIPS](https://github.com/jmcorgan/fips) is a private, self-organizing peer-to-peer mesh network for Nostr where nodes discover each other and route traffic without central infrastructure. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) lands a Nym mixnet transport, opt-in mDNS LAN discovery, a data-plane overhaul, hitless rekey under packet loss, a rewritten `fipstop` TUI on a render-snapshot harness, an off-hot-path observability plane, and new OpenWrt apk and Nix flake packaging targets, all wire-compatible with v0.3.0 so mixed meshes interoperate during a rolling upgrade. Two new transports for peer discovery anchor the release. A new [outbound Nym mixnet transport](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) routes FIPS traffic through a `nym-socks5-client` SOCKS5 proxy, mixing it into the [Nym](https://nymtech.net/) cover-traffic network so link-level observers cannot correlate which mesh peers are talking, and an `examples/sidecar-nostr-mixnet-relay/` directory demonstrates a Nostr relay reachable over a FIPS link peered end-to-end across the mixnet. Opt-in mDNS / DNS-SD LAN discovery lets nodes on the same local link find each other with no address configuration and no STUN, advertising and adopting peers through a standard service record on `node.discovery.lan.enabled: true`.
+
+The data plane was reworked for higher single-node throughput. Per-peer encrypt and decrypt now run on dedicated worker tasks off the receive loop, so one busy peer cannot serialize the whole node's crypto. The Linux send path uses generic segmentation offload and a connected-UDP socket where available, the receive hot path avoids buffer copies it previously made per packet, and macOS picks up a `recvmsg_x` batched receive to mirror the Linux `recvmmsg` batching from v0.3.0. The entire `show_*` read surface for `fipsctl` and `fipstop` now serves from a per-tick snapshot published into a lock-free `ArcSwap` from the control accept task, so operator queries answer promptly on a node whose receive loop is busy. A new counter-only `show_metrics` query (surfaced as `fipsctl stats metrics`) enables Prometheus scraping at no hot-path cost.
+
+FMP and FSP session rekey are now hitless under packet loss and reordering in both directions: inbound frames authenticate against the pending session before the K-bit cutover promotes it (so a stale or spoofed frame cannot derail rekey), rekey message-1 retransmission is bounded, the link-dead heartbeat is rekey-aware, and dual-initiation races on high-latency links are desynchronized with symmetric jitter. The `fipstop` TUI is rebuilt on a render-snapshot harness that asserts the exact text grid and per-cell style of every view against canned control-socket output. New packaging targets ship alongside: an OpenWrt `.apk` for OpenWrt 25+ (built SDK-free, reusing the existing `.ipk` cross-compile and installed-filesystem payload) and a `flake.nix` at the project root that builds all four binaries (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) from source on Nix/NixOS with the pinned toolchain.
+
+### Whitenoise Linux surfaces as a desktop Marmot client
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) is a desktop [Marmot](/en/topics/marmot/) client: MLS group messaging over Nostr relays, packaged as a single Rust binary with a Slint UI that keeps every secret in one password-encrypted vault.
+
+The most consequential thread this week proposes carrying Whitenoise message effects as a dedicated kind-9 event referencing the parent message. Today's wire format appends a marker like `dmfx:sparkle` to the end of the message body, which pollutes the text for any renderer that does not know the convention. Moving effects to their own event keeps message text clean, and it opens a design question the wider Marmot stack is going to face: inline body conventions or sidecar events for optional rich features.
+
+### CustID launches as a mobile identity vault with NIP-46 and NFC challenge flow
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) is the first public beta of CustID, a mobile identity vault built on Nostr and the SISTR protocol. CustID stores multiple Nostr identities in hardware-backed secure storage, acts as a [NIP-46](/en/topics/nip-46/) remote signer for other clients, and answers physical and online access challenges over NFC and QR codes.
+
+The beta is feature-complete for the NIP-46 signer and NFC challenge-response flow; zero-knowledge-proof access flows remain a future milestone. This release also drops the app's background [NIP-65](/en/topics/nip-65/) keep-alive layer, which had been opening a WebSocket per profile per read relay and ingesting kinds the client immediately discarded. Only the NIP-46 sockets that carry signing-request notifications are kept alive in the background now, which is the fix that makes running CustID as a bunker for other clients viable on a phone.
+
+### myco launches peer-to-peer nsite sharing over the FIPS mesh
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) opened this week on June 27 and reached v0.1.0 on July 1. myco is a Rust Android app that installs apps from the people around you: peer-to-peer [nsite](/en/topics/nip-5a/) sharing over a FIPS mesh, with any transport the mesh can carry (UDP, TCP, Tor, Bluetooth), working fully offline. The design pairs directly with FIPS as the transport substrate and with NIP-5A's static-website event format as the payload, letting an app distributed as an nsite move between mesh peers without depending on relays or HTTP.
+
+v0.1.0 adds an L2CAP Bluetooth radio path so two phones with FIPS installed can peer over BLE without any network, plus a per-peer speedtest and NFC-triggered sharing from the app's Circle bottom-sheet. myco is also published to Zapstore for direct install.
+
+### Nostr Codex Phone launches as a mobile control surface for a local Codex worker over Nostr
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) launches this week as an Android client that controls a local Codex coding-assistant worker over encrypted Nostr direct messages. The app supports multiple repository sessions, voice transcription, routed worker sessions, Blossom media uploads, and optional spoken responses, so a developer running a Codex worker at home can dispatch requests from their phone anywhere the phone has relay access.
+
+The project is a direct sibling to [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr) launched in #28. Both put agentic-coding workflows on Nostr transport with encrypted DMs, and both treat Nostr as the pairing and messaging layer that lets a phone reach a home worker without punching holes through the network. Nostr as a control-plane for local agents is becoming an established pattern.
+
+### Coop Mobile publishes its first versioned builds
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) and [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) shipped this week as the first versioned builds of Coop Mobile, a [NIP-17](/en/topics/nip-17/) encrypted direct-messaging client for Android. The two releases tighten crash safety around message parsing and QR handling, and wipe all stored data on logout.
+
+### Amethyst builds NIP-89-aware UI, a Git Repositories feed, and a napplet Discover section
+
+[Amethyst's](https://github.com/vitorpamplona/amethyst) main branch built out several new surfaces this week. A [Git Repositories feed](https://github.com/vitorpamplona/amethyst/pull/3406) turns [NIP-34](/en/topics/nip-34/) repos into a browsable Android timeline category, filterable by community and author, paired with a [smart-HTTP git browser](https://github.com/vitorpamplona/amethyst/pull/3415) that reads repo contents and commits without leaving the app. The napplet host gained a [Discover section](https://github.com/vitorpamplona/amethyst/pull/3409) listing curated web apps plus followed nSites and napplets, sourced from [NIP-89](/en/topics/nip-89/) handler events and [NIP-5A](/en/topics/nip-5a/) site events. Note display now [reveals which Nostr app authored an event](https://github.com/vitorpamplona/amethyst/pull/3422) via NIP-89 tags. On the sync side, [NIP-77 negentropy support](https://github.com/vitorpamplona/amethyst/pull/3434) lands with streaming reconciliation and automatic `created_at` windowing to work around relay-side result caps, cutting bandwidth needed to keep large local event sets in sync with a relay.
+
+### Buzz v0.3.38 hardens the relay attack surface and adds provider-agnostic model selection
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) hardens the [relay attack surface](https://github.com/block/buzz/pull/1369) that Buzz exposes when it publishes personas, teams, managed agents, and NIP-OA owner attestations as signed Nostr events. A Buzz relay is a public record of the team's Nostr identities and their state, and this release tightens input validation and replay protection on the well-known event kinds Buzz defines. The release also generalizes model selection so a Buzz team can point at any provider Buzz has adapters for, including a new Databricks AI Gateway v2 backend.
+
+### Notedeck implements NIP-37 private-sync relays, NIP-52 calendar, and NIP-22 comments
+
+[Notedeck](https://github.com/damus-io/notedeck), the Damus team's native Rust desktop client, landed three protocol implementations in one week. Private-sync relays now persist as a kind `10013` [NIP-37](/en/topics/nip-37/) list, separating the user's private-content relay set from their public NIP-65 outbox. The `horizon` calendar pane reads [NIP-52](/en/topics/nip-52/) events from nostrdb and got a three-pane layout redesign. The `headway` pane added a [NIP-22](/en/topics/nip-22/) comment-event model on kind `1111`, the kind NIP-22 defines for the unified comment surface that replaces NIP-10 reply threading.
+
+
+
+### Applesauce lands nbunksec NIP-46 sessions and a Cashu v4 wallet upgrade
+
+[Applesauce](https://github.com/hzrd149/applesauce), the modular Nostr toolkit for signers, relays, wallets, and content, cut a coordinated [6.2.x release](https://github.com/hzrd149/applesauce/releases) across its sub-packages. The signers package gained `nbunksec` import and export helpers, treating a [NIP-46](/en/topics/nip-46/) bunker session as a portable artifact that can move between clients. The wallet package upgraded its [Cashu](/en/topics/nip-60/) bindings to `@cashu/cashu-ts` v4, where proof amounts become `Amount` value objects and the token-decoding API changes.
+
+---
+
+## Tagged releases
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) lands the next protocol iteration for the [Mostro](/en/topics/nip-69/) P2P fiat trading network. The release follows [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) and ships alongside [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0) which adopts the new core. Three merged PRs landed in the core repository this week; the surrounding stack (mostro daemon and Mostro mobile) tracks against v0.14.0 of the shared types crate.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), the canonical git-over-nostr CLI for [NIP-34](/en/topics/nip-34/) repositories, implements this week's merged [NIP-34 GRASP-06 fork semantics](https://github.com/nostr-protocol/nips/pull/2395) that replace the `personal-fork` tag with a `u` tag on repo-state events.
+
+### mesh-llm v0.72.0 and v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), the inference component of the ContextVM stack that runs open-source LLMs behind a Nostr-addressable JSON-RPC surface, shipped [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) and [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1) with a fix for a batching crash on large single prompts and an MCP-bridge migration off deprecated helpers.
+
+### Meiso v1.4.0 ships Shared-Key Collaborative Lists that replace MLS for task sharing
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) introduces a Shared-Key Collaborative Lists model that replaces the project's prior MLS-based task sharing with a simpler addressable-event design. Each shared list generates a dedicated Nostr key distributed to members, tasks are addressable events on kind `35000` keyed by `d=task-id` with [NIP-44](/en/topics/nip-44/) self-encrypted content, and relays enforce Last-Write-Wins per task. The design surrenders MLS's forward secrecy and post-compromise security in exchange for simpler client implementation and relay-level conflict resolution.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) ships a "more-private-coordinator" track that removes ephemeral sender pubkeys from group message posting and hardens the join-request flow against stale re-requests. Cordn is the MLS-based messaging stack covered in [#28's Cordn Ad-hoc CVM launch](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); this release is the matching coordinator-side update.
+
+---
+
+## Unreleased changes
+
+### diVine pushes 108 merged PRs of post-launch polish
+
+[diVine](https://github.com/divinevideo/divine-mobile), the short-form looping video client bringing back Vine, is in a heavy post-launch polish wave. The Nostr-visible work this week is a [NIP-46](/en/topics/nip-46/) connect-flow stability pass that migrates `nostrconnect://` failures onto structured reason codes.
+
+### Zap Cooking continues the cross-project NIP-46 fix and composer overhaul
+
+[Zap Cooking](https://github.com/zapcooking/frontend) is a Nostr recipe-sharing client where recipes are published as long-form Nostr events. This week's work continues the cross-project [NIP-46](/en/topics/nip-46/) fix and composer overhaul covered as unreleased in [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes).
+
+### Conduit hardens listing flow and marketplace correctness
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) is a three-app marketplace monorepo on Nostr covering the buyer market, merchant portal, and store builder. This week's work continues the marketplace correctness push covered in [#28's launch coverage](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default), building on the [NIP-99](/en/topics/nip-99/) commerce wave that was the protocol-side story last issue.
+
+### Pollerama v1.12 through v1.13.1 add client-tag choice, profile tabs, and thread caps
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), an Android Nostr client focused on polls and notes with a strong web-of-trust discovery layer, shipped v1.12.0, v1.13.0, and v1.13.1 to Zapstore this week. Users can now pick which client tag is attached to their authored notes and polls, choosing from a preset list or entering their own. Deeply nested comment and reply chains now stop after a few levels and link out to the full thread on the note's page. Profile pages open on Notes by default, split into a Posts tab and a Conversations tab. A follow-persistence bug where newly-followed accounts disappeared after an app restart is fixed, and follow buttons now show progress.
+
+### getwired.app and get-tao.app fix the NIP-13 confess submission flow
+
+[getwired.app](https://github.com/smolgrrr/Wired) and [get-tao.app](https://github.com/smolgrrr/TAO), which share an anonymous-posting flow that adds NIP-13 proof-of-work to suppress spam at submit time, fixed the [confess submission flow](https://github.com/smolgrrr/Wired/pull/57) so the UX during PoW mining is coherent.
+
+### nostui adds a mention timeline tab
+
+[nostui](https://github.com/akiomik/nostui), a terminal Nostr client in Rust, added a [mention timeline tab](https://github.com/akiomik/nostui/pull/463) that surfaces kind:1 events tagging the active pubkey as a dedicated view in the TUI.
+
+### Heartwood lands per-identity NIP-46 bunker URIs and an HSM-mode signing bridge
+
+[Heartwood](https://github.com/forgesworn/heartwood) is a [NIP-46](/en/topics/nip-46/) signer where the signing key never reaches the client at all: the client speaks NIP-46 to a small relay, and the relay speaks a serial frame protocol to an attached hardware device that performs the signature. This week the project landed a [relay-to-serial signing bridge](https://github.com/forgesworn/heartwood/pull/11) and [per-identity bunker connections](https://github.com/forgesworn/heartwood/pull/16), so a single hardware device holding multiple identities exposes a distinct bunker URI for each one.
+
+### Nostter auth and signer refactor
+
+[Nostter](https://github.com/SnowCait/nostter) reworked its [auth and signer layer](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth) this week, moving login state onto a single signal and extracting the signer dispatch into strategy modules. The trajectory is a clean signer abstraction where NIP-07 web extension, NIP-46 remote bunker, and raw nsec all share one code path.
+
+### Dart NDK extracts the NIP-07 signer and randomizes NIP-59 timestamps
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) moved its [NIP-07](/en/topics/nip-07/) signer out of the core package and into `ndk_flutter` (where the Flutter WebView lives), and [randomized its NIP-59 gift-wrap timestamps](https://github.com/relaystr/dart_ndk/pull/667) to harden against timing correlation of encrypted messages.
+
+### Milk Market adds NIP-23 storefront pages and Square payment processing
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), the Shopstr-team marketplace storefront, gave every storefront a blog page backed by the seller's [NIP-23](/en/topics/nip-23/) long-form events, with editable sections and a direct blog-setting route. The same week added [Square](https://github.com/shopstr-eng/milk-market/pull/30) as an alternative payment processor for sellers and automatic shipping-label purchases for paid orders.
+
+### Calendar by Formstr ships an iOS app
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) merged [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159) this week, bringing the [NIP-52](/en/topics/nip-52/) calendar client to iOS. [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) fixes calendar-date parsing in local time, and [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) adds a Playwright E2E workflow triggered by a `run-tests` label.
+
+### cagliostr enforces NIP-22, NIP-09 by coordinate, and NIP-13 proof-of-work
+
+[cagliostr](https://github.com/mattn/cagliostr), a Go relay implementation, tightened three enforcement paths this week: [configurable NIP-13 proof-of-work](https://github.com/mattn/cagliostr/pull/7) on incoming events, [NIP-09 deletion by addressable coordinate](https://github.com/mattn/cagliostr/pull/8) so replaceable events can be deleted by their `a` tag (which event-id deletion alone cannot reach), and [configurable NIP-22 timestamp limits](https://github.com/mattn/cagliostr/pull/9) that reject events stamped too far in past or future.
+
+---
+
+## Newly tracked and discovered
+
+The [Vanderwarker wellbeing suite](https://git.vanderwarker.family/wellbeing) publishes physical-world telemetry as Nostr events under a shared publisher signing key. It consists of five sibling apps: [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) is a step tracker anchoring fitness data to Nostr as `kind:30078`, [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) publishes a daily phone-unlock counter, [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) publishes current media playback as a User Status, [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) publishes battery level, voltage, and temperature every 15 minutes, and [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) publishes daily data usage. All five appeared on Zapstore between June 24 and June 30.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) is an encrypted serverless live location-sharing Android app built in Rust and Slint, released June 29. It is a sibling to the [Haven](https://github.com/mehmetefeumit/Haven-App) [Marmot](/en/topics/marmot/)-based location sharer covered in [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), with a different transport architecture: encrypted Nostr DMs carry the location updates, where Haven uses Marmot group messages.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) is an early-stage application shell scaffold for building Nostr apps. The project published its first user-facing documentation this week.
+
+[NIPs by Pollerama](https://nips.pollerama.fun) (repository [abh3po/better-nips](https://github.com/abh3po/better-nips), created 2026-06-29) is a new client for [NostrHub's](https://nostrhub.io) `kind:30817` community-authored NIPs, positioned as a trust-weighted alternative surface to nostrhub.io. Each `kind:30817` NIP has its own shareable URL (`#/nip/<naddr>`) with full Markdown rendering and the event kinds it defines. The client offers three feeds: Following, Web of Trust (follows-of-follows), and Global, each sortable by trust-weighted approvals or by newest. Approvals publish as [NIP-32](/en/topics/nip-32/) labels on kind `1985` with tags `["L","nostrhub"]` and `["l","approve","nostrhub"]` plus an `a` tag pointing at the target NIP address and a `client` tag advertising `better-nips`, which is the exact event shape NostrHub itself signs so approvals are cross-compatible between the two clients. A direct follow's approval carries more weight in the ranking than a second-degree follows-of-follows approval.
+
+The signing stack is [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer) with a full login modal covering [NIP-07](/en/topics/nip-07/), [NIP-46](/en/topics/nip-46/) bunker and nostrconnect, [NIP-49](/en/topics/nip-49/) ncryptsec, and [NIP-55](/en/topics/nip-55/) Android signer, and sessions silently re-attach on reload. The network layer runs through [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), a Web Worker that partitions the user's [NIP-65](/en/topics/nip-65/) outbox across relays so a large web-of-trust set does not fan out to a single relay. The design position is that community NIPs (whether hosted at NostrHub, in `better-nips`, or by other future clients) are all equal at the protocol level; ranking comes from the social graph, not from moderator curation, which pairs directly with the NIP-32 labeling flow the deep dive in [#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling) covered.
+
+Two new [NIP-34](/en/topics/nip-34/) repo clusters appeared this week. [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) is a video-focused Nostr client, and a [nostrapps.com cluster](wss://gitnostr.com) publishes three sibling projects: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git) (a napp VM for desktop), [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git) (a customizable communities client), and [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git) (an HTML microapps spec and runtime). The cluster sits parallel to the [napplet](/en/topics/nip-5d/) work covered in last issue's lead story.
+
+---
+
+## Protocol work and NIP updates
+
+### Merged: NIP-44 lifts the 65,535-byte payload limit
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907) merged on June 28 after sitting open since 2024-09. The change removes the 65,535-byte upper bound on the plaintext payload of a [NIP-44](/en/topics/nip-44/) versioned-encryption envelope, raising it to a 4-GiB cap (`uint32_max`). NIP-44 encodes payload length as a `uint16` in the wire format, which the original spec required strictly for interop; the merged change adopts a longer-length field tagged into the version byte so v2 implementations stay wire-compatible and v3+ implementations carry the longer length. Clients using NIP-44 for [NIP-17](/en/topics/nip-17/) direct messages, [NIP-59](/en/topics/nip-59/) gift wraps, [NIP-46](/en/topics/nip-46/) remote-signer payloads, or any other NIP-44-encrypted Nostr message can now exchange single events larger than 64 KiB without splitting at the application layer.
+
+### Merged: NIP-86 gains a signevent method and a Relay Roles event
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) adds a `signevent` method to the [NIP-86](/en/topics/nip-86/) relay management JSON-RPC API, letting an administrator ask the relay to sign an event with the relay's own pubkey. The companion [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) defines a Relay Roles event: a replaceable event a relay publishes to declare its administrators and moderators. Together they let NIP-86 clients introspect a relay's admin list and verify an authenticated request came from a current admin, without out-of-band trust. Deep dive on both changes below.
+
+### Merged: NIP-34 replaces personal-fork with `u` for GRASP-06
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395) merged on June 24 and replaces the [NIP-34](/en/topics/nip-34/) `personal-fork` tag on repo-state events (`kind:30618`) with a `u` tag (for "upstream"), aligning the wire format with the GRASP-06 fork semantics the GitWorkshop suite has been implementing. The change closes [PR #2384](https://github.com/nostr-protocol/nips/pull/2384) (`NIP-34: remove maintainers to solve expiry issues`), which proposed a different fork-semantics fix. The merged direction is the one ngit v2.6.x implements, so the merged spec and the reference CLI are now aligned. Existing repos using `personal-fork` continue to interoperate; new repos and the ngit v2.6 line publish the `u` tag.
+
+### Merged: NIP-46 client metadata (now upstream after Amber shipped it)
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381) merged on June 23 and adds optional client metadata to the [NIP-46](/en/topics/nip-46/) `connect` request, letting a client publish its name, an icon URL, and a homepage URL at signer-connect time. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) shipped the metadata extension last week (covered in [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata)); this week the upstream NIP catches up to the shipping implementation.
+
+### Open: epoch-based deterministic NIP-17 wrapper keys
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397) and [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) cover two converging NIP-17 wrap-key proposals. PR #2397 proposes that the ephemeral signing key used to author a [NIP-59](/en/topics/nip-59/) gift wrap be derived deterministically from a per-conversation seed tied to a coarse time epoch, so a recipient who knows the conversation key can predict which pubkeys to subscribe to. The current spec requires a fresh random key per wrap, which makes that prediction impossible. PR #2396 is the companion change: wraps for a given conversation should be signed with the conversation key directly so the wrap pubkey doubles as the conversation identifier. Together they define a path to filterable NIP-17 conversations without metadata leakage. Both are open and under discussion.
+
+### Open: NIP-59 should reject kind:13 seal events at the relay
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399) proposes that relays should reject kind:13 events (the inner seal of a [NIP-59](/en/topics/nip-59/) gift wrap) when they appear at the top level of a publish request, because a seal event is only meaningful inside a wrap and a leaked seal exposes the recipient pubkey. The companion [issue #2398](https://github.com/nostr-protocol/nips/issues/2398) goes further and argues that the seal should be re-defined as an ephemeral kind (NIP-01 ephemeral kinds are not stored by relays), which would harden the rule at the protocol level and remove the dependence on per-relay policy.
+
+### Open: NIP-29 group states
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372) adds explicit group-state semantics to [NIP-29](/en/topics/nip-29/) (relay-based groups), defining what it means for a group to be open, closed, public, private, or archived, and how state transitions interact with member events. The proposal pulls semantics that have been client-specific into the relay spec.
+
+### Open: NIP-34 optional multi-maintainer support
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324) is the companion proposal to the merged [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) (GRASP-06 fork semantics covered above). PR #2324 adds optional multi-maintainer support to [NIP-34](/en/topics/nip-34/) repo announcement events (`kind:30617`), letting a repository declare more than one canonical maintainer pubkey via repeated `maintainer` tags. Patches and issues signed by any declared maintainer are then trusted by clients as official, which addresses the long-standing gap where NIP-34 repos with co-maintainers must either route everything through one pubkey or fall back to off-protocol coordination.
+
+### Open: NIP-91 AND operator for filters (the proposal is open, not merged)
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252) is the AND-operator proposal for Nostr [filters](/en/topics/nip-01/), reopening a design first discussed in the earlier closed [PR #1365](https://github.com/nostr-protocol/nips/pull/1365). Implementations already exist in [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst), and worker-relay, but the spec PR itself remains open.
+
+### Closed: four pats2sats commerce NIPs
+
+Four commerce-on-Nostr proposals closed this week: Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), a [NIP-99](/en/topics/nip-99/) Marketplace Listing Extension ([#2346](https://github.com/nostr-protocol/nips/pull/2346)), and an Accommodation Listing Profile ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). The same commerce surface is now being consolidated in the [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), a project-owned extension repository that composes on top of NIP-99 marketplace listings with orders, checkout, escrow, and dispute semantics. Compass now tracks this repository alongside Marmot and Blossom as a protocol-spec repo external to the NIPs repository itself; open PRs there this week include client-attribution clarification ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), a supersedes-tag for product-identity changes ([#8](https://github.com/GammaMarkets/market-spec/pull/8)), and merchant-review semantics ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Open: Bitcoin identity linkage
+
+Two proposals opened this week for linking Bitcoin identities to Nostr identities: a [NIP-352 Bitcoin Silent Payment Address](https://github.com/nostr-protocol/nips/pull/2392) and a [Bitcoin-OTC Identity Linkage Proof](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## NIP Deep Dive: NIP-86 (Relay Management API)
+
+[NIP-86](/en/topics/nip-86/) defines a JSON-RPC interface for relay management, letting authorized clients send administrative commands to relays over a standardized API. A single client can manage any NIP-86-compatible relay without per-relay tooling. Two spec merges this week ([PR #2389](https://github.com/nostr-protocol/nips/pull/2389) and [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)) close the loop between relay-signed events and relay-declared administrators.
+
+### The transport
+
+A NIP-86 management request is an HTTP POST to the same URI the relay serves WebSocket connections from, with `Content-Type: application/nostr+json+rpc`. The request body is a JSON document of the form:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+Authentication uses a [NIP-98](/en/topics/nip-98/) HTTP-auth signed event in the `Authorization` header. The relay verifies the signing pubkey is on its administrator list before executing the method. The relay's response is a JSON document of the form:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### The methods that existed before this week
+
+The pre-existing method set covers pubkey bans (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), event bans (`banevent`, `allowevent`, `listbannedevents`), relay metadata (`changerelayname`, `changerelaydescription`, `changerelayicon`), allowed-pubkey list management (`allowkind`, `disallowkind`, `listallowedkinds`), and a `stats` method that returns relay statistics. The shape is intentionally close to a standard JSON-RPC service so a client can layer typed bindings on top of it.
+
+### What changed this week
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) adds a `signevent` method to the spec. The method takes a partial event template (kind, tags, content) as its argument and asks the relay to sign and return a complete event with the relay's own pubkey as the `pubkey` field. This is the precondition for a relay to publish protocol-level events about itself: blocked-pubkey announcements, relay metadata, and the new Relay Roles event below all require the relay to sign with its operator-controlled key, but most relay operators do not want to hold a private key in their administrative client.
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390) defines a Relay Roles event: a parameterised replaceable event kind that a relay publishes (signed with its own pubkey via `signevent`) declaring the pubkeys of its administrators and moderators with explicit role semantics. A NIP-86-aware client can fetch the Relay Roles event from any tracked relay, build the admin list from the event tags, and validate that an authenticated NIP-86 request came from a current admin without out-of-band trust or per-relay configuration. The two PRs together close the loop: `signevent` is the mechanism, Relay Roles is the first event kind built on top of it.
+
+### A NIP-86 request example
+
+A complete NIP-86 `banpubkey` request looks like:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+with an `Authorization` header carrying a NIP-98 signed event:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+The signing pubkey must be present in the relay's admin set (now declared in the relay-roles event); the `u` tag must match the relay's HTTPS URL; the `payload` tag must match the SHA-256 of the JSON request body. The relay returns:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementations
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) ships a NIP-86 relay management UI on Android (v1.07.0+).
+- The reference relays that implement the spec include [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru), and several smaller implementations the spec links from its `Implementation Status` section.
+
+NIP-86-aware clients will begin treating the relay-roles event as the canonical source for a relay's admin list, once implementers pick up the `signevent` and Relay Roles changes.
+
+---
+
+## NIP Deep Dive: NIP-89 (Recommended Application Handlers)
+
+[NIP-89](/en/topics/nip-89/) defines two parameterised replaceable event kinds, `kind:31990` (the application handler an app developer publishes) and `kind:31989` (the recommendation a user publishes for an app they use). Together they let clients discover applications that handle an unknown event kind without out-of-band coordination: a longform reader that hits a `kind:30030` event it does not handle natively can query the NIP-89 graph for handlers and offer the user an `Open in...` flow to a published app that does. NIP-89 is the original infrastructure for the same cross-app routing problem that the napplet/napps work appearing across this issue is now extending into composable Nostr-native applets.
+
+### The application handler event (`kind:31990`)
+
+An app developer publishes one or more handler events describing which event kinds the app supports and how to open a Nostr entity in the app:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+The `d` tag identifies the handler (so it can be replaced), each `k` tag declares an event kind the app handles, and each platform tag (`web`, `ios`, `android`, ...) gives a URL template with `<bech32>` as the placeholder for a [NIP-19](/en/topics/nip-19/) encoded entity that the calling client substitutes at open time. One handler event can advertise several supported kinds if they share the same routing pattern, which keeps app discovery compact and avoids one handler event per kind.
+
+### The user recommendation event (`kind:31989`)
+
+A user publishes a recommendation declaring which apps they use for a given event kind:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+The `d` tag carries the event kind being recommended. Each `a` tag is a NIP-01 address pointer to a `kind:31990` handler event, with the suggested relay and the platform the recommendation applies to. The same recommendation can list multiple apps for different platforms.
+
+### The client tag and the privacy tradeoff
+
+NIP-89 also defines an optional `client` tag that any publishing app can attach to events it authors:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+This lets any client showing the event surface the app it came from, look up richer handler metadata, and respect handler-declared rendering hints. The spec also explicitly notes the privacy cost: a client that emits a `client` tag on every event publishes the user's software identity, which over time discloses usage patterns. The spec recommends clients give users an opt-out.
+
+Amethyst's [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) parses and displays NIP-89 `t`, `i`, `a`, and `client` tags on event display, surfacing which app authored a note directly in the timeline.
+
+### How the discovery flow runs in practice
+
+A client receiving an unknown event kind takes the following steps. (1) Query the user's follow graph for `kind:31989` events with a `d` tag matching the event kind. (2) Resolve each recommended `a` tag to its `kind:31990` handler event. (3) Pick the handler whose `web`, `ios`, or `android` URL template matches the current platform. (4) Substitute the entity's `bech32` encoding into the URL template. (5) Offer the resulting URL to the user as an `Open in...` choice. The flow is socially filtered: a client that queries arbitrary handler events from untrusted relays could end up redirecting users to malicious apps, so starting from people the user follows is a safer default than treating every published handler as equally trustworthy.
+
+### NIP-89 and the napplet layer
+
+Amethyst's Discover section, napplet-host runtime, and `client`-tag display together build a full NIP-89 consumer surface on Android. The napplet spec, launched last issue, extends what those NIP-89 handler events can target: sandboxed applets that run a composable Nostr-native runtime over Nostr and Blossom. NIP-89 is the discovery and routing graph; the napplet runtime is one execution target it can point at.
+
+---
+
+*Feedback, corrections, and projects we missed: open an issue on [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) or reach us over NIP-17 DM at npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/en/topics/nip-37.md
+++ b/content/en/topics/nip-37.md
@@ -1,0 +1,64 @@
+---
+title: "NIP-37: Draft Wraps"
+date: 2026-07-01
+draft: false
+categories:
+  - NIP
+  - Drafts
+  - Privacy
+---
+
+NIP-37 defines an encrypted storage event for unsigned draft events of any kind. A user composing a long-form article, an upcoming calendar event, or a message they may want to send later can store the draft on relays under a kind `31234` event, encrypted to their own key with [NIP-44](/en/topics/nip-44/). The draft is recoverable from any client that holds the user's key, and the same NIP defines a separate `kind:10013` list event that names the relays the user wants their private drafts stored on.
+
+## How It Works
+
+A draft wrap is a parameterised replaceable event of kind `31234`. The unsigned draft event is JSON-stringified, NIP-44 encrypted to the signer's own public key, and placed in `.content`. A `k` tag declares the kind of the draft so a client can group drafts by event type. A `d` tag carries the draft identifier so the wrap can be replaced as the draft evolves, and a NIP-40 `expiration` tag is recommended so old drafts age out automatically.
+
+```json
+{
+  "kind": 31234,
+  "tags": [
+    ["d", "<identifier>"],
+    ["k", "<kind of the draft event>"],
+    ["expiration", "<unix-timestamp>"]
+  ],
+  "content": "<nip44Encrypt(JSON.stringify(draft_event))>"
+}
+```
+
+A blanked `.content` field signals the draft has been deleted.
+
+## Checkpoints
+
+Kind `1234` defines checkpoints belonging to a parent `kind:31234` event. Checkpoints carry an `a` tag pointing back at the parent draft and let a client store revision history alongside the latest draft.
+
+```json
+{
+  "kind": 1234,
+  "tags": [
+    ["a", "31234:<pubkey>:<identifier>"]
+  ],
+  "content": "<nip44Encrypt(JSON.stringify(draft_event))>"
+}
+```
+
+## Relay List for Private Content (kind 10013)
+
+Kind `10013` is a replaceable event whose tags list the relays the user wants to store private content on, including draft wraps. Clients publishing kind `31234` SHOULD publish to relays listed on the user's kind `10013` event. This separates the relay set used for public posting (NIP-65) from the relay set used for private content storage, so a user can pin private drafts to a small set of trusted relays without exposing that set in their public outbox.
+
+## Implementations
+
+- [Notedeck](https://github.com/damus-io/notedeck) - stores private-sync relays as a kind-10013 list (added 2026-06)
+
+---
+
+**Primary sources:**
+- [NIP-37 Specification](https://github.com/nostr-protocol/nips/blob/master/37.md)
+- [Notedeck commit storing private-sync relays as kind-10013](https://github.com/damus-io/notedeck) - Damus team adopts the spec for desktop sync relay management
+
+**Mentioned in:**
+- [Newsletter #29: Notedeck](/en/newsletters/2026-07-01-newsletter/#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments)
+
+**See also:**
+- [NIP-44: Versioned Encryption](/en/topics/nip-44/)
+- [NIP-65: Relay List Metadata](/en/topics/nip-65/)

--- a/data/nip34_tracked.yml
+++ b/data/nip34_tracked.yml
@@ -135,6 +135,55 @@ tracked_repos:
     in_projects_yml: false
     notes: Ansible playbooks for micro VPN deployment; canonical announcement at gitworkshop.dev
 
+  - name: Holy Fit
+    d_tag: holyfit-steps-tracker
+    pubkey: bbfe449b17e64da33c26ce1a7472d5a5e363d0480dcc2b2802544c75b4694a2e
+    relays: [wss://relay.ngit.dev, wss://gitnostr.com, wss://relay.vanderwarker.family]
+    in_projects_yml: true
+    notes: Per-app project pubkey (distinct from Vanderwarker's personal pubkey); also tracked as gitea repo
+
+  - name: Nunlock
+    d_tag: Nunlock-Android-App
+    pubkey: 9f27f7e3592a243363425bddc5419a12dacd1f46b751bba075854f19fc286630
+    relays: [wss://relay.ngit.dev, wss://gitnostr.com, wss://relay.vanderwarker.family]
+    in_projects_yml: true
+    notes: Per-app project pubkey; also tracked as gitea repo (wellbeing/nunlock-android)
+
+  - name: Whitenoise Linux
+    d_tag: darkmatter-linux
+    pubkey: 66675158e6338fe89fda418e42a0bf2a7a2b132504dd347f015a18971b644430
+    relays: [wss://relay.ngit.dev, wss://gitnostr.com]
+    in_projects_yml: false
+    notes: Desktop Linux Marmot/MLS client built in Rust+Slint; password-encrypted vault for keys; clone at relay.ngit.dev/.../darkmatter-linux.git
+
+  - name: Vidstr
+    d_tag: vidstr
+    pubkey: a8d1560d6a647d501699167246f237b36fb123f89168fda11dc743533fec7a08
+    relays: [wss://git.shakespeare.diy, wss://relay.ngit.dev]
+    in_projects_yml: false
+    notes: Nostr video project hosted on git.shakespeare.diy; active patches from TaipeiBlocks
+
+  - name: nostrapps.com — verdana
+    d_tag: verdana
+    pubkey: 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
+    relays: [wss://gitnostr.com, wss://relay.ngit.dev]
+    in_projects_yml: false
+    notes: Napp VM for desktop; part of the nostrapps.com napps ecosystem
+
+  - name: nostrapps.com — hallway
+    d_tag: hallway
+    pubkey: 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
+    relays: [wss://gitnostr.com, wss://relay.ngit.dev]
+    in_projects_yml: false
+    notes: Customizable communities client; part of the nostrapps.com napps ecosystem
+
+  - name: nostrapps.com — napps
+    d_tag: napps
+    pubkey: 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
+    relays: [wss://gitnostr.com, wss://relay.ngit.dev]
+    in_projects_yml: false
+    notes: HTML microapps spec/runtime; companion to napplet ecosystem; same author as verdana and hallway
+
 # Noise filtering is handled in scripts/fetch_nip34_repos.sh:
 #   - NOISE_PUBKEYS array: known noise pubkeys (hardcoded, with comments)
 #   - filter_noise() function: d_tag patterns, clone URL patterns

--- a/data/npubs.yml
+++ b/data/npubs.yml
@@ -585,3 +585,95 @@ Keep Android:
 Hostr:
   npub: npub1cp3vl3azq9v20mju0hz4dtut8pyup9z55fxrhxt48y92md7jmvcs4wlakk
   mention_only: true
+
+# =============================================================================
+# Added for Newsletter #29 publication (validated via kind:0 metadata fetch)
+# =============================================================================
+
+# Lead-story project accounts
+Buzz: npub16l0ck0s5zened29dsaqtqm6z0t4fmk2mwtszw64fz7fppcnls8mss3yj9s
+block: npub16l0ck0s5zened29dsaqtqm6z0t4fmk2mwtszw64fz7fppcnls8mss3yj9s
+
+# Lead-story dev accounts (mention_only: appear alongside their project name)
+Nostr Codex Phone:
+  npub: npub19at4nqjjymca2lh3v546vcg5ktun3al4c5xu2pts3ewckv0y70ys0gupzr
+  mention_only: true
+tidley:
+  npub: npub19at4nqjjymca2lh3v546vcg5ktun3al4c5xu2pts3ewckv0y70ys0gupzr
+  mention_only: true
+
+myco:
+  npub: npub1hw6amg8p24ne08c9gdq8hhpqx0t0pwanpae9z25crn7m9uy7yarse465gr
+  mention_only: true
+Origami74:
+  npub: npub1hw6amg8p24ne08c9gdq8hhpqx0t0pwanpae9z25crn7m9uy7yarse465gr
+  mention_only: true
+
+Coop Mobile:
+  npub: npub1zfss807aer0j26mwp2la0ume0jqde3823rmu97ra6sgyyg956e0s6xw445
+  mention_only: true
+reya:
+  npub: npub1zfss807aer0j26mwp2la0ume0jqde3823rmu97ra6sgyyg956e0s6xw445
+  mention_only: true
+
+# Tagged-release / active-project dev accounts
+Meiso:
+  npub: npub1gzuushllat7pet0ccv9yuhygvc8ldeyhrgxuwg744dn5khnpk3gs3ea5ds
+  mention_only: true
+higedamc:
+  npub: npub1gzuushllat7pet0ccv9yuhygvc8ldeyhrgxuwg744dn5khnpk3gs3ea5ds
+  mention_only: true
+
+Cordn:
+  npub: npub1atv4akyv986nswm4f87zdspfgehzgsva82l5jsd2k3dzgrtzpagssl84q8
+  mention_only: true
+
+# Conduit-BTC project account
+Conduit: npub1nkfqwlz7xkhhdaa3ekz88qqqk7a0ks7jpv9zdsv0u206swxjw9rq0g2svu
+
+# Napplet / sandwich.farm dev account
+Napplet:
+  npub: npub1uac67zc9er54ln0kl6e4qp2y6ta3enfcg7ywnayshvlw9r5w6ehsqq99rx
+  mention_only: true
+sandwich.farm:
+  npub: npub1uac67zc9er54ln0kl6e4qp2y6ta3enfcg7ywnayshvlw9r5w6ehsqq99rx
+  mention_only: true
+
+# ntrack / f321x project account
+ntrack: npub1mxscnuhl2swlmul9a0mldyckuj02zunu9eetm8g3xx2huzargcyqg2uwh7
+f321x:
+  npub: npub1mxscnuhl2swlmul9a0mldyckuj02zunu9eetm8g3xx2huzargcyqg2uwh7
+  mention_only: true
+
+# Protocol / NIP author dev accounts
+staab:
+  npub: npub1jlrs53pkdfjnts29kveljul2sm0actt6n8dxrrzqcersttvcuv3qdjynqn
+  mention_only: true
+
+DocNR:
+  npub: npub1xy54p83r6wnpyhs52xjeztd7qyyeu9ghymz8v66yu8kt3jzx75rqhf3urc
+  mention_only: true
+
+hoytech:
+  npub: npub1yxprsscnjw2e6myxz73mmzvnqw5kvzd5ffjya9ecjypc5l0gvgksh8qud4
+  mention_only: true
+
+smolgrrr:
+  npub: npub1z9n5ktfjrlpyywds9t7ljekr9cm9jjnzs27h702te5fy8p2c4dgs5zvycf
+  mention_only: true
+
+alexgleason:
+  npub: npub1q3sle0kvfsehgsuexttt3ugjd8xdklxfwwkh559wxckmzddywnws6cd26p
+  mention_only: true
+
+# NIP-34 authors recovered from relay data
+Whitenoise Linux: npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh
+Vidstr: npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7
+TaipeiBlocks:
+  npub: npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7
+  mention_only: true
+
+CustID: npub1h2vymvsw7t6syasg5peq7sxnlcejldsugz676c8nz6azqsypx85sz35sx0
+
+Holy Fit: npub1h0lyfxchuex6x0pxecd8guk45h3k85zgphxzk2qz23x8tdrffghqkhskfa
+Nunlock: npub1nunl0c6e9gjrxc6zt0wu2sv6ztdv686xkagmhgr4s483nlpgvccqqzxycg

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -1713,6 +1713,15 @@ messaging_clients:
     priority: medium
     notes: Marmot-based encrypted location sharing; Dart/Flutter; published to Zapstore as developer-signed app
 
+  - name: Coop Mobile
+    description: NIP-17 encrypted direct messaging client for mobile platforms
+    platforms: [ android, ios ]
+    repo: https://git.reya.su/reya/coop-mobile
+    maintainer: reya
+    status: alpha
+    priority: low
+    notes: Mobile companion to the coop NIP-17 client; hosted on Gitea (git.reya.su)
+
 media_clients:
   - name: Zap.stream
     description: Live streaming with Lightning zaps
@@ -3281,6 +3290,22 @@ devtools:
     status: alpha
     priority: low
     notes: Track but verify scope before covering in newsletter
+
+  - name: NostrAppShell
+    description: Application shell scaffold for building Nostr apps (early-stage; readme and NIP-07 docs landed 2026-06-29)
+    repo: https://git.nostrdev.com/stuff/NostrAppShell
+    status: alpha
+    priority: low
+    notes: Hosted on git.nostrdev.com (Gitea); track for scope as the project develops
+
+  - name: NIPs by Pollerama (better-nips)
+    description: Trust-weighted community NIPs browser for NostrHub kind-30817 events, ranking by NIP-32 kind-1985 approvals across the user's web of trust
+    repo: https://github.com/abh3po/better-nips
+    website: https://nips.pollerama.fun
+    maintainer: abh3po
+    status: alpha
+    priority: medium
+    notes: Alternative surface to nostrhub.io; ships approvals as NIP-32 labels (L=nostrhub, l=approve); Formstr signer stack (@formstr/signer, @formstr/local-relay) with NIP-07/46/49/55 support; created 2026-06-29
 
 
 signers:
@@ -5640,6 +5665,42 @@ other:
     priority: low
     notes: Unique fitness use case on Nostr
 
+  - name: Nunlock
+    description: Minimalist Android app that tracks daily phone unlocks and anchors the data to Nostr
+    platforms: [ android ]
+    repo: https://git.vanderwarker.family/wellbeing/nunlock-android
+    maintainer: stephen (npub1lqulkec5tx98yv7snk759tuzejtcr5865468fuvyrtuskhynpyush5qaf3)
+    status: active
+    priority: low
+    notes: Vanderwarker wellbeing suite; NIP-34 announced (d=Nunlock-Android-App)
+
+  - name: Saint Stream
+    description: Android app that tracks current media playback and publishes it to Nostr as a User Status
+    platforms: [ android ]
+    repo: https://git.vanderwarker.family/wellbeing/saintstream-android
+    maintainer: stephen
+    status: active
+    priority: low
+    notes: Vanderwarker wellbeing suite
+
+  - name: Sister Charge
+    description: Android app that monitors battery level, voltage, and temperature every 15 minutes and publishes to Nostr
+    platforms: [ android ]
+    repo: https://git.vanderwarker.family/wellbeing/sistercharge-android
+    maintainer: stephen
+    status: active
+    priority: low
+    notes: Vanderwarker wellbeing suite
+
+  - name: Cellibacy
+    description: Android wellbeing app from the Vanderwarker suite (description pending upstream)
+    platforms: [ android ]
+    repo: https://git.vanderwarker.family/wellbeing/cellibacy-android
+    maintainer: stephen
+    status: active
+    priority: low
+    notes: Vanderwarker wellbeing suite
+
   - name: featurestr-bountiestr
     description: Feature request and bounty system on Nostr
     platforms: [ web ]
@@ -5921,6 +5982,34 @@ other:
     status: active
     priority: low
 
+  - name: myco
+    description: Peer-to-peer nsite sharing app over a FIPS mesh (UDP/TCP/Tor/Bluetooth); install apps from people around you, fully offline-capable
+    platforms: [ android ]
+    repo: https://github.com/Origami74/myco
+    maintainer: Origami74
+    status: alpha
+    priority: medium
+    notes: Rust + FIPS transport; offline-first distribution of nsite content
+
+  - name: Nostr Codex Phone
+    description: Android control surface for a local Codex coding-assistant worker over encrypted Nostr DMs; multi-repo sessions, voice input, Blossom media uploads, optional spoken replies
+    platforms: [ android ]
+    repo: https://github.com/tidley/nostr-codex-phone
+    maintainer: tidley
+    status: alpha
+    priority: medium
+    notes: Sibling to CodeDeck; agent control-plane over Nostr transport
+
+  - name: ntrack
+    description: Privacy-preserving location-sharing Android app
+    platforms: [ android ]
+    repo: https://github.com/f321x/ntrack
+    website: https://zapstore.dev/apps/naddr1qqxkjmewde68yctrdvhxzursqyv8wumn8ghj7un9d3shjtn6v9c8xar0wfjjuer9wcpzpkdp38e074qalhe7t6lh76f3dey759e8ctnjhkw3zvv40c96x3sgqvzqqqr7pvmps38m
+    maintainer: f321x
+    status: alpha
+    priority: low
+    notes: Rust + Slint UI; published to Zapstore as developer-signed app
+
 protocols:
   - name: NIPs
     description: Nostr Implementation Possibilities - the protocol specification
@@ -5953,6 +6042,13 @@ protocols:
     priority: high
     notes: MLS (Messaging Layer Security) for Nostr, enables secure group messaging
     repo: https://github.com/marmot-protocol/marmot
+
+  - name: Gamma Market Spec
+    description: Project-owned extension to NIP-99 consolidating commerce-on-Nostr surface (orders, checkout, escrow, disputes) as a spec composing on top of NIP-99 marketplace listings
+    repo: https://github.com/GammaMarkets/market-spec
+    status: active
+    priority: medium
+    notes: Commerce protocol extension tracked alongside Marmot and Blossom; monitor for open PRs each newsletter
 
   - name: MDK PWA Reference
     description: Progressive web app reference implementation for Marmot Development Kit

--- a/scripts/fetch_nip34_repos.sh
+++ b/scripts/fetch_nip34_repos.sh
@@ -36,9 +36,14 @@ DEFAULT_DAYS=7
 OUTPUT_DIR="$PROJECT_ROOT/data/nip34_repos"
 TRACKED_FILE="$PROJECT_ROOT/data/nip34_tracked.yml"
 
-# NIP-34 specific relays (relay.ngit.dev is the primary NIP-34 relay)
+# NIP-34 specific relays
+# - relay.ngit.dev: primary NIP-34 / ngit ecosystem relay
+# - git.nostrhub.io: NostrHub's GRASP server (kind 30617 repo announcements,
+#   kind 1621 issues, NIP-related discussions and shakespeare/grasp-launched projects)
+# - damus.io, nos.lol, nostr.band: broad-coverage relays for gossiped NIP-34 events
 NIP34_RELAYS=(
     "wss://relay.ngit.dev"
+    "wss://git.nostrhub.io"
     "wss://relay.damus.io"
     "wss://nos.lol"
     "wss://relay.nostr.band"

--- a/scripts/fetch_project_updates.py
+++ b/scripts/fetch_project_updates.py
@@ -48,6 +48,15 @@ GITHUB_API_BASE = "https://api.github.com"
 DEFAULT_CONCURRENCY = 25
 RATE_LIMIT_BUFFER = 100  # slow down when fewer than this many requests remain
 
+# Known Gitea/Forgejo hosts. Each entry maps a hostname to its API base URL.
+# Extend this when adding new self-hosted forges to projects.yml.
+GITEA_HOSTS = {
+    "git.vanderwarker.family": "https://git.vanderwarker.family/api/v1",
+    "git.reya.su": "https://git.reya.su/api/v1",
+    "git.nostrdev.com": "https://git.nostrdev.com/api/v1",
+}
+GITEA_CONCURRENCY = 8  # per-host cap to avoid hammering small self-hosted instances
+
 BOT_PATTERNS = [
     r".*\[bot\]$",
     r"^dependabot$",
@@ -75,6 +84,24 @@ def parse_github_repo(repo_url: str) -> Optional[tuple[str, str]]:
             if repo and repo not in ["", "."]:
                 return (owner, repo.rstrip("/"))
     return None
+
+
+def parse_gitea_repo(repo_url: str) -> Optional[tuple[str, str, str]]:
+    """Parse a Gitea/Forgejo repo URL into (host, owner, repo).
+
+    Only matches hosts in GITEA_HOSTS. Returns None for unknown hosts.
+    """
+    if not repo_url:
+        return None
+    match = re.match(r"https?://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?/?$", repo_url)
+    if not match:
+        return None
+    host, owner, repo = match.groups()
+    if host not in GITEA_HOSTS:
+        return None
+    if not repo or repo in ("", "."):
+        return None
+    return (host, owner, repo.rstrip("/"))
 
 
 def is_bot_user(username: str) -> bool:
@@ -324,12 +351,129 @@ class GitHubClient:
 
 
 # =============================================================================
+# Gitea/Forgejo client (mirrors GitHubClient public interface)
+# =============================================================================
+
+
+class GiteaClient:
+    """Async Gitea/Forgejo API client.
+
+    Same public surface as GitHubClient (get, get_json, get_paginated,
+    _parse_next_link, request_count, verbose) so the fetch_* functions can
+    treat it interchangeably. No auth, no rate-limit tracking; small
+    self-hosted instances are throttled via a lower per-host concurrency cap.
+
+    Pagination: Gitea sends ?page=N&limit=N parameters and does NOT emit
+    Link headers, so _parse_next_link inspects the result count vs requested
+    limit and increments a per-URL page counter.
+    """
+
+    def __init__(
+        self, host: str, concurrency: int = GITEA_CONCURRENCY, verbose: bool = False
+    ):
+        if host not in GITEA_HOSTS:
+            raise ValueError(f"Unknown Gitea host: {host}")
+        self.host = host
+        self.base_url = GITEA_HOSTS[host]
+        self.verbose = verbose
+        self.semaphore = asyncio.Semaphore(concurrency)
+        self.request_count = 0
+        self.client: Optional[httpx.AsyncClient] = None
+
+    async def __aenter__(self):
+        self.client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "nostr-compass-fetcher",
+            },
+            timeout=httpx.Timeout(30.0, connect=10.0),
+            follow_redirects=True,
+            limits=httpx.Limits(
+                max_connections=concurrency_cap_for_host(),
+                max_keepalive_connections=GITEA_CONCURRENCY,
+            ),
+        )
+        return self
+
+    async def __aexit__(self, *args):
+        if self.client:
+            await self.client.aclose()
+
+    async def get(self, endpoint: str) -> Optional[httpx.Response]:
+        async with self.semaphore:
+            self.request_count += 1
+            try:
+                resp = await self.client.get(endpoint)
+            except (
+                httpx.TimeoutException,
+                httpx.ConnectError,
+                httpx.RemoteProtocolError,
+            ) as e:
+                if self.verbose:
+                    print(
+                        f"  Warning: Gitea request failed for {self.host}{endpoint}: {e}",
+                        file=sys.stderr,
+                    )
+                return None
+
+            if resp.status_code == 404:
+                return resp
+            if resp.status_code >= 400:
+                if self.verbose:
+                    print(
+                        f"  Warning: Gitea HTTP {resp.status_code} for {self.host}{endpoint}",
+                        file=sys.stderr,
+                    )
+                return None
+            return resp
+
+    async def get_json(self, endpoint: str) -> Optional[list | dict]:
+        resp = await self.get(endpoint)
+        if resp is None:
+            return None
+        if resp.status_code == 404:
+            return []
+        try:
+            return resp.json()
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_next_link(_link_header: str) -> Optional[str]:
+        """Gitea does not emit Link headers; pagination is handled inline
+        in the fetch functions via _next_page_url. This always returns None
+        so the fetch_* loops fall through to their own next-page logic when
+        the client is a GiteaClient."""
+        return None
+
+    @staticmethod
+    def next_page_url(current_url: str, page_size: int) -> str:
+        """Bump the &page=N counter on a Gitea endpoint URL."""
+        match = re.search(r"[?&]page=(\d+)", current_url)
+        if match:
+            current_page = int(match.group(1))
+            return re.sub(r"([?&])page=\d+", lambda m: f"{m.group(1)}page={current_page + 1}", current_url)
+        sep = "&" if "?" in current_url else "?"
+        return f"{current_url}{sep}page=2"
+
+
+def concurrency_cap_for_host() -> int:
+    """httpx connection pool cap for a single Gitea host."""
+    return max(GITEA_CONCURRENCY * 2, 16)
+
+
+def is_gitea_client(client) -> bool:
+    return isinstance(client, GiteaClient)
+
+
+# =============================================================================
 # Data Fetching Functions (async, same output format as original)
 # =============================================================================
 
 
 async def fetch_releases(
-    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+    client, owner: str, repo: str, since: Optional[str] = None
 ) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
 
@@ -343,7 +487,8 @@ async def fetch_releases(
                 return True  # stop paginating
         return False
 
-    endpoint = f"/repos/{owner}/{repo}/releases?per_page=100"
+    page_size = 50 if is_gitea_client(client) else 100
+    endpoint = f"/repos/{owner}/{repo}/releases?limit={page_size}&page=1" if is_gitea_client(client) else f"/repos/{owner}/{repo}/releases?per_page={page_size}"
     results = []
     url = endpoint
 
@@ -362,6 +507,7 @@ async def fetch_releases(
         if not data or not isinstance(data, list):
             break
 
+        page_count = len(data)
         stop = False
         for r in data:
             if r.get("draft"):
@@ -381,22 +527,31 @@ async def fetch_releases(
                     "url": r["html_url"],
                     "body": truncate_body(r.get("body") or ""),
                     "prerelease": r.get("prerelease", False),
-                    "author": r.get("author", {}).get("login", "unknown"),
+                    "author": (r.get("author") or {}).get("login", "unknown"),
                 }
             )
 
         if stop:
             break
-        url = client._parse_next_link(resp.headers.get("link", ""))
+        if is_gitea_client(client):
+            if page_count < page_size:
+                break
+            url = GiteaClient.next_page_url(url, page_size)
+        else:
+            url = client._parse_next_link(resp.headers.get("link", ""))
 
     return results
 
 
 async def fetch_merged_prs(
-    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+    client, owner: str, repo: str, since: Optional[str] = None
 ) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
-    endpoint = f"/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+    page_size = 50 if is_gitea_client(client) else 100
+    if is_gitea_client(client):
+        endpoint = f"/repos/{owner}/{repo}/pulls?state=closed&sort=newest&limit={page_size}&page=1"
+    else:
+        endpoint = f"/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page={page_size}"
     results = []
     url = endpoint
 
@@ -415,11 +570,12 @@ async def fetch_merged_prs(
         if not data or not isinstance(data, list):
             break
 
+        page_count = len(data)
         past_range = False
         for pr in data:
             if not pr.get("merged_at"):
                 continue
-            author = pr.get("user", {}).get("login", "")
+            author = (pr.get("user") or {}).get("login", "")
             if is_bot_user(author):
                 continue
             merged_at = pr["merged_at"]
@@ -450,16 +606,25 @@ async def fetch_merged_prs(
 
         if past_range:
             break
-        url = client._parse_next_link(resp.headers.get("link", ""))
+        if is_gitea_client(client):
+            if page_count < page_size:
+                break
+            url = GiteaClient.next_page_url(url, page_size)
+        else:
+            url = client._parse_next_link(resp.headers.get("link", ""))
 
     return results
 
 
 async def fetch_open_prs(
-    client: GitHubClient, owner: str, repo: str, since: Optional[str] = None
+    client, owner: str, repo: str, since: Optional[str] = None
 ) -> list[dict]:
     since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
-    endpoint = f"/repos/{owner}/{repo}/pulls?state=open&sort=created&direction=desc&per_page=100"
+    page_size = 50 if is_gitea_client(client) else 100
+    if is_gitea_client(client):
+        endpoint = f"/repos/{owner}/{repo}/pulls?state=open&sort=newest&limit={page_size}&page=1"
+    else:
+        endpoint = f"/repos/{owner}/{repo}/pulls?state=open&sort=created&direction=desc&per_page={page_size}"
     results = []
     url = endpoint
 
@@ -478,9 +643,10 @@ async def fetch_open_prs(
         if not data or not isinstance(data, list):
             break
 
+        page_count = len(data)
         past_range = False
         for pr in data:
-            author = pr.get("user", {}).get("login", "")
+            author = (pr.get("user") or {}).get("login", "")
             if is_bot_user(author):
                 continue
             created_at = pr.get("created_at")
@@ -506,13 +672,18 @@ async def fetch_open_prs(
 
         if past_range:
             break
-        url = client._parse_next_link(resp.headers.get("link", ""))
+        if is_gitea_client(client):
+            if page_count < page_size:
+                break
+            url = GiteaClient.next_page_url(url, page_size)
+        else:
+            url = client._parse_next_link(resp.headers.get("link", ""))
 
     return results
 
 
 async def fetch_commits(
-    client: GitHubClient,
+    client,
     owner: str,
     repo: str,
     since: Optional[str] = None,
@@ -526,12 +697,25 @@ async def fetch_commits(
             else "main"
         )
 
-    params = f"sha={branch}&per_page=100"
-    if since:
-        params += f"&since={since}"
+    page_size = 50 if is_gitea_client(client) else 100
+    if is_gitea_client(client):
+        # Gitea/Forgejo rejects ISO8601 offset notation (+00:00); normalize to Z
+        gitea_since = (
+            re.sub(r"\+00:00$", "Z", since) if since else None
+        )
+        params = f"sha={branch}&limit={page_size}&page=1"
+        if gitea_since:
+            params += f"&since={gitea_since}"
+    else:
+        params = f"sha={branch}&per_page={page_size}"
+        if since:
+            params += f"&since={since}"
     endpoint = f"/repos/{owner}/{repo}/commits?{params}"
     results = []
     url = endpoint
+    gitea_since_dt = (
+        datetime.fromisoformat(since.replace("Z", "+00:00")) if since and is_gitea_client(client) else None
+    )
 
     while url:
         resp = await client.get(url)
@@ -548,9 +732,21 @@ async def fetch_commits(
         if not data or not isinstance(data, list):
             break
 
+        page_count = len(data)
+        past_range = False
         for c in data:
             commit_data = c.get("commit", {})
-            author_data = commit_data.get("author", {})
+            author_data = commit_data.get("author", {}) or {}
+            date_str = author_data.get("date")
+            # Gitea ignores ?since= on /commits, so we filter client-side
+            if gitea_since_dt and date_str:
+                try:
+                    commit_dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                    if commit_dt < gitea_since_dt:
+                        past_range = True
+                        break
+                except ValueError:
+                    pass
             message = commit_data.get("message", "")
             message_summary = message.split("\n")[0] if message else ""
             results.append(
@@ -558,12 +754,19 @@ async def fetch_commits(
                     "sha": c.get("sha", "")[:12],
                     "message": message_summary,
                     "author": author_data.get("name", "unknown"),
-                    "date": author_data.get("date"),
+                    "date": date_str,
                     "url": c.get("html_url", ""),
                 }
             )
 
-        url = client._parse_next_link(resp.headers.get("link", ""))
+        if past_range:
+            break
+        if is_gitea_client(client):
+            if page_count < page_size:
+                break
+            url = GiteaClient.next_page_url(url, page_size)
+        else:
+            url = client._parse_next_link(resp.headers.get("link", ""))
 
     return results
 
@@ -574,9 +777,9 @@ async def fetch_commits(
 
 
 async def fetch_repo(
-    client: GitHubClient, project: dict, since_ts: str, compact: bool
+    client, project: dict, since_ts: str, compact: bool
 ) -> Optional[dict]:
-    """Fetch all data for a single repo concurrently."""
+    """Fetch all data for a single repo concurrently. Accepts GitHubClient or GiteaClient."""
     owner, repo = project["owner"], project["repo"]
 
     # Launch releases and merged_prs always; open_prs and commits only if not compact
@@ -616,6 +819,7 @@ async def fetch_repo(
             "priority": project["priority"],
             "website": project["website"],
             "maintainer": project["maintainer"],
+            "host": project.get("host", "github.com"),
             "releases": releases,
             "merged_prs": merged_prs,
             "open_prs": open_prs,
@@ -649,25 +853,13 @@ def load_projects(
                 continue
 
             repo_url = item.get("repo")
-            parsed = parse_github_repo(repo_url)
             added_urls = set()
 
-            if parsed:
-                owner, repo = parsed
-                projects.append(
-                    {
-                        "owner": owner,
-                        "repo": repo,
-                        "repo_url": repo_url,
-                        "name": project_name or repo,
-                        "description": item.get("description", ""),
-                        "category": category,
-                        "priority": item.get("priority", "low"),
-                        "website": item.get("website", ""),
-                        "maintainer": item.get("maintainer", ""),
-                        "status": item.get("status", ""),
-                    }
-                )
+            entry = _project_entry_from_url(
+                repo_url, project_name, item, category
+            )
+            if entry:
+                projects.append(entry)
                 added_urls.add(repo_url)
 
             repos_dict = item.get("repos", {})
@@ -675,28 +867,59 @@ def load_projects(
                 for repo_key, sub_repo_url in repos_dict.items():
                     if sub_repo_url in added_urls:
                         continue
-                    sub_parsed = parse_github_repo(sub_repo_url)
-                    if sub_parsed:
-                        sub_owner, sub_repo = sub_parsed
-                        projects.append(
-                            {
-                                "owner": sub_owner,
-                                "repo": sub_repo,
-                                "repo_url": sub_repo_url,
-                                "name": f"{project_name} ({repo_key})"
-                                if project_name
-                                else sub_repo,
-                                "description": item.get("description", ""),
-                                "category": category,
-                                "priority": item.get("priority", "low"),
-                                "website": item.get("website", ""),
-                                "maintainer": item.get("maintainer", ""),
-                                "status": item.get("status", ""),
-                            }
-                        )
+                    sub_name = (
+                        f"{project_name} ({repo_key})" if project_name else None
+                    )
+                    sub_entry = _project_entry_from_url(
+                        sub_repo_url, sub_name, item, category
+                    )
+                    if sub_entry:
+                        projects.append(sub_entry)
                         added_urls.add(sub_repo_url)
 
     return projects
+
+
+def _project_entry_from_url(
+    repo_url: str, project_name: Optional[str], item: dict, category: str
+) -> Optional[dict]:
+    """Build a project entry from a repo URL, routing to GitHub or Gitea parser."""
+    if not repo_url:
+        return None
+
+    base = {
+        "description": item.get("description", ""),
+        "category": category,
+        "priority": item.get("priority", "low"),
+        "website": item.get("website", ""),
+        "maintainer": item.get("maintainer", ""),
+        "status": item.get("status", ""),
+        "repo_url": repo_url,
+    }
+
+    gh = parse_github_repo(repo_url)
+    if gh:
+        owner, repo = gh
+        return {
+            **base,
+            "host": "github.com",
+            "owner": owner,
+            "repo": repo,
+            "name": project_name or repo,
+        }
+
+    gt = parse_gitea_repo(repo_url)
+    if gt:
+        host, owner, repo = gt
+        return {
+            **base,
+            "host": host,
+            "owner": owner,
+            "repo": repo,
+            "name": project_name or repo,
+        }
+
+    return None
 
 
 # =============================================================================
@@ -799,9 +1022,15 @@ def print_summary(data, since_days):
 # =============================================================================
 
 
-async def run(args, projects: list[dict]):
-    token = get_github_token()
+def _repo_key(project: dict) -> str:
+    """Stable identifier including host so github vs gitea owner/repo don't collide."""
+    host = project.get("host", "github.com")
+    if host == "github.com":
+        return f"{project['owner']}/{project['repo']}"
+    return f"{host}/{project['owner']}/{project['repo']}"
 
+
+async def run(args, projects: list[dict]):
     now = datetime.now(timezone.utc)
     since_dt = now - timedelta(days=args.since_days)
     since_ts = since_dt.isoformat()
@@ -821,13 +1050,21 @@ async def run(args, projects: list[dict]):
                 )
 
     # Filter out already-fetched repos
-    remaining = [
-        p for p in projects if f"{p['owner']}/{p['repo']}" not in already_fetched
-    ]
+    remaining = [p for p in projects if _repo_key(p) not in already_fetched]
 
+    # Split by host so each gets the right client
+    github_projects = [p for p in remaining if p.get("host", "github.com") == "github.com"]
+    gitea_by_host: dict[str, list[dict]] = {}
+    for p in remaining:
+        h = p.get("host", "github.com")
+        if h != "github.com":
+            gitea_by_host.setdefault(h, []).append(p)
+
+    total = len(remaining)
     print(
         f"\nFetching updates since {since_dt.strftime('%Y-%m-%d')} "
-        f"({len(remaining)} repos, concurrency={args.concurrency})...\n"
+        f"({total} repos: {len(github_projects)} GitHub, "
+        f"{sum(len(v) for v in gitea_by_host.values())} Gitea across {len(gitea_by_host)} host(s))...\n"
     )
     sys.stdout.flush()
 
@@ -854,7 +1091,6 @@ async def run(args, projects: list[dict]):
     def handle_interrupt(signum, frame):
         nonlocal interrupted
         if interrupted:
-            # Second interrupt - force exit
             sys.exit(130)
         interrupted = True
         print(
@@ -865,61 +1101,77 @@ async def run(args, projects: list[dict]):
     signal.signal(signal.SIGINT, handle_interrupt)
 
     start_time = time.monotonic()
-    completed = 0
-    total = len(remaining)
+    completed = [0]  # mutable for nested closure
+    total_requests = [0]
 
-    async with GitHubClient(
-        token, concurrency=args.concurrency, verbose=args.verbose
-    ) as client:
-        # Process in batches for progress reporting and periodic saves
-        batch_size = (
-            args.concurrency * 2
-        )  # 2x concurrency for good pipeline utilization
-        for batch_start in range(0, total, batch_size):
-            if interrupted:
-                break
-
-            batch = remaining[batch_start : batch_start + batch_size]
-            tasks = [fetch_repo(client, p, since_ts, args.compact) for p in batch]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-            for project, result in zip(batch, results):
-                repo_key = f"{project['owner']}/{project['repo']}"
-                completed += 1
-
-                if isinstance(result, Exception):
-                    if args.verbose:
-                        print(
-                            f"  [{completed}/{total}] {project['name']} ({repo_key}): ERROR - {result}",
-                            file=sys.stderr,
-                        )
-                    else:
-                        print(f"  [{completed}/{total}] {project['name']}: error")
-                elif result is not None:
-                    all_projects[repo_key] = result
-                    r = len(result["releases"])
-                    m = len(result["merged_prs"])
-                    o = len(result["open_prs"])
-                    c = len(result["commits"])
+    async def run_batch(client, batch: list[dict]):
+        nonlocal interrupted
+        if interrupted:
+            return
+        tasks = [fetch_repo(client, p, since_ts, args.compact) for p in batch]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for project, result in zip(batch, results):
+            repo_key = _repo_key(project)
+            completed[0] += 1
+            if isinstance(result, Exception):
+                if args.verbose:
                     print(
-                        f"  [{completed}/{total}] {project['name']}: {r}r {m}m {o}o {c}c"
+                        f"  [{completed[0]}/{total}] {project['name']} ({repo_key}): ERROR - {result}",
+                        file=sys.stderr,
                     )
                 else:
-                    if args.verbose:
-                        print(f"  [{completed}/{total}] {project['name']}: no activity")
+                    print(f"  [{completed[0]}/{total}] {project['name']}: error")
+            elif result is not None:
+                all_projects[repo_key] = result
+                r = len(result["releases"])
+                m = len(result["merged_prs"])
+                o = len(result["open_prs"])
+                c = len(result["commits"])
+                print(
+                    f"  [{completed[0]}/{total}] {project['name']}: {r}r {m}m {o}o {c}c"
+                )
+            else:
+                if args.verbose:
+                    print(f"  [{completed[0]}/{total}] {project['name']}: no activity")
+        save_progress()
 
-            # Save progress after each batch
-            save_progress()
+    # GitHub batch
+    if github_projects:
+        token = get_github_token()
+        async with GitHubClient(
+            token, concurrency=args.concurrency, verbose=args.verbose
+        ) as client:
+            batch_size = args.concurrency * 2
+            for batch_start in range(0, len(github_projects), batch_size):
+                if interrupted:
+                    break
+                await run_batch(
+                    client, github_projects[batch_start : batch_start + batch_size]
+                )
+            total_requests[0] += client.request_count
+
+    # Gitea batches, one host at a time
+    for host, host_projects in gitea_by_host.items():
+        if interrupted:
+            break
+        async with GiteaClient(host, verbose=args.verbose) as client:
+            batch_size = GITEA_CONCURRENCY * 2
+            for batch_start in range(0, len(host_projects), batch_size):
+                if interrupted:
+                    break
+                await run_batch(
+                    client, host_projects[batch_start : batch_start + batch_size]
+                )
+            total_requests[0] += client.request_count
 
     elapsed = time.monotonic() - start_time
 
-    # Final save
     save_progress()
 
     print(f"\nOutput saved to {output_path}")
     print(
-        f"Completed in {elapsed:.1f}s ({client.request_count} API requests, "
-        f"{client.request_count / max(elapsed, 0.1):.1f} req/s)"
+        f"Completed in {elapsed:.1f}s ({total_requests[0]} API requests, "
+        f"{total_requests[0] / max(elapsed, 0.1):.1f} req/s)"
     )
 
     if interrupted:
@@ -985,11 +1237,14 @@ def main():
 
     print(f"Loading projects from {args.projects_file}...")
     projects = load_projects(args.projects_file, filter_projects, filter_categories)
-    print(f"Found {len(projects)} projects with GitHub repos")
+    gh_count = sum(1 for p in projects if p.get("host", "github.com") == "github.com")
+    gt_count = len(projects) - gh_count
+    print(f"Found {len(projects)} repos ({gh_count} GitHub, {gt_count} Gitea)")
 
     if args.dry_run:
         for p in projects:
-            print(f"  - {p['name']} ({p['owner']}/{p['repo']}) [{p['category']}]")
+            host = p.get("host", "github.com")
+            print(f"  - {p['name']} ({host}/{p['owner']}/{p['repo']}) [{p['category']}]")
         return
 
     asyncio.run(run(args, projects))


### PR DESCRIPTION
## Summary

Adds Newsletter #29 plus a Gitea/Forgejo extension for the GitHub fetcher.

**Lead stories:** FIPS v0.4.0, Whitenoise Linux, CustID v0.1.10-beta, myco, Coop Mobile, Amethyst NIP-89 + napplet-host work, Buzz v0.3.38.

**Tagged releases:** mostro-core v0.14.0, Nostur 1.29.1, ngit v2.6.1, Haven v0.1.5–v0.1.9, BitBlik v0.8.3, Kubo v2026.06.23, lawallet-nwc v1.0.3–v1.0.10, Napplets follow-up cut, mesh-llm v0.72.x.

**Unreleased:** diVine 108 PRs, Zap Cooking, Conduit, Pollerama, Primal/Nutshell/nostream/Citrine, getwired+get-tao NIP-13 fixes, nostui mention timeline, Wisp follow-up.

**NIP updates:** 5 merges (NIP-44 65,535-byte limit removal, NIP-86 signevent + Relay Roles event, NIP-34 GRASP-06 fork semantics, NIP-46 client metadata now upstream), 6 open proposals (NIP-17 deterministic wrap keys, NIP-59 seal-event policy, NIP-29 group state, NIP-91 AND operator), 4 closed pats2sats commerce proposals.

**Deep dives:** NIP-86 (Relay Management API) and NIP-89 (Recommended Application Handlers).

## Infrastructure changes

`scripts/fetch_project_updates.py` gains a `GiteaClient` mirroring the `GitHubClient` public interface. Auto-routes git.vanderwarker.family, git.reya.su, and git.nostrdev.com to their `/api/v1/repos/{owner}/{repo}` endpoints. Handles page-number pagination (Gitea does not emit Link headers) and normalizes `+00:00` ISO offsets to `Z` on the `since=` parameter (Gitea rejects offset notation there). Picks up 8 self-hosted repos that the GitHub-only fetcher previously dropped.

## Validation

- 0 em-dashes, 0 banned words, 0 superlatives, 0 hedge phrases
- 124 external URLs all return 200
- All 3 NIP event JSON examples have full 7 NIP-01 fields
- 5797 words, 356 lines