### PR TITLE
Add candidate-only Nostr app discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ data/nostr_nip_discussions/*.json
 data/nostr_recap/*.json
 data/shakespeare_apps/*.json
 data/zapstore_releases/
+data/app_discovery/
 data/april_history/
 data/non_github_sources_*.json
 data/coverage_history.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,24 @@ In scope:
 
 The NIP-34 tracker (`data/nip34_tracked.yml`) MUST only track repositories whose subject matter is itself Nostr-relevant. NIP-34 repos for Bitcoin-only tools are visible in the discovery output but never promoted into `nip34_tracked.yml` and never written into newsletter prose. If a NIP-34 repo's project description names a Bitcoin-only protocol (CoinJoin, PayJoin, BIP-352 silent payments outside a Nostr context, etc.) and the project does not also implement a Nostr surface, the repo fails this gate.
 
+### New-application discovery is candidate-only (CRITICAL)
+
+`scripts/fetch_app_discovery.py` adds three candidate streams beyond the tracked-repository, release, NIP-34, Shakespeare, and heartbeat fetchers:
+
+- paginated GitHub searches for active `nostr`-topic repositories and recently created repositories with `nostr` in the name or description;
+- recent NIP-89 kind 31990 application-handler descriptors recovered from several public relays; and
+- recent Zapstore kind 32267 app listings, including developer-signed listings that do not yet have a kind 30063 release in the issue window.
+
+The script writes `data/app_discovery/discovery_YYYY-MM-DD.json`, excludes canonical repo/website/name matches already in `data/projects.yml`, and persists `seen_repos.json` so the weekly active-repository query does not repeat its baseline forever. Every GitHub result requires explicit Nostr plus application/tooling metadata; libraries and SDKs do not qualify on those labels alone. NIP-89 records require a stable `d` identifier, supported non-DVM kinds, and usable identity/location evidence. Zapstore listings require a stable app ID, canonical location, and an explicit Nostr protocol surface. Relay events are signature-verified, relay and source provenance is retained, unsafe URLs are rejected, GitHub truncation/incomplete-result warnings and partial source failures are reported, and independent records merge only when their canonical repository or website matches.
+
+Relay multiplicity is transport-availability evidence only: `relay_status: multi-relay` does not confirm reputation, ownership, or product legitimacy, and every candidate's `evidence_status` remains `unconfirmed` pending Triage. NIP-89 `latest`/`next` kind 35128 nsite references are retained as optional corroboration pointers, not fetched as a broad discovery source. Kind 31989 recommendations are intentionally excluded because Compass has no explicit trusted-author/follow-graph set; a global recommendation sweep would be sybil-prone and could never be a standalone approval signal.
+
+Every output row remains `candidate-only; never auto-add to projects.yml`. Forge topics and descriptions are self-asserted. A signed kind 31990 or 32267 event proves only that a key published the descriptor. Triage must open the product and repository, verify concrete Nostr relay behavior, establish canonical ownership, apply the per-item Nostr-surface gate, and record a GREEN/MAYBE/SKIP reason. Cross-source agreement raises confidence but does not replace verification.
+
+### Pre-intake link-queue enrichment (CRITICAL)
+
+Once the current issue is fully published, preserve each user-submitted future link verbatim in `data/newsletter_workspace/link_queue.md`, then immediately add a dated `Prep (verified YYYY-MM-DD):` block. Resolve the canonical repository from project-owned links or redirects, check whether it is an existing project/rebrand/component, and resolve a dedicated project npub or personal maintainer npub only from primary evidence plus a relay-backed kind 0 profile. Record exact evidence URLs, identity type, and obvious scope/continuity flags. Never guess a key, start the newsletter pipeline, write prose, or auto-add the project at queue time. Tuesday Intake revalidates stale/conflicting fields instead of repeating completed prep.
+
 ### Per-PR Nostr-surface gate (CRITICAL — applies to EVERY project)
 
 **Compass is a Nostr newsletter. Every PR, release item, or feature mentioned MUST touch a Nostr surface.** A project being broadly Nostr-aware (e.g. Zeus has NWC, Alby Extension has NIP-07) does NOT make every change in that project newsletter material. Each item is gated individually.

--- a/scripts/fetch_all.sh
+++ b/scripts/fetch_all.sh
@@ -14,9 +14,10 @@
 #   4. fetch_shakespeare_apps.sh      (Soapbox MiniApps submissions)
 #   5. fetch_nip34_repos.sh           (NIP-34 git repos from relays)
 #   6. fetch_zapstore_releases.sh     (Zapstore developer-signed app releases)
-#   7. fetch_heartbeats.sh            (OpenSats + Sovereign Engineering grantee activity)
-#   8. fetch_monthly_history.py       (history candidates; final weekly issue only)
-#   9. fetch_spec_updates.py          (NIP, BUD, NAP, Marmot, Gamma, Concord, NWC specs)
+#   7. fetch_app_discovery.py          (candidate-only GitHub + NIP-89 + Zapstore listings)
+#   8. fetch_heartbeats.sh             (OpenSats + Sovereign Engineering grantee activity)
+#   9. fetch_monthly_history.py        (history candidates; final weekly issue only)
+#  10. fetch_spec_updates.py           (NIP, BUD, NAP, Marmot, Gamma, Concord, NWC specs)
 #
 # Prerequisites:
 #   - Python 3 + requirements.txt (for GitHub fetcher)
@@ -86,7 +87,7 @@ FAILED=0
 SKIPPED=0
 
 # 1. GitHub project updates (Python)
-echo "[1/9] GitHub project updates..."
+echo "[1/10] GitHub project updates..."
 if command -v python3 &>/dev/null; then
     cd "$PROJECT_ROOT"
     if python3 scripts/fetch_project_updates.py $SINCE_ARG $VERBOSE; then
@@ -102,7 +103,7 @@ fi
 echo ""
 
 # 2. NIP discussions (Nostr relay via nak)
-echo "[2/9] NIP discussions from relays..."
+echo "[2/10] NIP discussions from relays..."
 if command -v nak &>/dev/null; then
     if "$SCRIPT_DIR/fetch_nostr_nip_discussions.sh" $SINCE_ARG; then
         echo "  Done."
@@ -117,7 +118,7 @@ fi
 echo ""
 
 # 3. Nostr Recap weekly summaries (Nostr relay via nak)
-echo "[3/9] Nostr Recap summaries..."
+echo "[3/10] Nostr Recap summaries..."
 if command -v nak &>/dev/null; then
     if "$SCRIPT_DIR/fetch_nostr_recap.sh" $SINCE_ARG; then
         echo "  Done."
@@ -132,7 +133,7 @@ fi
 echo ""
 
 # 4. Shakespeare Apps / Soapbox MiniApps (Nostr relay via nak)
-echo "[4/9] Shakespeare Apps (Soapbox MiniApps)..."
+echo "[4/10] Shakespeare Apps (Soapbox MiniApps)..."
 if command -v nak &>/dev/null; then
     if "$SCRIPT_DIR/fetch_shakespeare_apps.sh" $SINCE_ARG; then
         echo "  Done."
@@ -147,7 +148,7 @@ fi
 echo ""
 
 # 5. NIP-34 git repos (Nostr relay via nak)
-echo "[5/9] NIP-34 git repos..."
+echo "[5/10] NIP-34 git repos..."
 if command -v nak &>/dev/null; then
     if "$SCRIPT_DIR/fetch_nip34_repos.sh" $SINCE_ARG; then
         echo "  Done."
@@ -162,7 +163,7 @@ fi
 echo ""
 
 # 6. Zapstore developer-signed releases (Nostr relay via nak)
-echo "[6/9] Zapstore releases..."
+echo "[6/10] Zapstore releases..."
 if command -v nak &>/dev/null; then
     if "$SCRIPT_DIR/fetch_zapstore_releases.sh" $SINCE_ARG; then
         echo "  Done."
@@ -176,8 +177,24 @@ else
 fi
 echo ""
 
-# 7. Grantee heartbeat feeds (OpenSats nostr/general funds + Sovereign Engineering note)
-echo "[7/9] Grantee heartbeat feeds (OpenSats / Sovereign Engineering)..."
+# 7. Untracked application candidates (GitHub + NIP-89 handlers + Zapstore listings)
+echo "[7/10] Untracked Nostr application discovery..."
+if command -v python3 &>/dev/null && command -v gh &>/dev/null && command -v nak &>/dev/null; then
+    cd "$PROJECT_ROOT"
+    if python3 scripts/fetch_app_discovery.py $SINCE_ARG; then
+        echo "  Done."
+    else
+        echo "  WARNING: application discovery failed (exit code $?) — soft-fail, continuing"
+        FAILED=$((FAILED + 1))
+    fi
+else
+    echo "  SKIPPED: python3, gh, or nak not found"
+    SKIPPED=$((SKIPPED + 1))
+fi
+echo ""
+
+# 8. Grantee heartbeat feeds (OpenSats nostr/general funds + Sovereign Engineering note)
+echo "[8/10] Grantee heartbeat feeds (OpenSats / Sovereign Engineering)..."
 if "$SCRIPT_DIR/fetch_heartbeats.sh" "$HB_SINCE" "$HB_UNTIL"; then
     echo "  Done."
 else
@@ -186,11 +203,11 @@ else
 fi
 echo ""
 
-# 8. Same-calendar-month history candidates (final weekly issue only)
+# 9. Same-calendar-month history candidates (final weekly issue only)
 ISSUE_MONTH="$(date -d "$NEWSLETTER_DATE" +%m)"
 ISSUE_YEAR="$(date -d "$NEWSLETTER_DATE" +%Y)"
 NEXT_WEEK_MONTH="$(date -d "$NEWSLETTER_DATE +7 days" +%m)"
-echo "[8/9] Month-end history candidates..."
+echo "[9/10] Month-end history candidates..."
 if [ "$ISSUE_MONTH" != "$NEXT_WEEK_MONTH" ]; then
     if python3 "$SCRIPT_DIR/fetch_monthly_history.py" \
         --month "$((10#$ISSUE_MONTH))" \
@@ -206,8 +223,8 @@ else
 fi
 echo ""
 
-# 9. Protocol/spec-family activity (GitHub)
-echo "[9/9] Specification families (NIP / BUD / NAP / Marmot / Gamma / Concord / NWC)..."
+# 10. Protocol/spec-family activity (GitHub)
+echo "[10/10] Specification families (NIP / BUD / NAP / Marmot / Gamma / Concord / NWC)..."
 if command -v python3 &>/dev/null && command -v gh &>/dev/null; then
     cd "$PROJECT_ROOT"
     SPEC_ARGS=()
@@ -230,14 +247,14 @@ echo ""
 echo "==========================================="
 echo "  Collection Summary"
 echo "==========================================="
-echo "  Completed: $((9 - FAILED - SKIPPED))/9"
+echo "  Completed: $((10 - FAILED - SKIPPED))/10"
 echo "  Failed:    $FAILED"
 echo "  Skipped:   $SKIPPED"
 echo ""
 
 # Show data freshness
 echo "Data freshness:"
-for dir in project_updates nostr_nip_discussions nostr_recap shakespeare_apps nip34_repos zapstore_releases heartbeats spec_updates; do
+for dir in project_updates nostr_nip_discussions nostr_recap shakespeare_apps nip34_repos zapstore_releases app_discovery heartbeats spec_updates; do
     latest=$(ls -t "$PROJECT_ROOT/data/$dir"/*.json 2>/dev/null | head -1)
     if [ -n "$latest" ]; then
         age_hours=$(( ($(date +%s) - $(stat -c %Y "$latest")) / 3600 ))

--- a/scripts/fetch_app_discovery.py
+++ b/scripts/fetch_app_discovery.py
@@ -1,0 +1,813 @@
+#!/usr/bin/env python3
+"""Discover untracked Nostr applications from protocol and forge metadata."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
+import re
+import subprocess
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def normalize_url(value: str | None) -> str:
+    if not value:
+        return ""
+    value = value.strip().strip('"\'')
+    if not value or any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
+        return ""
+    scheme_match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", value)
+    if scheme_match and scheme_match.group(1).casefold() not in {"http", "https"}:
+        return ""
+    if not scheme_match:
+        if value.startswith(("/", ".", "#", "?")):
+            return ""
+        value = f"https://{value}"
+    try:
+        parts = urlsplit(value)
+        host = parts.hostname
+        port = parts.port
+    except ValueError:
+        return ""
+    if parts.scheme.casefold() not in {"http", "https"} or not host or parts.username or parts.password:
+        return ""
+    if "." not in host and ":" not in host:
+        return ""
+    host = host.casefold()
+    if host.startswith("www."):
+        host = host[4:]
+    netloc = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    path = parts.path.rstrip("/")
+    if host == "github.com" and path.lower().endswith(".git"):
+        path = path[:-4]
+    return urlunsplit(("https", netloc, path, "", ""))
+
+
+def parse_projects_index(text: str) -> dict[str, dict[str, str]]:
+    repos: dict[str, str] = {}
+    websites: dict[str, str] = {}
+    names: dict[str, str] = {}
+    current_name = ""
+    for line in text.splitlines():
+        name_match = re.match(r"^\s*-\s+name:\s*(.+?)\s*$", line)
+        if name_match:
+            current_name = name_match.group(1).strip().strip('"\'')
+            names[current_name.casefold()] = current_name
+            continue
+        field_match = re.match(r"^\s+(repo|website):\s*(.+?)\s*$", line)
+        if not field_match or not current_name:
+            continue
+        normalized = normalize_url(field_match.group(2))
+        if not normalized:
+            continue
+        target = repos if field_match.group(1) == "repo" else websites
+        target[normalized.casefold()] = current_name
+    return {"repos": repos, "websites": websites, "names": names}
+
+
+def parse_iso8601(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+APPLICATION_SIGNALS = {
+    "app",
+    "application",
+    "bot",
+    "browser",
+    "chat",
+    "client",
+    "extension",
+    "feed",
+    "market",
+    "mobile",
+    "pwa",
+    "relay",
+    "signer",
+    "social",
+    "tool",
+    "wallet",
+}
+
+
+def has_explicit_nostr_application_signal(item: dict) -> bool:
+    haystack = " ".join(
+        [
+            item.get("full_name") or "",
+            item.get("description") or "",
+            " ".join(item.get("topics") or []),
+        ]
+    ).casefold()
+    if "nostr" not in haystack:
+        return False
+    words = set(re.findall(r"[a-z]+", haystack))
+    return bool(words & APPLICATION_SIGNALS)
+
+
+def github_candidates(
+    items: list[dict],
+    tracked: dict[str, dict[str, str]],
+    seen_repos: set[str],
+    since: datetime,
+    *,
+    first_run: bool,
+) -> tuple[list[dict], set[str]]:
+    candidates: list[dict] = []
+    updated_seen = {normalize_url(repo) for repo in seen_repos if repo}
+    for item in items:
+        repository = normalize_url(item.get("html_url"))
+        if not repository:
+            continue
+        homepage = normalize_url(item.get("homepage"))
+        discovery_sources = item.get("_discovery_sources") or ["github_topic_active"]
+        if not has_explicit_nostr_application_signal(item):
+            continue
+        if repository.casefold() in tracked["repos"] or (
+            homepage and homepage.casefold() in tracked["websites"]
+        ):
+            continue
+        created_at = parse_iso8601(item["created_at"])
+        is_new = created_at >= since
+        first_seen = repository not in updated_seen
+        updated_seen.add(repository)
+        if not is_new and (first_run or not first_seen):
+            continue
+        source_types = discovery_sources
+        if is_new:
+            source_types = ["github_topic_new" if source == "github_topic_active" else source for source in source_types]
+        else:
+            source_types = ["github_topic_first_seen"]
+        candidates.append(
+            {
+                "name": item.get("full_name", "").split("/")[-1],
+                "description": item.get("description") or "",
+                "repository": repository,
+                "website": homepage,
+                "created_at": item.get("created_at"),
+                "last_activity": item.get("pushed_at"),
+                "stars": item.get("stargazers_count", 0),
+                "topics": sorted(set(item.get("topics") or [])),
+                "source_types": sorted(set(source_types)),
+                "evidence_status": "unconfirmed",
+                "evidence_level": "candidate-only",
+                "review_flags": ["self-asserted forge metadata; verify Nostr behavior before tracking"],
+            }
+        )
+    candidates.sort(key=lambda candidate: (candidate["created_at"] or "", candidate["repository"]), reverse=True)
+    return candidates, updated_seen
+
+
+def tag_values(event: dict, name: str) -> list[str]:
+    return [tag[1] for tag in event.get("tags", []) if len(tag) >= 2 and tag[0] == name and tag[1]]
+
+
+def parse_metadata(content: str) -> dict:
+    try:
+        value = json.loads(content or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+NOSTR_LISTING_PATTERNS = (
+    r"\bnostr\b",
+    r"\bnip[- ]?\d+\b",
+    r"\bnwc\b",
+    r"\bnutzaps?\b",
+    r"\bblossom\b",
+    r"\brelay (?:app|client|server|service)\b",
+    r"\bsigned (?:nostr )?events?\b",
+)
+
+
+def has_nostr_listing_signal(name: str, summary: str, content: str) -> bool:
+    text = " ".join((name, summary, content)).casefold()
+    text = re.sub(r"\b(?:no|without)\s+(?:nostr|relay)\b", "", text)
+    return any(re.search(pattern, text) for pattern in NOSTR_LISTING_PATTERNS)
+
+
+def zapstore_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) -> list[dict]:
+    grouped: dict[tuple[str, str], list[dict]] = {}
+    for event in events:
+        if event.get("kind") != 32267 or not event.get("pubkey"):
+            continue
+        app_ids = tag_values(event, "d")
+        if not app_ids or not app_ids[0].strip():
+            continue
+        grouped.setdefault((event["pubkey"], app_ids[0].strip()), []).append(event)
+
+    candidates: list[dict] = []
+    for (pubkey, app_id), versions in grouped.items():
+        latest_created_at = max(int(event.get("created_at", 0)) for event in versions)
+        latest_versions = [event for event in versions if int(event.get("created_at", 0)) == latest_created_at]
+        latest = sorted(latest_versions, key=lambda event: event.get("id", ""))[-1]
+        name = (tag_values(latest, "name") or [app_id])[0].strip()
+        summary = (tag_values(latest, "summary") or [""])[0].strip()
+        repository = normalize_url((tag_values(latest, "repository") or [""])[0])
+        website = normalize_url((tag_values(latest, "url") or [""])[0])
+        if not name or not (repository or website):
+            continue
+        if not has_nostr_listing_signal(name, summary, latest.get("content") or ""):
+            continue
+        if repository and repository.casefold() in tracked["repos"]:
+            continue
+        if website and website.casefold() in tracked["websites"]:
+            continue
+        if name.casefold() in tracked["names"]:
+            continue
+        relays = sorted(
+            {
+                event["_relay"]
+                for event in latest_versions
+                if event.get("id") == latest.get("id") and event.get("_relay")
+            }
+        )
+        candidates.append(
+            {
+                "name": name,
+                "description": summary or latest.get("content") or "",
+                "repository": repository,
+                "website": website,
+                "pubkeys": [pubkey],
+                "event_id": latest.get("id"),
+                "address": f"32267:{pubkey}:{app_id}",
+                "created_at": latest_created_at,
+                "source_relays": relays,
+                "source_types": ["zapstore_listing"],
+                "has_release_in_window": False,
+                "relay_status": "multi-relay" if len(relays) >= 2 else "single-relay",
+                "evidence_status": "unconfirmed",
+                "evidence_level": "candidate-only",
+                "review_flags": ["developer-signed listing without a joined release; verify product and repository ownership"],
+            }
+        )
+    candidates.sort(key=lambda candidate: (candidate["created_at"], candidate["name"].casefold()), reverse=True)
+    return candidates
+
+
+def filter_verified_events(events: list[dict], validator) -> tuple[list[dict], list[str]]:
+    validity: dict[str, bool] = {}
+    rejected: list[str] = []
+    for event in events:
+        event_id = event.get("id") or ""
+        if not event_id or event_id in validity:
+            continue
+        try:
+            validity[event_id] = bool(validator(event))
+        except (OSError, subprocess.SubprocessError, ValueError):
+            validity[event_id] = False
+        if not validity[event_id]:
+            rejected.append(event_id)
+    return [event for event in events if validity.get(event.get("id") or "", False)], rejected
+
+
+def verify_nostr_event(event: dict) -> bool:
+    raw_event = {key: value for key, value in event.items() if not key.startswith("_")}
+    proc = subprocess.run(
+        ["nak", "verify"],
+        input=json.dumps(raw_event, separators=(",", ":")),
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def nsite_references(event: dict) -> list[dict[str, str]]:
+    references: list[dict[str, str]] = []
+    for tag in event.get("tags", []):
+        if len(tag) < 2 or tag[0] not in {"latest", "next"}:
+            continue
+        address = tag[1]
+        if not isinstance(address, str) or not re.fullmatch(r"35128:[0-9a-fA-F]{64}:[^:\s]+", address):
+            continue
+        reference = {"relation": tag[0], "address": address}
+        if len(tag) >= 3 and isinstance(tag[2], str) and tag[2].startswith("wss://") and not any(char.isspace() for char in tag[2]):
+            reference["relay"] = tag[2]
+        if reference not in references:
+            references.append(reference)
+    return references
+
+
+def nip89_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) -> list[dict]:
+    grouped: dict[tuple[str, str], list[dict]] = {}
+    for event in events:
+        if event.get("kind") != 31990 or not event.get("pubkey"):
+            continue
+        d_tags = tag_values(event, "d")
+        if not d_tags:
+            continue
+        grouped.setdefault((event["pubkey"], d_tags[0]), []).append(event)
+
+    candidates: list[dict] = []
+    for (pubkey, d_tag), versions in grouped.items():
+        latest_created_at = max(event.get("created_at", 0) for event in versions)
+        latest_versions = [event for event in versions if event.get("created_at", 0) == latest_created_at]
+        latest = max(latest_versions, key=lambda event: event.get("id", ""))
+        supported_kinds = sorted(
+            {
+                int(value)
+                for value in tag_values(latest, "k")
+                if value.isdigit()
+            }
+        )
+        if not supported_kinds or all(5000 <= kind < 6000 for kind in supported_kinds):
+            continue
+
+        metadata = parse_metadata(latest.get("content", ""))
+        name = metadata.get("name") or metadata.get("display_name") or metadata.get("displayName") or ""
+        repository = normalize_url(metadata.get("repository") or metadata.get("repo") or metadata.get("github"))
+        website = normalize_url(metadata.get("website") or metadata.get("url"))
+        platform_tags = [
+            {"platform": tag[0], "template": tag[1]}
+            for tag in latest.get("tags", [])
+            if len(tag) >= 2 and tag[0] in {"web", "ios", "android"} and tag[1]
+        ]
+        if not name or not (repository or website or platform_tags):
+            continue
+        if repository and repository.casefold() in tracked["repos"]:
+            continue
+        if website and website.casefold() in tracked["websites"]:
+            continue
+        if name.casefold() in tracked["names"]:
+            continue
+
+        relays = sorted(
+            {
+                event["_relay"]
+                for event in latest_versions
+                if event.get("id") == latest.get("id") and event.get("_relay")
+            }
+        )
+        candidates.append(
+            {
+                "name": name,
+                "description": metadata.get("about") or metadata.get("description") or "",
+                "repository": repository,
+                "website": website,
+                "platform_handlers": platform_tags,
+                "nsite_references": nsite_references(latest),
+                "pubkeys": [pubkey],
+                "supported_kinds": supported_kinds,
+                "event_id": latest.get("id"),
+                "address": f"31990:{pubkey}:{d_tag}",
+                "created_at": latest_created_at,
+                "source_relays": relays,
+                "source_types": ["nip89_handler"],
+                "relay_status": "multi-relay" if len(relays) >= 2 else "single-relay",
+                "evidence_status": "unconfirmed",
+                "evidence_level": "candidate-only",
+                "review_flags": ["self-published handler; verify repository ownership and released product"],
+            }
+        )
+    candidates.sort(key=lambda candidate: (candidate["created_at"], candidate["name"].casefold()), reverse=True)
+    return candidates
+
+
+def candidate_aliases(candidate: dict) -> list[str]:
+    aliases: list[str] = []
+    repository = normalize_url(candidate.get("repository"))
+    website = normalize_url(candidate.get("website"))
+    if repository:
+        aliases.append(f"repo:{repository.casefold()}")
+    if website:
+        aliases.append(f"website:{website.casefold()}")
+    if not aliases:
+        aliases.append(f"name:{candidate.get('name', '').casefold()}")
+    return aliases
+
+
+def candidate_key(candidate: dict) -> str:
+    return candidate_aliases(candidate)[0]
+
+
+def evidence_status_rank(value: object) -> int:
+    ranks = {"rejected": 0, "unconfirmed": 1, "corroborated": 2}
+    return ranks.get(value if isinstance(value, str) else "", -1)
+
+
+def relay_status_rank(value: object) -> int:
+    ranks = {"single-relay": 1, "multi-relay": 2}
+    return ranks.get(value if isinstance(value, str) else "", -1)
+
+
+def merge_candidate_fields(current: dict, candidate: dict, list_fields: set[str]) -> None:
+    for field, value in candidate.items():
+        if field in list_fields and isinstance(value, list):
+            existing = current.setdefault(field, [])
+            for item in value:
+                if item not in existing:
+                    existing.append(item)
+        elif field == "evidence_status" and evidence_status_rank(value) > evidence_status_rank(current.get(field)):
+            current[field] = value
+        elif field == "relay_status" and relay_status_rank(value) > relay_status_rank(current.get(field)):
+            current[field] = value
+        elif not current.get(field) and value:
+            current[field] = value
+
+
+def merge_candidates(candidates: list[dict]) -> list[dict]:
+    merged: dict[str, dict] = {}
+    aliases_to_key: dict[str, str] = {}
+    list_fields = {
+        "source_types",
+        "review_flags",
+        "topics",
+        "pubkeys",
+        "supported_kinds",
+        "source_relays",
+        "platform_handlers",
+        "nsite_references",
+    }
+    for candidate in candidates:
+        aliases = candidate_aliases(candidate)
+        matching_keys = list(dict.fromkeys(aliases_to_key[alias] for alias in aliases if alias in aliases_to_key))
+        key = matching_keys[0] if matching_keys else candidate_key(candidate)
+        if key not in merged:
+            merged[key] = {
+                field: list(value) if field in list_fields and isinstance(value, list) else value
+                for field, value in candidate.items()
+            }
+        else:
+            merge_candidate_fields(merged[key], candidate, list_fields)
+
+        # A candidate can bridge records previously keyed by repo and website.
+        for duplicate_key in matching_keys[1:]:
+            if duplicate_key == key or duplicate_key not in merged:
+                continue
+            merge_candidate_fields(merged[key], merged.pop(duplicate_key), list_fields)
+            for alias, mapped_key in list(aliases_to_key.items()):
+                if mapped_key == duplicate_key:
+                    aliases_to_key[alias] = key
+
+        for alias in candidate_aliases(merged[key]):
+            aliases_to_key[alias] = key
+        for alias in aliases:
+            aliases_to_key[alias] = key
+    for candidate in merged.values():
+        for field in list_fields:
+            if field in candidate:
+                if field in {"source_types", "topics", "pubkeys", "supported_kinds", "source_relays"}:
+                    candidate[field] = sorted(candidate[field])
+    return sorted(merged.values(), key=lambda candidate: (candidate.get("name", "").casefold(), candidate_key(candidate)))
+
+
+def build_report(
+    *,
+    since: str,
+    github_items: list[dict],
+    nip89_events: list[dict],
+    tracked: dict[str, dict[str, str]],
+    seen_repos: set[str],
+    first_run: bool,
+    source_errors: dict[str, list[str]],
+    zapstore_events: list[dict] | None = None,
+    signature_rejections: dict[str, list[str]] | None = None,
+) -> dict:
+    since_dt = parse_iso8601(since)
+    github, updated_seen = github_candidates(
+        github_items,
+        tracked,
+        seen_repos,
+        since_dt,
+        first_run=first_run,
+    )
+    nip89 = nip89_candidates(nip89_events, tracked)
+    zapstore = zapstore_candidates(zapstore_events or [], tracked)
+    candidates = merge_candidates(github + nip89 + zapstore)
+    signature_rejections = signature_rejections or {}
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "period": {"since": since},
+        "source_status": {
+            "github": "partial" if source_errors.get("github") else "ok",
+            "nip89": "partial" if source_errors.get("nip89") else "ok",
+            "zapstore": "partial" if source_errors.get("zapstore") else "ok",
+        },
+        "source_errors": source_errors,
+        "signature_rejections": {
+            source: {"count": len(event_ids), "event_ids": sorted(event_ids)}
+            for source, event_ids in signature_rejections.items()
+            if event_ids
+        },
+        "summary": {
+            "source_records": {
+                "github": len(github_items),
+                "nip89": len({event.get("id") for event in nip89_events if event.get("id")}),
+                "zapstore": len({event.get("id") for event in (zapstore_events or []) if event.get("id")}),
+            },
+            "github_candidates": len(github),
+            "nip89_candidates": len(nip89),
+            "zapstore_listing_candidates": len(zapstore),
+            "candidate_count": len(candidates),
+        },
+        "review_policy": "candidate-only; never auto-add to projects.yml",
+        "candidates": candidates,
+        "_updated_seen_repositories": sorted(updated_seen),
+    }
+
+
+DEFAULT_RELAYS = [
+    "wss://nos.lol",
+    "wss://relay.primal.net",
+    "wss://relay.snort.social",
+    "wss://relay.nostr.net",
+    "wss://nostr.mom",
+]
+
+
+def run_github_search(
+    query: str,
+    source: str,
+    *,
+    max_pages: int = 5,
+    warnings: list[str] | None = None,
+) -> list[dict]:
+    items: list[dict] = []
+    incomplete_results = False
+    total_count = 0
+    for page in range(1, max_pages + 1):
+        command = [
+            "gh",
+            "api",
+            "search/repositories",
+            "-X",
+            "GET",
+            "-f",
+            f"q={query}",
+            "-f",
+            "sort=updated",
+            "-f",
+            "order=desc",
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        ]
+        proc = subprocess.run(command, check=False, capture_output=True, text=True, timeout=60)
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or f"gh exited {proc.returncode}")
+        payload = json.loads(proc.stdout)
+        incomplete_results = incomplete_results or bool(payload.get("incomplete_results"))
+        page_items = payload.get("items", [])
+        for item in page_items:
+            item["_discovery_sources"] = [source]
+        items.extend(page_items)
+        total_count = min(int(payload.get("total_count", len(items))), 1000)
+        if len(items) >= total_count or len(page_items) < 100:
+            break
+    if warnings is not None:
+        if incomplete_results:
+            warnings.append(f"{source}: GitHub search reported incomplete_results")
+        if len(items) < total_count:
+            warnings.append(f"{source}: GitHub search truncated at {len(items)} of {total_count} records")
+    return items
+
+
+def merge_github_results(result_sets: list[list[dict]]) -> list[dict]:
+    merged: dict[str, dict] = {}
+    for items in result_sets:
+        for item in items:
+            key = (item.get("full_name") or item.get("html_url") or "").casefold()
+            if not key:
+                continue
+            if key not in merged:
+                merged[key] = dict(item)
+                merged[key]["_discovery_sources"] = list(item.get("_discovery_sources") or [])
+                continue
+            sources = merged[key].setdefault("_discovery_sources", [])
+            for source in item.get("_discovery_sources") or []:
+                if source not in sources:
+                    sources.append(source)
+    return list(merged.values())
+
+
+def github_search_queries(since_day: str) -> list[tuple[str, str]]:
+    return [
+        (f"topic:nostr pushed:>={since_day} archived:false fork:false", "github_topic_active"),
+        (f"nostr in:name,description created:>={since_day} archived:false fork:false", "github_text_new"),
+    ]
+
+
+def fetch_github_discovery(since_day: str) -> tuple[list[dict], list[str]]:
+    queries = github_search_queries(since_day)
+    results: list[list[dict]] = []
+    errors: list[str] = []
+    for query, source in queries:
+        query_warnings: list[str] = []
+        try:
+            results.append(run_github_search(query, source, warnings=query_warnings))
+        except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            errors.append(f"{source}: {exc}")
+        errors.extend(query_warnings)
+    return merge_github_results(results), errors
+
+
+def query_relay_kind(
+    relay: str,
+    kind: int,
+    since_timestamp: int,
+    *,
+    page_size: int = 200,
+    max_pages: int = 5,
+) -> list[dict]:
+    events: list[dict] = []
+    until_timestamp: int | None = None
+    for _ in range(max_pages):
+        command = [
+            "nak",
+            "req",
+            "-q",
+            "-k",
+            str(kind),
+            "--since",
+            str(since_timestamp),
+            "--limit",
+            str(page_size),
+        ]
+        if until_timestamp is not None:
+            command.extend(["--until", str(until_timestamp)])
+        command.append(relay)
+        proc = subprocess.run(command, check=False, capture_output=True, text=True, timeout=25)
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or f"nak exited {proc.returncode}")
+        page: list[dict] = []
+        for line in proc.stdout.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict) and event.get("id") and event.get("kind") == kind:
+                event["_relay"] = relay
+                page.append(event)
+        events.extend(page)
+        if len(page) < page_size:
+            break
+        oldest = min(int(event.get("created_at", 0)) for event in page)
+        if oldest <= since_timestamp:
+            break
+        until_timestamp = oldest - 1
+    unique: dict[tuple[str, str], dict] = {}
+    for event in events:
+        unique[(event["id"], event["_relay"])] = event
+    return list(unique.values())
+
+
+def query_nip89_relay(relay: str, since_timestamp: int) -> list[dict]:
+    return query_relay_kind(relay, 31990, since_timestamp)
+
+
+def fetch_relay_kind_discovery(
+    kind: int,
+    since_timestamp: int,
+    relays: list[str],
+) -> tuple[list[dict], list[str], list[str]]:
+    events: list[dict] = []
+    errors: list[str] = []
+    with ThreadPoolExecutor(max_workers=min(5, len(relays))) as executor:
+        futures = {
+            executor.submit(query_relay_kind, relay, kind, since_timestamp): relay
+            for relay in relays
+        }
+        for future in as_completed(futures):
+            relay = futures[future]
+            try:
+                events.extend(future.result())
+            except (RuntimeError, subprocess.TimeoutExpired) as exc:
+                errors.append(f"{relay}: {exc}")
+    verified, rejected = filter_verified_events(events, verify_nostr_event)
+    return verified, sorted(errors), rejected
+
+
+def fetch_nip89_discovery(since_timestamp: int, relays: list[str]) -> tuple[list[dict], list[str], list[str]]:
+    return fetch_relay_kind_discovery(31990, since_timestamp, relays)
+
+
+def fetch_zapstore_discovery(since_timestamp: int) -> tuple[list[dict], list[str], list[str]]:
+    return fetch_relay_kind_discovery(32267, since_timestamp, ["wss://relay.zapstore.dev"])
+
+
+def load_json_list(path: Path) -> list[dict]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, list):
+        raise ValueError(f"fixture must contain a JSON list: {path}")
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since-days", type=int, default=8)
+    parser.add_argument("--today", help="UTC date override for reproducible runs (YYYY-MM-DD)")
+    parser.add_argument("--projects-file", type=Path, default=root / "data/projects.yml")
+    parser.add_argument("--output-dir", type=Path, default=root / "data/app_discovery")
+    parser.add_argument("--state-file", type=Path, default=root / "data/app_discovery/seen_repos.json")
+    parser.add_argument("--relay", action="append", dest="relays")
+    parser.add_argument("--github-fixture", type=Path)
+    parser.add_argument("--nip89-fixture", type=Path)
+    parser.add_argument("--zapstore-fixture", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    today = date.fromisoformat(args.today) if args.today else datetime.now(timezone.utc).date()
+    since_day = today - timedelta(days=args.since_days)
+    since_dt = datetime.combine(since_day, time.min, timezone.utc)
+    source_errors: dict[str, list[str]] = {}
+
+    if args.github_fixture:
+        github_items = load_json_list(args.github_fixture)
+        github_errors: list[str] = []
+    else:
+        github_items, github_errors = fetch_github_discovery(since_day.isoformat())
+    if github_errors:
+        source_errors["github"] = github_errors
+
+    if args.nip89_fixture:
+        nip89_events = load_json_list(args.nip89_fixture)
+        nip89_errors: list[str] = []
+        nip89_rejections: list[str] = []
+    else:
+        nip89_events, nip89_errors, nip89_rejections = fetch_nip89_discovery(
+            int(since_dt.timestamp()), args.relays or DEFAULT_RELAYS
+        )
+    if nip89_errors:
+        source_errors["nip89"] = nip89_errors
+
+    if args.zapstore_fixture:
+        zapstore_events = load_json_list(args.zapstore_fixture)
+        zapstore_errors: list[str] = []
+        zapstore_rejections: list[str] = []
+    else:
+        zapstore_events, zapstore_errors, zapstore_rejections = fetch_zapstore_discovery(int(since_dt.timestamp()))
+    if zapstore_errors:
+        source_errors["zapstore"] = zapstore_errors
+
+    signature_rejections = {
+        "nip89": nip89_rejections,
+        "zapstore": zapstore_rejections,
+    }
+
+    tracked = parse_projects_index(args.projects_file.read_text())
+    first_run = not args.state_file.exists()
+    if first_run:
+        seen_repos: set[str] = set()
+    else:
+        state = json.loads(args.state_file.read_text())
+        seen_repos = set(state.get("repositories", []))
+
+    report = build_report(
+        since=since_dt.isoformat(),
+        github_items=github_items,
+        nip89_events=nip89_events,
+        zapstore_events=zapstore_events,
+        tracked=tracked,
+        seen_repos=seen_repos,
+        first_run=first_run,
+        source_errors=source_errors,
+        signature_rejections=signature_rejections,
+    )
+    updated_seen = report.pop("_updated_seen_repositories")
+    report["period"]["through"] = today.isoformat()
+    report["period"]["days"] = args.since_days
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = args.output_dir / f"discovery_{today.isoformat()}.json"
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    args.state_file.parent.mkdir(parents=True, exist_ok=True)
+    args.state_file.write_text(
+        json.dumps(
+            {"updated_at": datetime.now(timezone.utc).isoformat(), "repositories": updated_seen},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    print(f"App discovery candidates: {report['summary']['candidate_count']}")
+    print(
+        f"GitHub: {report['summary']['github_candidates']}; "
+        f"NIP-89: {report['summary']['nip89_candidates']}; "
+        f"Zapstore listings: {report['summary']['zapstore_listing_candidates']}"
+    )
+    print(f"Saved: {output_path}")
+    if (
+        not github_items
+        and not nip89_events
+        and not zapstore_events
+        and source_errors.get("github")
+        and source_errors.get("nip89")
+        and source_errors.get("zapstore")
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_app_discovery.py
+++ b/scripts/fetch_app_discovery.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 
-def normalize_url(value: str | None) -> str:
-    if not value:
+def normalize_url(value: object) -> str:
+    if not isinstance(value, str) or not value:
         return ""
     value = value.strip().strip('"\'')
     if not value or any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
@@ -162,10 +162,20 @@ def github_candidates(
 
 
 def tag_values(event: dict, name: str) -> list[str]:
-    return [tag[1] for tag in event.get("tags", []) if len(tag) >= 2 and tag[0] == name and tag[1]]
+    return [
+        tag[1]
+        for tag in event.get("tags", [])
+        if isinstance(tag, list)
+        and len(tag) >= 2
+        and tag[0] == name
+        and isinstance(tag[1], str)
+        and tag[1]
+    ]
 
 
-def parse_metadata(content: str) -> dict:
+def parse_metadata(content: object) -> dict:
+    if not isinstance(content, str):
+        return {}
     try:
         value = json.loads(content or "{}")
     except json.JSONDecodeError:
@@ -184,8 +194,8 @@ NOSTR_LISTING_PATTERNS = (
 )
 
 
-def has_nostr_listing_signal(name: str, summary: str, content: str) -> bool:
-    text = " ".join((name, summary, content)).casefold()
+def has_nostr_listing_signal(name: object, summary: object, content: object) -> bool:
+    text = " ".join(value if isinstance(value, str) else "" for value in (name, summary, content)).casefold()
     text = re.sub(r"\b(?:no|without)\s+(?:nostr|relay)\b", "", text)
     return any(re.search(pattern, text) for pattern in NOSTR_LISTING_PATTERNS)
 
@@ -207,11 +217,12 @@ def zapstore_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) 
         latest = sorted(latest_versions, key=lambda event: event.get("id", ""))[-1]
         name = (tag_values(latest, "name") or [app_id])[0].strip()
         summary = (tag_values(latest, "summary") or [""])[0].strip()
+        content = latest.get("content") if isinstance(latest.get("content"), str) else ""
         repository = normalize_url((tag_values(latest, "repository") or [""])[0])
         website = normalize_url((tag_values(latest, "url") or [""])[0])
         if not name or not (repository or website):
             continue
-        if not has_nostr_listing_signal(name, summary, latest.get("content") or ""):
+        if not has_nostr_listing_signal(name, summary, content):
             continue
         if repository and repository.casefold() in tracked["repos"]:
             continue
@@ -229,7 +240,7 @@ def zapstore_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) 
         candidates.append(
             {
                 "name": name,
-                "description": summary or latest.get("content") or "",
+                "description": summary or content,
                 "repository": repository,
                 "website": website,
                 "pubkeys": [pubkey],
@@ -294,6 +305,19 @@ def nsite_references(event: dict) -> list[dict[str, str]]:
     return references
 
 
+def is_safe_handler_template(platform: str, value: object) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
+        return False
+    if platform == "web":
+        return bool(normalize_url(value))
+    scheme_match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", value)
+    if not scheme_match:
+        return False
+    return scheme_match.group(1).casefold() not in {"data", "file", "javascript", "vbscript"}
+
+
 def nip89_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) -> list[dict]:
     grouped: dict[tuple[str, str], list[dict]] = {}
     for event in events:
@@ -320,13 +344,27 @@ def nip89_candidates(events: list[dict], tracked: dict[str, dict[str, str]]) -> 
             continue
 
         metadata = parse_metadata(latest.get("content", ""))
-        name = metadata.get("name") or metadata.get("display_name") or metadata.get("displayName") or ""
+        name = next(
+            (
+                value.strip()
+                for value in (
+                    metadata.get("name"),
+                    metadata.get("display_name"),
+                    metadata.get("displayName"),
+                )
+                if isinstance(value, str) and value.strip()
+            ),
+            "",
+        )
         repository = normalize_url(metadata.get("repository") or metadata.get("repo") or metadata.get("github"))
         website = normalize_url(metadata.get("website") or metadata.get("url"))
         platform_tags = [
             {"platform": tag[0], "template": tag[1]}
             for tag in latest.get("tags", [])
-            if len(tag) >= 2 and tag[0] in {"web", "ios", "android"} and tag[1]
+            if isinstance(tag, list)
+            and len(tag) >= 2
+            and tag[0] in {"web", "ios", "android"}
+            and is_safe_handler_template(tag[0], tag[1])
         ]
         if not name or not (repository or website or platform_tags):
             continue

--- a/scripts/fetch_app_discovery.py
+++ b/scripts/fetch_app_discovery.py
@@ -495,6 +495,24 @@ def merge_candidates(candidates: list[dict]) -> list[dict]:
     return sorted(merged.values(), key=lambda candidate: (candidate.get("name", "").casefold(), candidate_key(candidate)))
 
 
+def filter_protocol_updates(
+    candidates: list[dict],
+    seen_protocol_events: dict[str, str],
+) -> tuple[list[dict], dict[str, str]]:
+    updated = dict(seen_protocol_events)
+    fresh: list[dict] = []
+    for candidate in candidates:
+        address = candidate.get("address")
+        event_id = candidate.get("event_id")
+        if not isinstance(address, str) or not address or not isinstance(event_id, str) or not event_id:
+            continue
+        if seen_protocol_events.get(address) == event_id:
+            continue
+        updated[address] = event_id
+        fresh.append(candidate)
+    return fresh, updated
+
+
 def build_report(
     *,
     since: str,
@@ -506,6 +524,7 @@ def build_report(
     source_errors: dict[str, list[str]],
     zapstore_events: list[dict] | None = None,
     signature_rejections: dict[str, list[str]] | None = None,
+    seen_protocol_events: dict[str, str] | None = None,
 ) -> dict:
     since_dt = parse_iso8601(since)
     github, updated_seen = github_candidates(
@@ -517,6 +536,8 @@ def build_report(
     )
     nip89 = nip89_candidates(nip89_events, tracked)
     zapstore = zapstore_candidates(zapstore_events or [], tracked)
+    nip89, updated_protocol_events = filter_protocol_updates(nip89, seen_protocol_events or {})
+    zapstore, updated_protocol_events = filter_protocol_updates(zapstore, updated_protocol_events)
     candidates = merge_candidates(github + nip89 + zapstore)
     signature_rejections = signature_rejections or {}
     return {
@@ -547,6 +568,7 @@ def build_report(
         "review_policy": "candidate-only; never auto-add to projects.yml",
         "candidates": candidates,
         "_updated_seen_repositories": sorted(updated_seen),
+        "_updated_seen_protocol_events": updated_protocol_events,
     }
 
 
@@ -680,7 +702,14 @@ def query_relay_kind(
                 event = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if isinstance(event, dict) and event.get("id") and event.get("kind") == kind:
+            if (
+                isinstance(event, dict)
+                and isinstance(event.get("id"), str)
+                and event.get("id")
+                and event.get("kind") == kind
+                and isinstance(event.get("created_at"), int)
+                and not isinstance(event.get("created_at"), bool)
+            ):
                 event["_relay"] = relay
                 page.append(event)
         events.extend(page)
@@ -796,9 +825,16 @@ def main() -> int:
     first_run = not args.state_file.exists()
     if first_run:
         seen_repos: set[str] = set()
+        seen_protocol_events: dict[str, str] = {}
     else:
         state = json.loads(args.state_file.read_text())
         seen_repos = set(state.get("repositories", []))
+        raw_protocol_events = state.get("protocol_events", {})
+        seen_protocol_events = {
+            address: event_id
+            for address, event_id in raw_protocol_events.items()
+            if isinstance(address, str) and isinstance(event_id, str)
+        } if isinstance(raw_protocol_events, dict) else {}
 
     report = build_report(
         since=since_dt.isoformat(),
@@ -810,8 +846,10 @@ def main() -> int:
         first_run=first_run,
         source_errors=source_errors,
         signature_rejections=signature_rejections,
+        seen_protocol_events=seen_protocol_events,
     )
     updated_seen = report.pop("_updated_seen_repositories")
+    updated_protocol_events = report.pop("_updated_seen_protocol_events")
     report["period"]["through"] = today.isoformat()
     report["period"]["days"] = args.since_days
 
@@ -821,7 +859,11 @@ def main() -> int:
     args.state_file.parent.mkdir(parents=True, exist_ok=True)
     args.state_file.write_text(
         json.dumps(
-            {"updated_at": datetime.now(timezone.utc).isoformat(), "repositories": updated_seen},
+            {
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "repositories": updated_seen,
+                "protocol_events": updated_protocol_events,
+            },
             indent=2,
             sort_keys=True,
         )

--- a/tests/test_fetch_app_discovery.py
+++ b/tests/test_fetch_app_discovery.py
@@ -334,6 +334,58 @@ clients:
             [{"relation": "latest", "address": f"35128:{'a' * 64}:reader-site", "relay": "wss://nos.lol"}],
         )
 
+    def test_nip89_discovery_ignores_malformed_metadata_and_unsafe_handlers(self):
+        mod = load_module()
+        malformed = {
+            "id": "malformed",
+            "pubkey": "a" * 64,
+            "kind": 31990,
+            "created_at": 100,
+            "content": '{"name":{"nested":true},"website":["https://bad.example"]}',
+            "tags": [["d", "bad"], ["k", "1"]],
+            "_relay": "wss://nos.lol",
+        }
+        non_string_content = {
+            "id": "non-string-content",
+            "pubkey": "c" * 64,
+            "kind": 31990,
+            "created_at": 100,
+            "content": {"name": "Not valid NIP-01 content"},
+            "tags": [["d", "bad-content"], ["k", "1"]],
+            "_relay": "wss://nos.lol",
+        }
+        safe = {
+            "id": "safe",
+            "pubkey": "b" * 64,
+            "kind": 31990,
+            "created_at": 101,
+            "content": '{"name":"Reader","website":"https://reader.example"}',
+            "tags": [
+                ["d", "reader"],
+                ["k", "1"],
+                ["web", "javascript:alert(1)"],
+                ["web", "https://reader.example/<bech32>"],
+                ["ios", "reader://event/<bech32>"],
+                ["ios", {"not": "a string"}],
+            ],
+            "_relay": "wss://nos.lol",
+        }
+
+        candidates = mod.nip89_candidates(
+            [malformed, non_string_content, safe],
+            {"repos": {}, "websites": {}, "names": {}},
+        )
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["name"], "Reader")
+        self.assertEqual(
+            candidates[0]["platform_handlers"],
+            [
+                {"platform": "web", "template": "https://reader.example/<bech32>"},
+                {"platform": "ios", "template": "reader://event/<bech32>"},
+            ],
+        )
+
     def test_build_report_marks_partial_sources_without_promoting_candidates(self):
         mod = load_module()
         report = mod.build_report(
@@ -422,7 +474,7 @@ clients:
                 ["repository", "https://github.com/example/reader.git"],
                 ["url", "https://reader.example/"],
             ],
-            "content": "Reads signed Nostr events from user-selected relays.",
+            "content": {"unexpected": "object"},
             "_relay": "wss://relay.zapstore.dev",
         }
 

--- a/tests/test_fetch_app_discovery.py
+++ b/tests/test_fetch_app_discovery.py
@@ -1,0 +1,533 @@
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "fetch_app_discovery.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("app_discovery", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class AppDiscoveryTests(unittest.TestCase):
+    def test_cli_writes_candidate_report_and_seen_state_from_fixtures(self):
+        github_item = {
+            "full_name": "trbouma/safebox-acorn",
+            "html_url": "https://github.com/trbouma/safebox-acorn",
+            "description": "Acorn component from a Nostr application",
+            "created_at": "2026-07-27T20:28:08Z",
+            "pushed_at": "2026-08-01T18:28:48Z",
+            "homepage": "",
+            "stargazers_count": 0,
+            "topics": [],
+            "_discovery_sources": ["github_text_new"],
+        }
+        zapstore_event = {
+            "id": "e" * 64,
+            "pubkey": "a" * 64,
+            "created_at": 1785600000,
+            "kind": 32267,
+            "tags": [
+                ["d", "com.example.reader"],
+                ["name", "Example Reader"],
+                ["summary", "Nostr relay client"],
+                ["repository", "https://github.com/example/reader"],
+            ],
+            "content": "Nostr app listing",
+            "_relay": "wss://relay.zapstore.dev",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            projects = root / "projects.yml"
+            github_fixture = root / "github.json"
+            nip89_fixture = root / "nip89.json"
+            zapstore_fixture = root / "zapstore.json"
+            output_dir = root / "out"
+            state = root / "seen.json"
+            projects.write_text("clients: []\n")
+            github_fixture.write_text(json.dumps([github_item]))
+            nip89_fixture.write_text("[]\n")
+            zapstore_fixture.write_text(json.dumps([zapstore_event]))
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--since-days",
+                    "8",
+                    "--today",
+                    "2026-08-02",
+                    "--projects-file",
+                    str(projects),
+                    "--output-dir",
+                    str(output_dir),
+                    "--state-file",
+                    str(state),
+                    "--github-fixture",
+                    str(github_fixture),
+                    "--nip89-fixture",
+                    str(nip89_fixture),
+                    "--zapstore-fixture",
+                    str(zapstore_fixture),
+                ],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            report = json.loads((output_dir / "discovery_2026-08-02.json").read_text())
+            self.assertEqual(report["summary"]["candidate_count"], 2)
+            self.assertEqual(report["summary"]["zapstore_listing_candidates"], 1)
+            self.assertIn(
+                "zapstore_listing",
+                {source for item in report["candidates"] for source in item["source_types"]},
+            )
+            self.assertNotIn("_updated_seen_repositories", report)
+            seen = json.loads(state.read_text())
+            self.assertEqual(seen["repositories"], ["https://github.com/trbouma/safebox-acorn"])
+
+    def test_normalize_url_rejects_unsafe_or_relative_values(self):
+        mod = load_module()
+        for value in (
+            "javascript:alert(1)",
+            "/relative/path",
+            "docs/readme",
+            "https://user:pass@example.com/app",
+            "https://example.com/bad path",
+            "https://example.com/\nheader",
+        ):
+            self.assertEqual(mod.normalize_url(value), "", value)
+        self.assertEqual(mod.normalize_url("example.com/app"), "https://example.com/app")
+
+    def test_projects_index_normalizes_repository_and_website_urls(self):
+        mod = load_module()
+        text = """
+clients:
+  - name: StableKraft
+    repo: https://github.com/ChadFarrow/stablekraft-app/
+    website: https://stablekraft.app/
+  - name: SafeBox
+    repo: https://github.com/trbouma/safebox.git
+"""
+
+        index = mod.parse_projects_index(text)
+
+        self.assertEqual(index["repos"]["https://github.com/chadfarrow/stablekraft-app"], "StableKraft")
+        self.assertEqual(index["websites"]["https://stablekraft.app"], "StableKraft")
+        self.assertEqual(index["repos"]["https://github.com/trbouma/safebox"], "SafeBox")
+
+    def test_github_text_discovery_is_bounded_to_name_and_description(self):
+        mod = load_module()
+        queries = mod.github_search_queries("2026-07-25")
+        text_query = next(query for query, source in queries if source == "github_text_new")
+
+        self.assertIn("in:name,description", text_query)
+        self.assertNotIn("readme", text_query)
+
+    def test_github_search_paginates_bounded_results(self):
+        mod = load_module()
+        first = {
+            "total_count": 101,
+            "incomplete_results": True,
+            "items": [
+                {"full_name": f"example/repo-{index}", "html_url": f"https://github.com/example/repo-{index}"}
+                for index in range(100)
+            ],
+        }
+        second = {
+            "total_count": 101,
+            "items": [{"full_name": "example/repo-100", "html_url": "https://github.com/example/repo-100"}],
+        }
+        responses = [
+            subprocess.CompletedProcess([], 0, stdout=json.dumps(first), stderr=""),
+            subprocess.CompletedProcess([], 0, stdout=json.dumps(second), stderr=""),
+        ]
+
+        warnings = []
+        with mock.patch.object(mod.subprocess, "run", side_effect=responses) as run:
+            items = mod.run_github_search("topic:nostr", "github_topic_active", warnings=warnings)
+
+        self.assertEqual(len(items), 101)
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("page=1", run.call_args_list[0].args[0])
+        self.assertIn("page=2", run.call_args_list[1].args[0])
+        self.assertTrue(any("incomplete_results" in warning for warning in warnings))
+
+    def test_github_candidates_require_explicit_nostr_application_signal(self):
+        mod = load_module()
+        base = {
+            "html_url": "https://github.com/example/noise",
+            "full_name": "example/noise",
+            "homepage": "",
+            "created_at": "2026-07-31T00:00:00Z",
+            "pushed_at": "2026-08-01T00:00:00Z",
+            "stargazers_count": 0,
+            "topics": [],
+            "_discovery_sources": ["github_text_new"],
+        }
+        useful = {
+            **base,
+            "html_url": "https://github.com/example/signer",
+            "full_name": "example/signer",
+            "description": "A Nostr remote signer app",
+        }
+        noise = {**base, "description": "Generic coding exercise"}
+        topic_noise = {
+            **base,
+            "html_url": "https://github.com/example/topic-miner",
+            "full_name": "example/topic-miner",
+            "description": "Bitcoin mining experiment",
+            "topics": ["nostr"],
+            "_discovery_sources": ["github_topic_active"],
+        }
+        topic_useful = {
+            **base,
+            "html_url": "https://github.com/example/topic-signer",
+            "full_name": "example/topic-signer",
+            "description": "Remote signer",
+            "topics": ["nostr"],
+            "_discovery_sources": ["github_topic_active"],
+        }
+        topic_library = {
+            **base,
+            "html_url": "https://github.com/example/nostr-sdk",
+            "full_name": "example/nostr-sdk",
+            "description": "Protocol library",
+            "topics": ["nostr"],
+            "_discovery_sources": ["github_topic_active"],
+        }
+
+        candidates, _ = mod.github_candidates(
+            [useful, noise, topic_noise, topic_useful, topic_library],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+            seen_repos=set(),
+            since=datetime(2026, 7, 25, tzinfo=timezone.utc),
+            first_run=True,
+        )
+
+        self.assertEqual(
+            {candidate["repository"] for candidate in candidates},
+            {useful["html_url"], topic_useful["html_url"]},
+        )
+
+    def test_github_discovery_keeps_new_untracked_repos_and_baselines_old_ones(self):
+        mod = load_module()
+        since = datetime(2026, 7, 25, tzinfo=timezone.utc)
+        items = [
+            {
+                "full_name": "trbouma/safebox-acorn",
+                "html_url": "https://github.com/trbouma/safebox-acorn",
+                "description": "Acorn component from a Nostr application",
+                "created_at": "2026-07-27T20:28:08Z",
+                "pushed_at": "2026-08-01T18:28:48Z",
+                "homepage": "",
+                "stargazers_count": 0,
+                "topics": ["nostr"],
+            },
+            {
+                "full_name": "old/example",
+                "html_url": "https://github.com/old/example",
+                "description": "Older Nostr app",
+                "created_at": "2024-01-01T00:00:00Z",
+                "pushed_at": "2026-08-01T00:00:00Z",
+                "homepage": "https://old.example",
+                "stargazers_count": 3,
+                "topics": ["nostr"],
+            },
+            {
+                "full_name": "ChadFarrow/stablekraft-app",
+                "html_url": "https://github.com/ChadFarrow/stablekraft-app",
+                "description": "Tracked",
+                "created_at": "2025-01-01T00:00:00Z",
+                "pushed_at": "2026-08-01T00:00:00Z",
+                "homepage": "https://stablekraft.app",
+                "stargazers_count": 1,
+                "topics": ["nostr"],
+            },
+        ]
+        tracked = {"repos": {"https://github.com/chadfarrow/stablekraft-app": "StableKraft"}, "websites": {}, "names": {}}
+
+        candidates, seen = mod.github_candidates(items, tracked, set(), since, first_run=True)
+
+        self.assertEqual([candidate["repository"] for candidate in candidates], ["https://github.com/trbouma/safebox-acorn"])
+        self.assertEqual(candidates[0]["source_types"], ["github_topic_new"])
+        self.assertEqual(candidates[0]["evidence_status"], "unconfirmed")
+        self.assertIn("https://github.com/old/example", seen)
+        self.assertIn("https://github.com/trbouma/safebox-acorn", seen)
+
+    def test_github_discovery_surfaces_old_repo_when_first_seen_after_baseline(self):
+        mod = load_module()
+        since = datetime(2026, 7, 25, tzinfo=timezone.utc)
+        item = {
+            "full_name": "old/example",
+            "html_url": "https://github.com/old/example",
+            "description": "Older Nostr app newly tagged for discovery",
+            "created_at": "2024-01-01T00:00:00Z",
+            "pushed_at": "2026-08-01T00:00:00Z",
+            "homepage": "https://old.example",
+            "stargazers_count": 3,
+            "topics": ["nostr"],
+        }
+
+        candidates, _ = mod.github_candidates([item], {"repos": {}, "websites": {}, "names": {}}, set(), since, first_run=False)
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["source_types"], ["github_topic_first_seen"])
+
+    def test_nip89_discovery_requires_identity_location_and_non_dvm_kind(self):
+        mod = load_module()
+        useful = {
+            "id": "useful",
+            "pubkey": "a" * 64,
+            "kind": 31990,
+            "created_at": 100,
+            "content": '{"name":"New Reader","website":"https://reader.example","repository":"https://github.com/example/reader"}',
+            "tags": [
+                ["d", "reader"],
+                ["k", "30023"],
+                ["web", "https://reader.example/<bech32>"],
+                ["latest", f"35128:{'a' * 64}:reader-site", "wss://nos.lol"],
+                ["next", "javascript:bad"],
+            ],
+            "_relay": "wss://nos.lol",
+        }
+        dvm_only = {
+            "id": "dvm",
+            "pubkey": "b" * 64,
+            "kind": 31990,
+            "created_at": 101,
+            "content": '{"name":"Summarizer","website":"https://dvm.example"}',
+            "tags": [["d", "summarizer"], ["k", "5300"]],
+            "_relay": "wss://nos.lol",
+        }
+        no_location = {
+            "id": "missing",
+            "pubkey": "c" * 64,
+            "kind": 31990,
+            "created_at": 102,
+            "content": '{"name":"Mystery"}',
+            "tags": [["d", "mystery"], ["k", "1"]],
+            "_relay": "wss://nos.lol",
+        }
+
+        candidates = mod.nip89_candidates([useful, dvm_only, no_location], {"repos": {}, "websites": {}, "names": {}})
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["name"], "New Reader")
+        self.assertEqual(candidates[0]["repository"], "https://github.com/example/reader")
+        self.assertEqual(candidates[0]["pubkeys"], ["a" * 64])
+        self.assertEqual(candidates[0]["supported_kinds"], [30023])
+        self.assertEqual(candidates[0]["source_types"], ["nip89_handler"])
+        self.assertEqual(candidates[0]["evidence_status"], "unconfirmed")
+        self.assertEqual(candidates[0]["relay_status"], "single-relay")
+        self.assertEqual(
+            candidates[0]["nsite_references"],
+            [{"relation": "latest", "address": f"35128:{'a' * 64}:reader-site", "relay": "wss://nos.lol"}],
+        )
+
+    def test_build_report_marks_partial_sources_without_promoting_candidates(self):
+        mod = load_module()
+        report = mod.build_report(
+            since="2026-07-25T00:00:00+00:00",
+            github_items=[],
+            nip89_events=[],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+            seen_repos=set(),
+            first_run=True,
+            source_errors={"nip89": ["relay timeout"]},
+        )
+
+        self.assertEqual(report["summary"]["candidate_count"], 0)
+        self.assertEqual(report["summary"]["source_records"], {"github": 0, "nip89": 0, "zapstore": 0})
+        self.assertEqual(report["source_status"]["github"], "ok")
+        self.assertEqual(report["source_status"]["nip89"], "partial")
+        self.assertEqual(report["review_policy"], "candidate-only; never auto-add to projects.yml")
+
+    def test_merge_candidates_combines_protocol_and_github_evidence(self):
+        mod = load_module()
+        github = {
+            "name": "reader",
+            "repository": "https://github.com/example/reader",
+            "website": "https://reader.example",
+            "source_types": ["github_topic_new"],
+            "review_flags": ["github flag"],
+            "topics": ["nostr"],
+            "evidence_status": "unconfirmed",
+        }
+        nip89 = {
+            "name": "New Reader",
+            "repository": "https://github.com/example/reader",
+            "website": "https://reader.example",
+            "source_types": ["nip89_handler"],
+            "review_flags": ["nip89 flag"],
+            "pubkeys": ["a" * 64],
+            "supported_kinds": [30023],
+            "evidence_status": "unconfirmed",
+            "relay_status": "multi-relay",
+        }
+
+        merged = mod.merge_candidates([github, nip89])
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["source_types"], ["github_topic_new", "nip89_handler"])
+        self.assertEqual(merged[0]["pubkeys"], ["a" * 64])
+        self.assertEqual(merged[0]["review_flags"], ["github flag", "nip89 flag"])
+        self.assertEqual(merged[0]["evidence_status"], "unconfirmed")
+        self.assertEqual(merged[0]["relay_status"], "multi-relay")
+
+    def test_merge_candidates_uses_website_alias_when_only_github_has_repository(self):
+        mod = load_module()
+        github = {
+            "name": "reader",
+            "repository": "https://github.com/example/reader",
+            "website": "https://reader.example",
+            "source_types": ["github_topic_new"],
+            "review_flags": [],
+        }
+        nip89 = {
+            "name": "New Reader",
+            "repository": "",
+            "website": "https://reader.example/",
+            "source_types": ["nip89_handler"],
+            "review_flags": [],
+            "pubkeys": ["a" * 64],
+        }
+
+        merged = mod.merge_candidates([github, nip89])
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["repository"], "https://github.com/example/reader")
+        self.assertEqual(merged[0]["source_types"], ["github_topic_new", "nip89_handler"])
+
+    def test_zapstore_listing_discovers_unreleased_untracked_app(self):
+        mod = load_module()
+        event = {
+            "id": "e" * 64,
+            "pubkey": "a" * 64,
+            "created_at": 1785600000,
+            "kind": 32267,
+            "tags": [
+                ["d", "com.example.reader"],
+                ["name", "Example Reader"],
+                ["summary", "A Nostr relay client"],
+                ["repository", "https://github.com/example/reader.git"],
+                ["url", "https://reader.example/"],
+            ],
+            "content": "Reads signed Nostr events from user-selected relays.",
+            "_relay": "wss://relay.zapstore.dev",
+        }
+
+        candidates = mod.zapstore_candidates(
+            [event],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+        )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["repository"], "https://github.com/example/reader")
+        self.assertEqual(candidate["website"], "https://reader.example")
+        self.assertEqual(candidate["source_types"], ["zapstore_listing"])
+        self.assertEqual(candidate["address"], f"32267:{'a' * 64}:com.example.reader")
+        self.assertFalse(candidate["has_release_in_window"])
+        self.assertEqual(candidate["evidence_status"], "unconfirmed")
+        self.assertEqual(candidate["relay_status"], "single-relay")
+
+    def test_zapstore_listing_rejects_weak_or_tracked_metadata(self):
+        mod = load_module()
+        base = {
+            "id": "e" * 64,
+            "pubkey": "a" * 64,
+            "created_at": 1785600000,
+            "kind": 32267,
+            "tags": [
+                ["d", "com.example.wallet"],
+                ["name", "Example Wallet"],
+                ["summary", "Bitcoin wallet"],
+                ["repository", "https://github.com/example/wallet"],
+            ],
+            "content": "Bitcoin wallet with no relay functionality.",
+            "_relay": "wss://relay.zapstore.dev",
+        }
+        tracked = {
+            **base,
+            "id": "f" * 64,
+            "tags": [
+                ["d", "com.example.reader"],
+                ["name", "Example Reader"],
+                ["summary", "Nostr relay client"],
+                ["repository", "https://github.com/example/reader"],
+            ],
+        }
+
+        candidates = mod.zapstore_candidates(
+            [base, tracked],
+            tracked={
+                "repos": {"https://github.com/example/reader": "Reader"},
+                "websites": {},
+                "names": {},
+            },
+        )
+
+        self.assertEqual(candidates, [])
+
+    def test_relay_fetch_fails_closed_on_invalid_signatures(self):
+        mod = load_module()
+        valid = {"id": "a" * 64, "kind": 31990, "_relay": "wss://one"}
+        invalid = {"id": "b" * 64, "kind": 31990, "_relay": "wss://one"}
+        with (
+            mock.patch.object(mod, "query_relay_kind", return_value=[valid, invalid]),
+            mock.patch.object(mod, "verify_nostr_event", side_effect=lambda event: event["id"] == valid["id"]),
+        ):
+            events, errors, rejected = mod.fetch_relay_kind_discovery(31990, 0, ["wss://one"])
+
+        self.assertEqual(events, [valid])
+        self.assertEqual(errors, [])
+        self.assertEqual(rejected, [invalid["id"]])
+
+    def test_verified_events_deduplicates_validation_by_event_id(self):
+        mod = load_module()
+        events = [
+            {"id": "a" * 64, "_relay": "wss://one"},
+            {"id": "a" * 64, "_relay": "wss://two"},
+            {"id": "b" * 64, "_relay": "wss://one"},
+        ]
+        checked = []
+
+        kept, rejected = mod.filter_verified_events(events, lambda event: checked.append(event["id"]) or event["id"].startswith("a"))
+
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(rejected, ["b" * 64])
+        self.assertEqual(checked, ["a" * 64, "b" * 64])
+
+    def test_nip89_discovery_deduplicates_address_and_records_relays(self):
+        mod = load_module()
+        base = {
+            "pubkey": "d" * 64,
+            "kind": 31990,
+            "content": '{"name":"Handler","website":"https://handler.example"}',
+            "tags": [["d", "handler"], ["k", "1"], ["web", "https://handler.example/<bech32>"]],
+        }
+        older = {**base, "id": "old", "created_at": 100, "_relay": "wss://nos.lol"}
+        newer_a = {**base, "id": "new", "created_at": 200, "_relay": "wss://nos.lol"}
+        newer_b = {**base, "id": "new", "created_at": 200, "_relay": "wss://relay.primal.net"}
+
+        candidates = mod.nip89_candidates([older, newer_a, newer_b], {"repos": {}, "websites": {}, "names": {}})
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["event_id"], "new")
+        self.assertEqual(candidates[0]["source_relays"], ["wss://nos.lol", "wss://relay.primal.net"])
+        self.assertEqual(candidates[0]["evidence_status"], "unconfirmed")
+        self.assertEqual(candidates[0]["relay_status"], "multi-relay")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fetch_app_discovery.py
+++ b/tests/test_fetch_app_discovery.py
@@ -162,6 +162,16 @@ clients:
         self.assertIn("page=2", run.call_args_list[1].args[0])
         self.assertTrue(any("incomplete_results" in warning for warning in warnings))
 
+    def test_relay_query_drops_malformed_created_at_before_pagination(self):
+        mod = load_module()
+        malformed = {"id": "a" * 64, "kind": 31990, "created_at": "not-a-timestamp"}
+        response = subprocess.CompletedProcess([], 0, stdout=json.dumps(malformed) + "\n", stderr="")
+
+        with mock.patch.object(mod.subprocess, "run", return_value=response):
+            events = mod.query_relay_kind("wss://relay.example", 31990, 0, page_size=1, max_pages=1)
+
+        self.assertEqual(events, [])
+
     def test_github_candidates_require_explicit_nostr_application_signal(self):
         mod = load_module()
         base = {
@@ -403,6 +413,52 @@ clients:
         self.assertEqual(report["source_status"]["github"], "ok")
         self.assertEqual(report["source_status"]["nip89"], "partial")
         self.assertEqual(report["review_policy"], "candidate-only; never auto-add to projects.yml")
+
+    def test_protocol_candidates_emit_once_and_reemit_on_replacement(self):
+        mod = load_module()
+        base = {
+            "pubkey": "a" * 64,
+            "kind": 31990,
+            "created_at": 100,
+            "content": '{"name":"Reader","website":"https://reader.example"}',
+            "tags": [["d", "reader"], ["k", "1"]],
+            "_relay": "wss://nos.lol",
+        }
+
+        first = mod.build_report(
+            since="2026-07-25T00:00:00+00:00",
+            github_items=[],
+            nip89_events=[{**base, "id": "1" * 64}],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+            seen_repos=set(),
+            first_run=True,
+            source_errors={},
+            seen_protocol_events={},
+        )
+        unchanged = mod.build_report(
+            since="2026-07-25T00:00:00+00:00",
+            github_items=[],
+            nip89_events=[{**base, "id": "1" * 64}],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+            seen_repos=set(),
+            first_run=False,
+            source_errors={},
+            seen_protocol_events=first["_updated_seen_protocol_events"],
+        )
+        replacement = mod.build_report(
+            since="2026-07-25T00:00:00+00:00",
+            github_items=[],
+            nip89_events=[{**base, "id": "2" * 64, "created_at": 101}],
+            tracked={"repos": {}, "websites": {}, "names": {}},
+            seen_repos=set(),
+            first_run=False,
+            source_errors={},
+            seen_protocol_events=first["_updated_seen_protocol_events"],
+        )
+
+        self.assertEqual(first["summary"]["candidate_count"], 1)
+        self.assertEqual(unchanged["summary"]["candidate_count"], 0)
+        self.assertEqual(replacement["summary"]["candidate_count"], 1)
 
     def test_merge_candidates_combines_protocol_and_github_evidence(self):
         mod = load_module()


### PR DESCRIPTION
## Summary
- discover untracked Nostr applications from bounded GitHub metadata searches, signature-verified NIP-89 kind 31990 handlers, and Zapstore kind 32267 listings
- keep every result candidate-only with tracked-project deduplication, first-seen state, source health, relay provenance, unsafe-URL rejection, and signature-failure reporting
- preserve NIP-89 nsite references while explicitly excluding trustless global kind 31989 recommendation sweeps
- integrate discovery into `fetch_all.sh` and document pre-intake queue enrichment

## Validation
- `python3 -m unittest tests.test_fetch_app_discovery -v` — 17 passed
- `python3 -m unittest discover -s tests -v` — 49 passed
- `python3 -m py_compile scripts/fetch_app_discovery.py`
- `bash -n scripts/fetch_all.sh`
- `git diff --check`
- clean live run: 53 candidates from 352 GitHub and 167 NIP-89 records; all remain unconfirmed; one relay failure is reported as partial source health

## Review notes
- no automatic writes to `data/projects.yml`
- multi-relay recovery means availability only, not ownership or legitimacy
- generated `data/app_discovery/` output remains ignored runtime state