### PR TITLE
Emit full post content in RSS feeds

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,68 @@
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+	{{- if reflect.IsMap . }}
+		{{- with .email }}
+			{{- $authorEmail = . }}
+		{{- end }}
+	{{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+	{{- if reflect.IsMap . }}
+		{{- with .name }}
+			{{- $authorName = . }}
+		{{- end }}
+	{{- else }}
+		{{- $authorName = . }}
+	{{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+	{{- $pages = $pctx.RegularPages }}
+{{- else }}
+	{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+	{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	<channel>
+		<title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+		<link>{{ .Permalink }}</link>
+		<description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+		<generator>Hugo</generator>
+		<language>{{ site.Language.Lang }}</language>
+		{{ with $authorEmail }}
+			<managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
+		{{ end }}
+		{{ with $authorEmail }}
+			<webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>
+		{{ end }}
+		{{ with .Site.Copyright }}
+			<copyright>{{ . }}</copyright>
+		{{ end }}
+		{{ if not .Date.IsZero }}
+			<lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+		{{ end }}
+		{{- with .OutputFormats.Get "RSS" }}
+			{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+		{{- end }}
+		{{- range $pages }}
+			<item>
+				<title>{{ .Title }}</title>
+				<link>{{ .Permalink }}</link>
+				<pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+				{{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+				<guid>{{ .Permalink }}</guid>
+				<description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+				<content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+			</item>
+		{{- end }}
+	</channel>
+</rss>


### PR DESCRIPTION
Hugo's embedded RSS template emits only `<description>` with `.Summary`, truncating feed items to the first paragraph. This overrides the embedded template to also emit a `<content:encoded>` element per item with the full rendered HTML body of the newsletter or topic page.

## Change

Single new file: `layouts/_default/rss.xml` (68 lines).

- Copies Hugo's embedded RSS template.
- Adds `xmlns:content="http://purl.org/rss/1.0/modules/content/"` to the `<rss>` root.
- Emits `<content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>` on each `<item>`.
- Keeps existing `<description>` unchanged for readers that only render that field.

## Verification

Tested against both Hugo v0.123.7 (local) and Hugo v0.140.0 (CI version).

- All 10 language feeds well-formed per Python XML parser (`en`, `de`, `es`, `fr`, `it`, `ja`, `ko`, `nl`, `pt`, `zh`).
- Item count matches `<content:encoded>` count in every feed (138 EN, 121 per translation).
- Newsletter #30's `<content:encoded>` is ~80KB — from opening welcome line through closing content, all H2 sections intact.
- Feed size grows from ~35KB to ~1.5-2.2MB per language (expected for full-content feeds).

## Why not an alternative

- No Hugo config flag exists to make the embedded template emit full content.
- `<!--more-->` divider would require touching every newsletter and topic across all 10 languages, and would break on-site newsletter list cards.
- `summaryLength` bump would change every `.Summary` call site-wide.

Custom template override is the mechanism Hugo itself documents for this.