### PR TITLE
Harden Nostr identity provenance and attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,33 @@ Use `git reset --soft $(git merge-base HEAD origin/main)` to collapse everything
 
 ## Publishing to Nostr
 
-**NEVER ask for an nsec. NEVER use `nak` directly. Always use the pipeline.**
+### Identity resolution and attribution
+
+- Run `bun run check:npubs` before preparing mentions or outreach. Invalid
+  Bech32 keys, contradictory project/person roles, and incomplete unresolved
+  records are blockers.
+- Resolve an unknown identity in this order: project-controlled website or
+  repository; official NIP-05; npub.world; exact signed kind-0/profile queries
+  with read-only `nak`; then broader web search. A matching display name alone
+  never proves ownership. If the project/role binding remains uncertain, ask
+  the editor and record the negative research under `unresolved` in
+  `data/npubs.yml`.
+- A `project` identity is controlled by one project. An `organization` identity
+  represents an organization and must not be described as a project's own
+  account. A `maintainer`, `lead-developer`, or `individual` identity is
+  personal and prose must name the person and role. Never render a personal
+  key as though it were the project's key.
+- Default inline attribution uses a verified project key. Use a personal key
+  only where the prose credits that person, or label it explicitly as
+  `maintainer`/`lead developer`/`individual`. Researched unresolved projects
+  stay untagged.
+- Outreach must consume `mentions.outreachRecipients` from `scripts/publish.ts`;
+  that list applies `outreach: false` and the normalized `no_dm` list before
+  send/idempotency checks. When project and maintainer keys differ, retain both
+  roles in the dry run and receipt; collapse only identical pubkeys. Never infer
+  relationships from YAML adjacency, comments, or alias order.
+
+**NEVER ask for an nsec. NEVER use `nak` to sign or publish. Always use the pipeline for publication.** Read-only `nak` queries are permitted only for public identity research.
 
 ```bash
 # Full pipeline (all stages: parse → sign → announce-sign → broadcast → merge)

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "nostr-tools": "^2.24.1",
         "yaml": "^2.9.0",
       },
       "devDependencies": {
@@ -12,6 +13,12 @@
     },
   },
   "packages": {
+    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
+
+    "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
+
+    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
     "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
 
     "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw=="],
@@ -25,6 +32,16 @@
     "@pagefind/windows-arm64": ["@pagefind/windows-arm64@1.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g=="],
 
     "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg=="],
+
+    "@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
+    "@scure/bip32": ["@scure/bip32@2.0.1", "", { "dependencies": { "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA=="],
+
+    "@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
+
+    "nostr-tools": ["nostr-tools@2.24.1", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/bip32": "2.0.1", "@scure/bip39": "2.0.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-KdrKjC74n/rr6J3eCSfZj8dcbZFvolHYe4S22SefNZ5YWbhHiB0KL/mmJjEZ0u6B9mZK0YcQtl+WQ46KzwapeQ=="],
+
+    "nostr-wasm": ["nostr-wasm@0.1.0", "", {}, "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA=="],
 
     "pagefind": ["pagefind@1.5.2", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.5.2", "@pagefind/darwin-x64": "1.5.2", "@pagefind/freebsd-x64": "1.5.2", "@pagefind/linux-arm64": "1.5.2", "@pagefind/linux-x64": "1.5.2", "@pagefind/windows-arm64": "1.5.2", "@pagefind/windows-x64": "1.5.2" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q=="],
 

--- a/data/npubs.yml
+++ b/data/npubs.yml
@@ -2,32 +2,88 @@
 # Maps project/person names to their Nostr npubs
 # Used by scripts/publish.ts to generate nostr:npub1... mentions
 #
-# Lookup is case-insensitive
-# One npub per entry; deduplicated by value before building mention strings
+# Identity lookup is case-insensitive and deduplicated by npub.
 #
-# To add entries: look up npubs via njump.me, nostr.band, or ask the project maintainer
+# Before adding an identity, research the project's primary website/repository,
+# npub.world, and signed relay profiles with NAK. Never infer an npub from a
+# similar display name. If ownership or role remains unclear, leave the entry
+# commented as unresolved and ask a maintainer or the editor.
 #
 # --- Never DM (read by publish/dm-outreach.ts) ---
-# npubs listed here are never sent a weekly outreach DM, even when
-# scripts/publish.ts resolves them as a genuine mention in that week's
-# newsletter. Use this for accounts that should not receive outreach
-# solicitation, as distinct from being excluded from the npub lookup itself.
+# npubs listed here are never sent outreach even when scripts/publish.ts resolves
+# them as a genuine mention. `outreach: false` additionally marks an entry such
+# as an unmonitored organizational signing key as unsuitable for DMs.
 no_dm:
   - npub1marm0t9qkmv8lq7pe7vdx60ed8fl2d876a2ytk3ade208dlyfweqg5r6m9  # Marmot protocol/MDK - this chat, the bunker signing, and the DM transport itself all run over Marmot; never solicit outreach to it
+  - npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm  # Sirius Business Ltd repository-signing identity; no monitored outreach inbox verified
+
+# Researched projects without a defensible active project/maintainer identity.
+# These remain visible to validation and workflow reporting, but never become
+# mentions or outreach recipients.
+unresolved:
+  Granary:
+    checked_at: 2026-08-02
+    reason: No project identity or Ryan Barrett npub is bound by a primary source.
+    sources:
+      - https://github.com/snarfed/granary
+  Heartwood:
+    checked_at: 2026-08-02
+    reason: Repository identities and example npubs do not bind a public key to Heartwood or its current maintainer.
+    sources:
+      - https://github.com/forgesworn/heartwood
+  Napplet Toolchain:
+    checked_at: 2026-08-02
+    reason: The historical sandwich.farm key is not bound to Napplet by the canonical repositories or site.
+    sources:
+      - https://github.com/napplet/web
+      - https://github.com/napplet/napplet
+      - https://napplet.run/
+  Nostr Applet Protocol:
+    checked_at: 2026-08-02
+    reason: No NAP project account or maintainer npub is bound by a primary source.
+    sources:
+      - https://github.com/napplet/naps
+      - https://napplet.run/
+  keep-android:
+    checked_at: 2026-08-02
+    reason: Candidate personal keys for the maintainer are not bound to PrivKey or keep-android by a primary source.
+    sources:
+      - https://github.com/privkeyio/keep-android
+  swift-nostr-client:
+    checked_at: 2026-08-02
+    reason: No project account or Yusuke Morishita npub is bound by the repository, maintainer site, or profile.
+    sources:
+      - https://github.com/yysskk/swift-nostr-client
+      - https://yusuke.ca/
+  nsite:
+    checked_at: 2026-08-02
+    reason: No project or maintainer npub was verified; the previous value failed its Bech32 checksum.
+    sources:
+      - https://github.com/lez/nsite
+  Dart NDK:
+    checked_at: 2026-08-02
+    reason: No project or maintainer npub was verified; the previous vanity value decoded to 33 bytes and the repository linked by the project site is unavailable.
+    sources:
+      - https://dart-nostr.com/
+  pakstr:
+    checked_at: 2026-07-29
+    reason: No project account or ado maintainer npub was bound after repository, profile, NIP-05, relay, and site checks.
+    sources:
+      - https://git.nostrdev.com/stuff/pakstr
 #
-# Two formats:
-#   String value (project account):  ProjectName: npub1...
-#     -> Replaces "ProjectName" with nostr:npub in body (renders as project name)
-#   Object value (dev account):      ProjectName:
-#                                       npub: npub1...
-#                                       mention_only: true
-#     -> Keeps "ProjectName" in body, appends (nostr:npub) after it
-#        Renders as "ProjectName (devname)" so readers see both
+# New and corrected records use the typed object format:
+#   ProjectName:
+#     npub: npub1...
+#     identity_type: project | organization | maintainer | lead-developer | individual
+#     person: Person Name          # required for maintainer/lead-developer
+#     display_name: Organization   # required for organization
+#     outreach: false              # optional; defaults true
+#     evidence: [https://primary.example/source]
 #
-# Legend:
-#   [project]  = dedicated project account (string format)
-#   [dev:name] = uses developer's personal npub (object format, mention_only)
-#   commented  = no verified npub found
+# Dedicated project identities render directly. Organization and personal
+# identities retain the project name and add an explicit role label, e.g.
+# `(maintainer Tim Bouma: nostr:npub...)`. Legacy string/mention_only records
+# remain readable but `bun run check:npubs` reports them for migration.
 
 # =============================================================================
 # Nostr Compass
@@ -150,7 +206,6 @@ Amber:
 Frostr: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 # aliases for Frostr
 Frost2x: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
-Igloo desktop: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 Igloo Desktop: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 Igloo for Android: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 Igloo for iOS: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
@@ -399,30 +454,58 @@ Igloo: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 Igloo Signer: npub17uvdffljczhlpjfvfj0q30dmh4ugh8wlzm8u6w64y2v4ts7fqsqqj28tr4
 Schemata: npub1g5qtwz2nh9q0mnw555kv787kh6lysds95522gzptre3qpvz9p20s83m80d
 Nymchat: npub16jdfqgazrkapk0yrqm9rdxlnys7ck39c7zmdzxtxqlmmpxg04r0sd733sv
-YakiHonne: npub1yzvxlwp7wawed5vgefwfmugvumtp8c8t0etk3g8sky4n0ndvyxfslnm9n4
-YakiHonne Mobile: npub1yzvxlwp7wawed5vgefwfmugvumtp8c8t0etk3g8sky4n0ndvyxfslnm9n4
+# Dedicated project account verified through YakiHonne's NIP-05 and signed profile.
+YakiHonne:
+  npub: npub1yzvxlwp7wawed5vgefwfmugvumtp8c8t0etk3g8sky4n0ndvyxesnxrf8q
+  identity_type: project
+  evidence:
+    - "https://yakihonne.com/.well-known/nostr.json?name=_"
+    - https://njump.me/nevent1qgszpxr0hql8whvk6xyv5hya7yxwd4snur4hu4mg5rctz2ehekkzrvcpp4mhxue69uhkummn9ekx7mqpz4mhxue69uhhyetvv9ujumn0wd68ytnwv46qqg8k2qt22pwjh6jluf2mgkzj4vt8vaahcqjf7jela7ggngxzpk4dqvd4ryw9
+YakiHonne Mobile:
+  npub: npub1yzvxlwp7wawed5vgefwfmugvumtp8c8t0etk3g8sky4n0ndvyxesnxrf8q
+  identity_type: project
+  evidence:
+    - "https://yakihonne.com/.well-known/nostr.json?name=_"
+# The canonical Nostr repository is signed by Sirius Business Ltd. This is an
+# organizational code identity, not Martti Malmi's personal account, and is not
+# assumed to be a monitored DM inbox.
 Nostr VPN:
-  npub: npub1klgggm0e8jmjzde5sswx0ger4fzmkfjqy9erdsq79fqsz80kzlzsz9ky7h
-  mention_only: true
+  npub: npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm
+  identity_type: organization
+  display_name: Sirius Business Ltd
+  outreach: false
+  evidence:
+    - https://github.com/mmalmi/nostr-vpn#readme
+    - https://njump.me/nevent1qgsrxme3ja3k2lttpej6tdv8vuv73jxumnunj6zjhec7uf4hxd5t9xcpp4mhxue69uhkummn9ekx7mqpz4mhxue69uhhyetvv9ujumn0wd68ytnwv46qqgxpje403wcptsnlgsp7fgx8frtaa93sla58h8fqenjwxfnzplaszsnx7gx2
 Hashtree:
-  npub: npub1klgggm0e8jmjzde5sswx0ger4fzmkfjqy9erdsq79fqsz80kzlzsz9ky7h
-  mention_only: true
-nsite:
-  npub: npub1lez7kezu34ntcpe3xyshkmz8wnyhvmad0aulqez47rfscu4zxmrspm7u08
-  mention_only: true
+  npub: npub1xdhnr9mrv47kkrn95k6cwecearydeh8e895990n3acntwvmgk2dsdeeycm
+  identity_type: organization
+  display_name: Sirius Business Ltd
+  outreach: false
+  evidence:
+    - https://github.com/mmalmi/nostr-vpn#readme
+# nsite: no project or maintainer npub verified after GitHub, web, npub.world,
+# and relay research on 2026-08-02. Do not restore the checksum-invalid value.
 Nostr-Doc: npub1qu7dsd44275lms4x9snnwvnnmgx926nsppmr7lcw9dlj36n4fltqgs7p98
 Nalgorithm:
   npub: npub1m2mvvpjugwdehtaskrcl7ksvdqnnhnjur9v6g9v266nss504q7mqvlr8p9
   mention_only: true
-Dart NDK:
-  npub: npub1relaystr0ng75ecpd8av2v35kwf3a86vlrr3c4gs02p3gvy57haaqgt3a6p
-  mention_only: true
+# Dart NDK: no project or maintainer npub verified after GitHub, project-site,
+# npub.world, and relay research on 2026-08-02. The old vanity value decoded to
+# 33 bytes and was not a valid Nostr public key.
 Vertex:
-  npub: npub176phtjylv0t6wv2d7mc6z50w3rr90k4g5eyauhwmhrcga8kh3wpqrgvgup
-  mention_only: true
+  npub: npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz
+  identity_type: project
+  evidence:
+    - https://vertexlab.io/docs/verification/
+    - https://npub.world/npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz
+    - https://njump.me/nevent1qgstq4j6pk2sgaupru6l7ah9nq0dueafq356jllwcy7uzlek9yx7hlspp4mhxue69uhkummn9ekx7mqpz4mhxue69uhhyetvv9ujumn0wd68ytnwv46qqgxt5a46g23mz2d8hrshrrs7mpm4y8jgflg9c964mj93exe8qt7wwqlhhcsv
 Vertex Lab:
-  npub: npub176phtjylv0t6wv2d7mc6z50w3rr90k4g5eyauhwmhrcga8kh3wpqrgvgup
-  mention_only: true
+  npub: npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz
+  identity_type: project
+  evidence:
+    - https://vertexlab.io/docs/verification/
+    - https://npub.world/npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz
 Branta: npub16ndruwfg7dsdhnp3w8zvqrg0r2rn3wucnttgrg5acm2lhqpkepkqncr9qr
 Vertex Lab relay: npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz
 
@@ -487,7 +570,13 @@ Quartz:
 # =============================================================================
 # Podcast Guests
 # =============================================================================
-Tim Bouma: npub1q6mcr8tlr3l4gus3sfnw6772s7zae6hqncmw5wj27ejud5wcxf7q0nx7d5
+Tim Bouma:
+  npub: npub1q6mcr8tlr3l4gus3sfnw6772s7zae6hqncmw5wj27ejud5wcxf7q0nx7d5
+  identity_type: individual
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma
+    - https://njump.me/nevent1qgsqddupn4l3cl65wggcyehd009g0pwuatsfudh28f90vewx68vrylqpp4mhxue69uhkummn9ekx7mqqyqtfkymmr77cjn39ajgehndtykz665tyj3gvckuz3y2n9s0mfsugsdheaza
 Pete Marcano: npub1marcan0laywmjprf4m8d34dr8m724a6jxxa56a5wwygcgj23q7nskfwmfg
 Vinny: npub19ma2w9dmk3kat0nt0k5dwuqzvmg3va9ezwup0zkakhpwv0vcwvcsg8axkl
 calvadev: npub16dhgpql60vmd4mnydjut87vla23a38j689jssaqlqqlzrtqtd0kqex0nkq
@@ -496,7 +585,13 @@ Vincenzo: npub1szgdn7q6g9huf8a4zd980khntyk2mwqa7s5rlqye6v3y3w7gs4zspmv73y
 elsat: npub1zafcms4xya5ap9zr7xxr0jlrtrattwlesytn2s42030lzu0dwlzqpd26k5
 JeffG: npub1zuuajd7u3sx8xu92yav9jwxpr839cs0kc3q6t56vd5u9q033xmhsk6c2uc
 Fmar: npub1wf4pufsucer5va8g9p0rj5dnhvfeh6d8w0g6eayaep5dhps6rsgs43dgh9
-Pip: npub1plpngahkx2pudue7enq3su2cl0uy2f6gzm83j62rg2r6y3ehp9sqluct7p
+Pip:
+  npub: npub176p7sup477k5738qhxx0hk2n0cty2k5je5uvalzvkvwmw4tltmeqw7vgup
+  identity_type: individual
+  person: pip
+  evidence:
+    - "https://vertexlab.io/.well-known/nostr.json?name=pip"
+    - https://njump.me/nevent1qgs0dqlgwq6l0t20gnstnr8mm9fhu9j9t2fv6wxwl3xtx8dh24l4auspp4mhxue69uhkummn9ekx7mqpz4mhxue69uhhyetvv9ujumn0wd68ytnwv46qqgyj8u6krhgtg6mlxnjsmhklf7r7gvemzeeuge6s8599020yf38kyun0kq2s
 Sondre: npub1zl3g38a6qypp6py2z07shggg45cu8qex992xpss7d8zrl28mu52s4cjajh
 
 # --- Newsletter #17 additions ---
@@ -872,7 +967,13 @@ WhisperHash maintainer:
   mention_only: true
 
 # Kairos Zapstore releases are signed by LWB's relay-backed personal key.
-Kairos: npub1vjxq75czca0nswp2f5kgtfyzhynuccdjs29q098rd3kv09k7s6nq39hh7v
+Kairos:
+  npub: npub1vjxq75czca0nswp2f5kgtfyzhynuccdjs29q098rd3kv09k7s6nq39hh7v
+  identity_type: maintainer
+  person: LWB
+  evidence:
+    - https://github.com/Lwb89dev/kairos
+    - https://njump.me/nevent1qgsxfrq02vpvwhec8q4y6ty95jptjf7vvxeg9zs8jn3kcmx8jm0gdfspzemhxue69uhhyetvv9ujuurjd9kkzmpwdejhgqpqdcpyxzzy40dt74pph06hgksfau58pe9dayl4vcn7u9963k6c5q9qkxjmtu
 LWB maintainer:
   npub: npub1vjxq75czca0nswp2f5kgtfyzhynuccdjs29q098rd3kv09k7s6nq39hh7v
   mention_only: true
@@ -892,10 +993,19 @@ wksantiago maintainer:
 # identity was established from primary evidence.
 Routstrd project account:
   npub: npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s
-  mention_only: true
+  identity_type: project
+  evidence:
+    - https://github.com/Routstr/routstrd
+    - https://npub.world/npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s
 
 # Mill's discussion event is signed by 0ceanSlim's relay-backed key.
-Mill: npub1zmc6qyqdfnllhnzzxr5wpepfpnzcf8q6m3jdveflmgruqvd3qa9sjv7f60
+Mill:
+  npub: npub1zmc6qyqdfnllhnzzxr5wpepfpnzcf8q6m3jdveflmgruqvd3qa9sjv7f60
+  identity_type: maintainer
+  person: 0ceanSlim
+  evidence:
+    - https://github.com/0ceanSlim/nostr-mill
+    - https://njump.me/nevent1qgspdudqzqx5ellme3prp68qus5se3vynsddcexkv5la5p7qxxcswjcpzemhxue69uhhyetvv9ujuurjd9kkzmpwdejhgqpqvd3dnvqxvtaxggq9xru29xh9gafphtq2rc7fx700jzrw437jqv9sw8zh2t
 0ceanSlim maintainer:
   npub: npub1zmc6qyqdfnllhnzzxr5wpepfpnzcf8q6m3jdveflmgruqvd3qa9sjv7f60
   mention_only: true
@@ -917,7 +1027,49 @@ block maintainer:
 # Heading alias needed by automated H3 mention extraction.
 lawallet-nwc: npub1ek4262k6nv3l9axh403w2e66pzl2pqhhnjrhgv2wpzx2akak285scxv4pd
 
-# No verified public Nostr identity found after repository, profile, NIP-05,
-# relay-search, and project-site checks. Never guess an npub.
-# swift-nostr / yysskk: no verified npub found
-# pakstr / ado: no verified npub found
+# =============================================================================
+# Identity audit additions (verified 2026-08-02)
+# =============================================================================
+21Meetup:
+  npub: npub1rl4wlgapxcapk0p3242kqcw7az584sjxgssuwh38u2gatk0cwewsudjz85
+  identity_type: project
+  evidence:
+    - https://github.com/21Koblenz/einundzwanzig-meetup-website/blob/main/social.html
+    - https://njump.me/nevent1qgspl6h05wsnvwsm8sc424tqv80w32r6cfryggw8tcn79yw4m8u8vhgpp4mhxue69uhkummn9ekx7mqqyq3uszr2d30tt8l39t25uh5zngl3gm3putuls6xv84ca98thpu8827m9m85
+
+Deepmarks:
+  npub: npub199zwj9d6w88slsvlthdqfr8q2w58cq0aw3utz7fnpgt7mjjvut6qc80sqk
+  identity_type: project
+  evidence:
+    - https://github.com/ostermayer/deepmarks-public/blob/main/docs/nostr.md
+    - https://github.com/ostermayer/deepmarks-public/blob/main/frontend/static/.well-known/nostr.json
+    - https://njump.me/nevent1qgszj38fzka8rnc0cx04mksy3ns982ruq87hg7930yes59ldefxw9aqpp4mhxue69uhkummn9ekx7mqqyruyjrchuewej5r4vy4aurys2h89kdwvejyas9yss4uxzsawrq9rqleh382
+
+# Newsletter #30 links mattn/nostr-relay. GitHub's verified social account points
+# to this same npub, so it is a maintainer identity, not a relay project account.
+Nostr-relay:
+  npub: npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6
+  identity_type: maintainer
+  person: Yasuhiro Matsumoto (mattn)
+  evidence:
+    - https://github.com/mattn/nostr-relay
+    - https://github.com/mattn
+    - https://njump.compile-error.net/npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6
+
+OpenETR:
+  npub: npub1q6mcr8tlr3l4gus3sfnw6772s7zae6hqncmw5wj27ejud5wcxf7q0nx7d5
+  identity_type: lead-developer
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma/openetr
+    - https://trbouma.github.io/openetr/
+    - https://njump.me/nevent1qgsqddupn4l3cl65wggcyehd009g0pwuatsfudh28f90vewx68vrylqpp4mhxue69uhkummn9ekx7mqqyqtfkymmr77cjn39ajgehndtykz665tyj3gvckuz3y2n9s0mfsugsdheaza
+
+SafeBox:
+  npub: npub1q6mcr8tlr3l4gus3sfnw6772s7zae6hqncmw5wj27ejud5wcxf7q0nx7d5
+  identity_type: lead-developer
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma/safebox
+    - https://github.com/trbouma
+    - https://njump.me/nevent1qgsqddupn4l3cl65wggcyehd009g0pwuatsfudh28f90vewx68vrylqpp4mhxue69uhkummn9ekx7mqqyqtfkymmr77cjn39ajgehndtykz665tyj3gvckuz3y2n9s0mfsugsdheaza

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "scripts": {
-    "build": "bash scripts/build-site.sh"
+    "build": "bash scripts/build-site.sh",
+    "check:npubs": "bun scripts/check_npubs.ts data/npubs.yml"
   },
   "dependencies": {
+    "nostr-tools": "^2.24.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/scripts/check_npubs.ts
+++ b/scripts/check_npubs.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { validateNpubDatabase } from "./lib/npub-database";
+
+const file = resolve(process.argv[2] ?? "data/npubs.yml");
+const strict = process.argv.includes("--strict");
+const result = validateNpubDatabase(readFileSync(file, "utf8"));
+
+for (const error of result.errors) console.error(`ERROR: ${error}`);
+for (const warning of result.warnings) console.error(`WARN: ${warning}`);
+console.error(
+  `npub database: ${result.entries} entries, ${result.uniquePubkeys} valid unique pubkeys, ${result.errors.length} errors, ${result.warnings.length} warnings`,
+);
+if (result.errors.length > 0 || (strict && result.warnings.length > 0)) process.exit(1);

--- a/scripts/lib/npub-database.ts
+++ b/scripts/lib/npub-database.ts
@@ -1,0 +1,341 @@
+import { nip19 } from "nostr-tools";
+import { parse as parseYaml } from "yaml";
+
+export type IdentityType = "project" | "organization" | "maintainer" | "lead-developer" | "individual";
+
+export interface NpubEntry {
+  npub: string;
+  identity_type: IdentityType;
+  person?: string;
+  display_name?: string;
+  evidence: string[];
+  outreach: boolean;
+  mention_only: boolean;
+  legacy: boolean;
+}
+
+export interface NpubMap {
+  [name: string]: NpubEntry;
+}
+
+export interface NpubValidationResult {
+  errors: string[];
+  warnings: string[];
+  entries: number;
+  uniquePubkeys: number;
+}
+
+export interface UnresolvedIdentity {
+  checked_at: string;
+  reason: string;
+  sources: string[];
+}
+
+export interface UnresolvedIdentityMap {
+  [name: string]: UnresolvedIdentity;
+}
+
+const IDENTITY_TYPES = new Set<IdentityType>([
+  "project",
+  "organization",
+  "maintainer",
+  "lead-developer",
+  "individual",
+]);
+
+function parseDatabase(raw: string): Record<string, unknown> {
+  const parsed = parseYaml(raw, { uniqueKeys: true });
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("npub database must be a YAML mapping");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function normalizeEntry(name: string, value: unknown): NpubEntry | null {
+  if (typeof value === "string") {
+    if (!value.startsWith("npub1")) return null;
+    return {
+      npub: value,
+      identity_type: "project",
+      evidence: [],
+      outreach: true,
+      mention_only: false,
+      legacy: true,
+    };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const object = value as Record<string, unknown>;
+  if (typeof object.npub !== "string" || !object.npub.startsWith("npub1")) return null;
+  const explicitType = object.identity_type;
+  const identityType = typeof explicitType === "string" && IDENTITY_TYPES.has(explicitType as IdentityType)
+    ? explicitType as IdentityType
+    : object.mention_only === true
+      ? "maintainer"
+      : "project";
+  const personal = identityType === "maintainer" || identityType === "lead-developer" || identityType === "individual";
+  const evidence = Array.isArray(object.evidence)
+    ? object.evidence.filter((item): item is string => typeof item === "string")
+    : [];
+  return {
+    npub: object.npub,
+    identity_type: identityType,
+    person: typeof object.person === "string" ? object.person.trim() : undefined,
+    display_name: typeof object.display_name === "string" ? object.display_name.trim() : undefined,
+    evidence,
+    outreach: object.outreach !== false,
+    mention_only: personal,
+    legacy: typeof explicitType !== "string",
+  };
+}
+
+export function formatNpubMention(entry: NpubEntry): string {
+  if (entry.identity_type === "organization") {
+    const name = entry.display_name ? ` ${entry.display_name}` : "";
+    return ` (organization${name}: nostr:${entry.npub})`;
+  }
+  if (entry.identity_type === "maintainer" || entry.identity_type === "lead-developer") {
+    const role = entry.identity_type === "lead-developer" ? "lead developer" : "maintainer";
+    const person = entry.person ? ` ${entry.person}` : "";
+    return ` (${role}${person}: nostr:${entry.npub})`;
+  }
+  if (entry.identity_type === "individual") {
+    const person = entry.person ? ` ${entry.person}` : "";
+    return ` (individual${person}: nostr:${entry.npub})`;
+  }
+  return ` nostr:${entry.npub}`;
+}
+
+export function loadNpubMapFromText(raw: string): NpubMap {
+  const parsed = parseDatabase(raw);
+  const map: NpubMap = {};
+  for (const [name, value] of Object.entries(parsed)) {
+    if (name === "no_dm" || name === "unresolved") continue;
+    const entry = normalizeEntry(name, value);
+    if (entry) map[name.toLocaleLowerCase()] = entry;
+  }
+  return map;
+}
+
+export function loadUnresolvedFromText(raw: string): UnresolvedIdentityMap {
+  const parsed = parseDatabase(raw);
+  const source = parsed.unresolved;
+  if (!source || typeof source !== "object" || Array.isArray(source)) return {};
+  const map: UnresolvedIdentityMap = {};
+  for (const [name, value] of Object.entries(source as Record<string, unknown>)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.checked_at === "string" &&
+      typeof record.reason === "string" &&
+      Array.isArray(record.sources)
+    ) {
+      map[name.toLocaleLowerCase()] = {
+        checked_at: record.checked_at,
+        reason: record.reason,
+        sources: record.sources.filter((item): item is string => typeof item === "string"),
+      };
+    }
+  }
+  return map;
+}
+
+export function loadNoDmFromText(raw: string): Set<string> {
+  const parsed = parseDatabase(raw);
+  const values = parsed.no_dm;
+  if (!Array.isArray(values)) return new Set();
+  return new Set(values.filter((value): value is string => typeof value === "string").map((value) => value.toLocaleLowerCase()));
+}
+
+export function isOutreachAllowed(entry: NpubEntry, noDm: Set<string>): boolean {
+  return entry.outreach && !noDm.has(entry.npub.toLocaleLowerCase());
+}
+
+function validateNpub(name: string, npub: string, errors: string[]): string | null {
+  try {
+    const decoded = nip19.decode(npub);
+    if (decoded.type !== "npub" || typeof decoded.data !== "string" || !/^[0-9a-f]{64}$/.test(decoded.data)) {
+      errors.push(`${name}: value is not a 32-byte npub public key`);
+      return null;
+    }
+    return decoded.data;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`${name}: invalid npub checksum or encoding (${message})`);
+    return null;
+  }
+}
+
+export function validateNpubDatabase(raw: string): NpubValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseDatabase(raw);
+  } catch (error) {
+    return {
+      errors: [error instanceof Error ? error.message : String(error)],
+      warnings,
+      entries: 0,
+      uniquePubkeys: 0,
+    };
+  }
+
+  const byHex = new Map<string, Array<{ name: string; entry: NpubEntry }>>();
+  const seenNames = new Set<string>();
+  let entries = 0;
+  let legacyProjects = 0;
+  let legacyRepresentatives = 0;
+
+  for (const [name, value] of Object.entries(parsed)) {
+    if (name === "no_dm" || name === "unresolved") continue;
+    const folded = name.toLocaleLowerCase();
+    if (seenNames.has(folded)) errors.push(`${name}: duplicate case-insensitive label`);
+    seenNames.add(folded);
+
+    const entry = normalizeEntry(name, value);
+    if (!entry) {
+      errors.push(`${name}: expected an npub string or typed identity object`);
+      continue;
+    }
+    entries += 1;
+    const object = value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : null;
+    const explicitType = object?.identity_type;
+
+    if (object) {
+      if (object.outreach !== undefined && typeof object.outreach !== "boolean") {
+        errors.push(`${name}: outreach must be a boolean`);
+      }
+      if (object.mention_only !== undefined && typeof object.mention_only !== "boolean") {
+        errors.push(`${name}: mention_only must be a boolean`);
+      }
+      if (object.person !== undefined && typeof object.person !== "string") {
+        errors.push(`${name}: person must be a string`);
+      }
+      if (object.display_name !== undefined && typeof object.display_name !== "string") {
+        errors.push(`${name}: display_name must be a string`);
+      }
+      if (Array.isArray(object.evidence) && object.evidence.some((item) => typeof item !== "string")) {
+        errors.push(`${name}: every evidence item must be a string URL`);
+      }
+    }
+
+    if (entry.legacy) {
+      if (typeof value === "string") legacyProjects += 1;
+      else legacyRepresentatives += 1;
+    } else {
+      if (typeof explicitType !== "string" || !IDENTITY_TYPES.has(explicitType as IdentityType)) {
+        errors.push(`${name}: unknown identity_type ${String(explicitType)}`);
+      }
+      if ((entry.identity_type === "maintainer" || entry.identity_type === "lead-developer" || entry.identity_type === "individual") && !entry.person) {
+        errors.push(`${name}: ${entry.identity_type} identity requires person`);
+      }
+      if (entry.identity_type === "organization" && !entry.display_name) {
+        errors.push(`${name}: organization identity requires display_name`);
+      }
+      if (entry.evidence.length === 0) {
+        errors.push(`${name}: typed identity requires at least one evidence URL`);
+      }
+      for (const evidence of entry.evidence) {
+        try {
+          const url = new URL(evidence);
+          if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("not web evidence");
+        } catch {
+          errors.push(`${name}: invalid evidence URL ${evidence}`);
+        }
+      }
+    }
+
+    const hex = validateNpub(name, entry.npub, errors);
+    if (hex) {
+      const rows = byHex.get(hex) ?? [];
+      rows.push({ name, entry });
+      byHex.set(hex, rows);
+    }
+  }
+
+  if (legacyProjects > 0) {
+    warnings.push(`${legacyProjects} legacy project entries lack explicit evidence`);
+  }
+  if (legacyRepresentatives > 0) {
+    warnings.push(`${legacyRepresentatives} legacy representative entries lack explicit person/role evidence`);
+  }
+
+  const unresolved = parsed.unresolved;
+  if (unresolved !== undefined) {
+    if (!unresolved || typeof unresolved !== "object" || Array.isArray(unresolved)) {
+      errors.push("unresolved: expected a mapping of researched projects");
+    } else {
+      const unresolvedNames = new Set<string>();
+      for (const [name, value] of Object.entries(unresolved as Record<string, unknown>)) {
+        const folded = name.toLocaleLowerCase();
+        if (unresolvedNames.has(folded)) errors.push(`unresolved.${name}: duplicate case-insensitive label`);
+        unresolvedNames.add(folded);
+        if (seenNames.has(folded)) errors.push(`unresolved.${name}: identity is also present in the active database`);
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          errors.push(`unresolved.${name}: expected a research record`);
+          continue;
+        }
+        const record = value as Record<string, unknown>;
+        if (typeof record.checked_at !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(record.checked_at)) {
+          errors.push(`unresolved.${name}: checked_at must be YYYY-MM-DD`);
+        }
+        if (typeof record.reason !== "string" || record.reason.trim().length === 0) {
+          errors.push(`unresolved.${name}: reason is required`);
+        }
+        if (!Array.isArray(record.sources) || record.sources.length === 0) {
+          errors.push(`unresolved.${name}: at least one source URL is required`);
+        } else {
+          for (const source of record.sources) {
+            try {
+              const url = new URL(String(source));
+              if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("not web evidence");
+            } catch {
+              errors.push(`unresolved.${name}: invalid source URL ${String(source)}`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const noDm = parsed.no_dm;
+  if (noDm !== undefined) {
+    if (!Array.isArray(noDm)) {
+      errors.push("no_dm: expected a list of npubs");
+    } else {
+      const seen = new Set<string>();
+      for (const [index, value] of noDm.entries()) {
+        if (typeof value !== "string") {
+          errors.push(`no_dm[${index}]: expected an npub string`);
+          continue;
+        }
+        const hex = validateNpub(`no_dm[${index}]`, value, errors);
+        if (hex && seen.has(hex)) errors.push(`no_dm[${index}]: duplicate pubkey`);
+        if (hex) seen.add(hex);
+      }
+    }
+  }
+
+  for (const rows of byHex.values()) {
+    // Legacy aliases are ambiguous, but they must not suppress a contradiction
+    // between explicit typed records sharing the same pubkey.
+    const typedRows = rows.filter(({ entry }) => !entry.legacy);
+    const types = new Set(typedRows.map(({ entry }) => entry.identity_type));
+    if ((types.has("project") || types.has("organization")) && (types.has("individual") || types.has("maintainer") || types.has("lead-developer"))) {
+      errors.push(`${typedRows.map(({ name }) => name).join(", ")}: pubkey is classified as both organizational and personal identity`);
+    }
+  }
+
+  return { errors, warnings, entries, uniquePubkeys: byHex.size };
+}
+
+export function loadValidatedNpubMapFromText(raw: string): NpubMap {
+  const validation = validateNpubDatabase(raw);
+  if (validation.errors.length > 0) {
+    throw new Error(`Invalid npub database:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+  return loadNpubMapFromText(raw);
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -24,6 +24,17 @@ import { readFileSync, readdirSync } from "fs";
 import { join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
+import {
+  formatNpubMention,
+  isOutreachAllowed,
+  loadNoDmFromText,
+  loadValidatedNpubMapFromText,
+  loadUnresolvedFromText,
+  type NpubEntry,
+  type NpubMap,
+  type UnresolvedIdentity,
+  type UnresolvedIdentityMap,
+} from "./lib/npub-database";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,43 +49,16 @@ const BANNER_IMAGE =
 // Load npubs database
 // ---------------------------------------------------------------------------
 
-export interface NpubEntry {
-  npub: string;
-  mention_only: boolean; // true = dev account, keep project name + append npub
-}
-
-export interface NpubMap {
-  [name: string]: NpubEntry; // lowercased name -> entry
-}
-
 function loadNpubs(): NpubMap {
-  const raw = readFileSync(NPUBS_FILE, "utf-8");
+  return loadValidatedNpubMapFromText(readFileSync(NPUBS_FILE, "utf-8"));
+}
 
-  // Parse the YAML file; commented-out entries are not parsed
-  const parsed = parseYaml(raw);
-  if (!parsed || typeof parsed !== "object") return {};
+function loadUnresolvedIdentities(): UnresolvedIdentityMap {
+  return loadUnresolvedFromText(readFileSync(NPUBS_FILE, "utf-8"));
+}
 
-  const map: NpubMap = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value === "string" && value.startsWith("npub1")) {
-      // Simple string value = project account (replace name with npub)
-      map[key.toLowerCase()] = { npub: value, mention_only: false };
-    } else if (
-      value &&
-      typeof value === "object" &&
-      "npub" in (value as Record<string, unknown>)
-    ) {
-      // Object value = may have mention_only flag
-      const obj = value as { npub: string; mention_only?: boolean };
-      if (typeof obj.npub === "string" && obj.npub.startsWith("npub1")) {
-        map[key.toLowerCase()] = {
-          npub: obj.npub,
-          mention_only: obj.mention_only === true,
-        };
-      }
-    }
-  }
-  return map;
+function loadNoDmNpubs(): Set<string> {
+  return loadNoDmFromText(readFileSync(NPUBS_FILE, "utf-8"));
 }
 
 // ---------------------------------------------------------------------------
@@ -158,31 +142,38 @@ function simplifyFooter(body: string): string {
 
 export function extractMentions(
   body: string,
-  npubs: NpubMap
+  npubs: NpubMap,
+  unresolvedIdentities: UnresolvedIdentityMap = {},
+  noDm: Set<string> = new Set(),
 ): {
-  found: { name: string; npub: string; mention_only: boolean }[];
+  found: Array<{ name: string } & NpubEntry>;
+  outreachRecipients: Array<{ name: string } & NpubEntry>;
+  unresolved: Array<{ name: string; record: UnresolvedIdentity }>;
   missing: string[];
   mentionString: string;
 } {
   const mentionedNames = new Set<string>();
 
   const projectSections = new Set([
-    "Top Stories",
-    "Tagged Releases",
-    "Shipping This Week",
-    "In Development",
-    "New Projects",
+    "top stories",
+    "lead stories",
+    "tagged releases",
+    "shipping this week",
+    "in development",
+    "unreleased changes",
+    "new projects",
   ]);
   const protocolProjectSections = new Set([
-    "Protocol Work",
-    "Protocol and Spec Work",
+    "protocol work",
+    "protocol and spec work",
+    "protocol work and nip updates",
   ]);
 
   let linkSection = "";
   const applicationLines: string[] = [];
   for (const line of body.split("\n")) {
     const h2 = line.match(/^##\s+(.+)$/);
-    if (h2) linkSection = h2[1].trim();
+    if (h2) linkSection = h2[1].trim().toLocaleLowerCase();
     if (projectSections.has(linkSection)) applicationLines.push(line);
   }
   const applicationBody = applicationLines.join("\n");
@@ -190,6 +181,12 @@ export function extractMentions(
   // Helper: clean a candidate name and decide whether to keep it
   function addIfValid(text: string, fromApplicationHeading = false) {
     text = text.trim();
+    // GitHub link labels often use owner/repository; identity records are keyed
+    // by the project/repository name rather than the owner prefix.
+    if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(text)) {
+      const parts = text.split("/");
+      text = parts[parts.length - 1] || text;
+    }
     // Skip very short names (noise like "Mi", "Go", etc.)
     if (text.length < 3) return;
     // Skip NIP refs, PR numbers, version strings, commit hashes, kind descriptions
@@ -246,7 +243,7 @@ export function extractMentions(
   for (const line of body.split("\n")) {
     const h2 = line.match(/^##\s+(.+)$/);
     if (h2) {
-      currentSection = h2[1].trim();
+      currentSection = h2[1].trim().toLocaleLowerCase();
       continue;
     }
     const h3 = line.match(/^###\s+(.+)$/);
@@ -255,7 +252,7 @@ export function extractMentions(
     if (/^NIP-/.test(fullHeader)) continue;
     // Extract name before action verb, version, or colon
     const nameMatch = fullHeader.match(
-      /^(.+?)(?:\s+(?:Ships?|Adds?|Implements?|Releases?|Merges?|Launches?|Fixes?|Receives?|Recovers?|Remembers?|Keeps?|Tightens?|Pairs?|Gives?|Lets?|Clarifies?|Schedules?|Binds?|Turns?|Enables?|Expands?|Extracts?|Gets?|Updates?|Introduces?|Reaches?|Begins?|Gains?|Supports?|Drops?|Brings?|Rolls?|Publishes?|Integrates?|Migrates?|Moves?|Coordinates?|Opens?)\b|\s+v\d|\s+\d+\.\d|:|$)/i
+      /^(.+?)(?:\s+(?:Ships?|Adds?|Implements?|Releases?|Merges?|Launches?|Fixes?|Receives?|Recovers?|Remembers?|Keeps?|Tightens?|Pairs?|Gives?|Lets?|Clarifies?|Schedules?|Binds?|Turns?|Enables?|Expands?|Extracts?|Gets?|Updates?|Introduces?|Reaches?|Begins?|Gains?|Supports?|Drops?|Brings?|Rolls?|Publishes?|Integrates?|Migrates?|Moves?|Coordinates?|Opens?|Polishes?|Extends?)\b|\s+v\d|\s+\d+\.\d|:|$)/i
     );
     if (nameMatch) {
       let name = nameMatch[1].trim();
@@ -290,33 +287,62 @@ export function extractMentions(
     normalized.add(name);
   }
 
-  // 5. Match against npubs database
-  const found: { name: string; npub: string; mention_only: boolean }[] = [];
+  // 5. Match against npubs database. When aliases share a pubkey, choose the
+  // strongest explicit semantic record rather than whichever alias appeared first.
+  const foundByNpub = new Map<string, { name: string } & NpubEntry>();
+  const unresolved: Array<{ name: string; record: UnresolvedIdentity }> = [];
   const missing: string[] = [];
-  const seenNpubs = new Set<string>();
+  const identityPriority = (entry: NpubEntry): number => {
+    if (entry.legacy) return entry.mention_only ? 20 : 10;
+    switch (entry.identity_type) {
+      case "project": return 150;
+      case "organization": return 140;
+      case "lead-developer": return 130;
+      case "maintainer": return 120;
+      case "individual": return 110;
+    }
+  };
+  const identityAliases: Record<string, string> = {
+    "21meetup 1.1.0": "21meetup",
+    "applesauce signers": "applesauce",
+    "bitcredit core": "bitcredit",
+    "mdk workspace": "mdk",
+    "nymchat 1.0.1": "nymchat",
+    "primal-android": "primal android",
+    "swift-nostr": "swift-nostr-client",
+    "zap cooking's frontend": "zap cooking",
+  };
 
   for (const name of normalized) {
     const lower = name.toLowerCase();
-    const entry = npubs[lower];
+    const lookupName = npubs[lower] ? lower : (identityAliases[lower] ?? lower);
+    const entry = npubs[lookupName];
 
     if (entry) {
-      if (!seenNpubs.has(entry.npub)) {
-        seenNpubs.add(entry.npub);
-        found.push({ name, npub: entry.npub, mention_only: entry.mention_only });
+      const candidate = { name, ...entry };
+      const existing = foundByNpub.get(entry.npub);
+      if (!existing || identityPriority(candidate) > identityPriority(existing)) {
+        foundByNpub.set(entry.npub, candidate);
       }
+    } else if (unresolvedIdentities[lookupName]) {
+      unresolved.push({ name, record: unresolvedIdentities[lookupName] });
     } else {
       missing.push(name);
     }
   }
 
+  const found = [...foundByNpub.values()];
+
   // Sort found by name for stable output
   found.sort((a, b) => a.name.localeCompare(b.name));
+  unresolved.sort((a, b) => a.name.localeCompare(b.name));
   missing.sort();
 
   // Build mention string: "nostr:npub1... nostr:npub2..."
   const mentionString = found.map((f) => `nostr:${f.npub}`).join(" ");
+  const outreachRecipients = found.filter((entry) => isOutreachAllowed(entry, noDm));
 
-  return { found, missing, mentionString };
+  return { found, outreachRecipients, unresolved, missing, mentionString };
 }
 
 // ---------------------------------------------------------------------------
@@ -330,11 +356,11 @@ export function extractMentions(
  * the display name). Placing it next to a markdown link keeps the human-
  * readable name visible while notifying the project/dev.
  *
- * Two modes based on npub type:
- * - Project account (mention_only=false):
+ * Identity-aware rendering:
+ * - Dedicated project or individual account:
  *     `[ProjectName](url) nostr:npub1...`
- * - Dev account (mention_only=true):
- *     `[ProjectName](url) (nostr:npub1...)`
+ * - Personal maintainer/lead-developer account:
+ *     `[ProjectName](url) (maintainer Person: nostr:npub1...)`
  *
  * Algorithm:
  * 1. For each project with a known npub, find the FIRST markdown link
@@ -348,7 +374,7 @@ export function extractMentions(
  */
 function injectNpubMentions(
   body: string,
-  found: { name: string; npub: string; mention_only: boolean }[]
+  found: Array<{ name: string } & NpubEntry>
 ): string {
   // Sort by name length descending to avoid partial matches
   // (e.g. "Primal Android" before "Primal")
@@ -358,14 +384,13 @@ function injectNpubMentions(
   // Split body into lines for line-level analysis
   let lines = body.split("\n");
 
-  for (const { name, npub, mention_only } of sorted) {
+  for (const entry of sorted) {
+    const { name, npub } = entry;
     // Skip if we already injected this npub (deduplicate aliases)
     if (injected.has(npub)) continue;
 
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const npubTag = mention_only
-      ? ` (nostr:${npub})`
-      : ` nostr:${npub}`;
+    const npubTag = formatNpubMention(entry);
 
     // --- Strategy 1: Find first markdown link containing the name ---
     // Match: [text containing Name](url)
@@ -499,7 +524,9 @@ function main() {
 
   // Load npubs and extract mentions
   const npubs = loadNpubs();
-  const mentions = extractMentions(body, npubs);
+  const unresolvedIdentities = loadUnresolvedIdentities();
+  const noDm = loadNoDmNpubs();
+  const mentions = extractMentions(body, npubs, unresolvedIdentities, noDm);
 
   // Inject nostr:npub tags into body text (NIP-27: after first link per project)
   if (!noInject) {
@@ -509,10 +536,19 @@ function main() {
   // Report found mentions on stderr
   if (mentions.found.length > 0) {
     console.error(`[publish] Found npubs for ${mentions.found.length} projects:`);
-    for (const { name, npub, mention_only } of mentions.found) {
-      const tag = mention_only ? "[dev]" : "[project]";
+    for (const { name, npub, identity_type } of mentions.found) {
+      const tag = `[${identity_type}]`;
       console.error(`  + ${tag} ${name} -> ${npub.slice(0, 20)}...`);
     }
+  }
+
+  if (mentions.unresolved.length > 0) {
+    console.error("");
+    console.error(`[publish] RESEARCHED UNRESOLVED identities for ${mentions.unresolved.length} projects:`);
+    for (const { name, record } of mentions.unresolved) {
+      console.error(`  - ${name} (checked ${record.checked_at}): ${record.reason}`);
+    }
+    console.error("[publish] Leave these projects untagged and out of outreach unless new primary evidence is found.");
   }
 
   // Warn about missing npubs on stderr
@@ -524,7 +560,8 @@ function main() {
     }
     console.error("");
     console.error("[publish] Add missing npubs to data/npubs.yml and re-run.");
-    console.error("[publish] Lookup: njump.me, nostr.band, or project docs.");
+    console.error("[publish] Research: primary project site/repository, npub.world, then exact NAK relay queries.");
+    console.error("[publish] If ownership or role remains unclear, add an unresolved record and ask the editor.");
     console.error("[publish] Use --force to skip this check.");
   }
 
@@ -536,6 +573,8 @@ function main() {
     body,
     mentions: {
       found: mentions.found,
+      outreachRecipients: mentions.outreachRecipients,
+      unresolved: mentions.unresolved,
       missing: mentions.missing,
       mentionString: mentions.mentionString,
     },

--- a/tests/npub_database.test.ts
+++ b/tests/npub_database.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatNpubMention,
+  isOutreachAllowed,
+  loadNoDmFromText,
+  loadNpubMapFromText,
+  loadValidatedNpubMapFromText,
+  validateNpubDatabase,
+} from "../scripts/lib/npub-database";
+
+const PROJECT_NPUB = "npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923";
+const PERSON_NPUB = "npub1q6mcr8tlr3l4gus3sfnw6772s7zae6hqncmw5wj27ejud5wcxf7q0nx7d5";
+
+describe("npub database", () => {
+  test("loads explicit project, maintainer, lead-developer, and individual identities", () => {
+    const raw = `
+Compass:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  evidence:
+    - https://nostrcompass.org/
+SafeBox:
+  npub: ${PERSON_NPUB}
+  identity_type: maintainer
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma/safebox
+Developer:
+  npub: ${PERSON_NPUB}
+  identity_type: individual
+  person: Alice
+  evidence:
+    - https://example.com/profile
+`;
+
+    const map = loadNpubMapFromText(raw);
+    expect(map.compass.identity_type).toBe("project");
+    expect(map.safebox.identity_type).toBe("maintainer");
+    expect(map.safebox.person).toBe("Tim Bouma");
+    expect(map.developer.identity_type).toBe("individual");
+    expect(formatNpubMention(map.developer)).toBe(` (individual Alice: nostr:${PERSON_NPUB})`);
+  });
+
+  test("labels personal project representatives explicitly in prose", () => {
+    const map = loadNpubMapFromText(`
+Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  evidence: [https://example.com/project]
+Maintained Project:
+  npub: ${PERSON_NPUB}
+  identity_type: maintainer
+  person: Tim Bouma
+  evidence: [https://example.com/maintainer]
+Led Project:
+  npub: ${PERSON_NPUB}
+  identity_type: lead-developer
+  person: Tim Bouma
+  evidence: [https://example.com/lead]
+Org Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: organization
+  display_name: Example Foundation
+  outreach: false
+  evidence: [https://example.com/org]
+`);
+
+    expect(formatNpubMention(map.project)).toBe(` nostr:${PROJECT_NPUB}`);
+    expect(formatNpubMention(map["maintained project"])).toBe(
+      ` (maintainer Tim Bouma: nostr:${PERSON_NPUB})`,
+    );
+    expect(formatNpubMention(map["led project"])).toBe(
+      ` (lead developer Tim Bouma: nostr:${PERSON_NPUB})`,
+    );
+    expect(formatNpubMention(map["org project"])).toBe(
+      ` (organization Example Foundation: nostr:${PROJECT_NPUB})`,
+    );
+    expect(map["org project"].outreach).toBe(false);
+  });
+
+  test("rejects invalid checksums and personal project identities without a person", () => {
+    const raw = `
+Bad: npub1relaystr0ng75ecpd8av2v35kwf3a86vlrr3c4gs02p3gvy57haaqgt3a6p
+Unattributed:
+  npub: ${PERSON_NPUB}
+  identity_type: maintainer
+  evidence:
+    - https://example.com
+`;
+
+    const result = validateNpubDatabase(raw);
+    expect(result.errors.some((error) => error.includes("Bad") && error.includes("checksum"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("Unattributed") && error.includes("person"))).toBe(true);
+  });
+
+  test("rejects unknown explicit identity types instead of normalizing them to project", () => {
+    const result = validateNpubDatabase(`
+Bad:
+  npub: ${PROJECT_NPUB}
+  identity_type: corporation
+  evidence: [https://example.com/bad]
+`);
+    expect(result.errors.some((error) => error.includes("unknown identity_type corporation"))).toBe(true);
+  });
+
+  test("rejects individual identities without a person", () => {
+    const result = validateNpubDatabase(`
+Anonymous:
+  npub: ${PERSON_NPUB}
+  identity_type: individual
+  evidence: [https://example.com/anonymous]
+`);
+    expect(result.errors.some((error) => error.includes("individual identity requires person"))).toBe(true);
+  });
+
+  test("rejects a pubkey classified as both a project and a person", () => {
+    const raw = `
+Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  evidence:
+    - https://example.com/project
+Person:
+  npub: ${PROJECT_NPUB}
+  identity_type: individual
+  person: Alice
+  evidence:
+    - https://example.com/person
+`;
+
+    const result = validateNpubDatabase(raw);
+    expect(result.errors.some((error) => error.includes("both organizational and personal"))).toBe(true);
+  });
+
+  test("a legacy alias cannot suppress a conflict between typed records", () => {
+    const result = validateNpubDatabase(`
+Legacy: ${PROJECT_NPUB}
+Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  evidence: [https://example.com/project]
+Person:
+  npub: ${PROJECT_NPUB}
+  identity_type: individual
+  person: Alice
+  evidence: [https://example.com/person]
+`);
+    expect(result.errors.some((error) => error.includes("both organizational and personal"))).toBe(true);
+  });
+
+  test("validated loading fails closed on malformed npubs", () => {
+    expect(() => loadValidatedNpubMapFromText("Bad: npub1notavalidkey")).toThrow("Invalid npub database");
+  });
+
+  test("allows maintainer and individual aliases for the same personal key", () => {
+    const raw = `
+SafeBox:
+  npub: ${PERSON_NPUB}
+  identity_type: maintainer
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma/safebox
+Tim Bouma:
+  npub: ${PERSON_NPUB}
+  identity_type: individual
+  person: Tim Bouma
+  evidence:
+    - https://github.com/trbouma
+`;
+
+    expect(validateNpubDatabase(raw).errors).toEqual([]);
+  });
+
+  test("keeps legacy entries readable but reports migration warnings", () => {
+    const raw = `
+Legacy Project: ${PROJECT_NPUB}
+Legacy Maintainer:
+  npub: ${PERSON_NPUB}
+  mention_only: true
+`;
+
+    const map = loadNpubMapFromText(raw);
+    const result = validateNpubDatabase(raw);
+    expect(map["legacy project"].identity_type).toBe("project");
+    expect(map["legacy maintainer"].identity_type).toBe("maintainer");
+    expect(result.warnings.length).toBe(2);
+  });
+
+  test("keeps researched unresolved projects out of the active identity map", () => {
+    const raw = `
+Project: ${PROJECT_NPUB}
+unresolved:
+  Granary:
+    checked_at: 2026-08-02
+    reason: No project or maintainer identity is bound by primary evidence.
+    sources:
+      - https://github.com/snarfed/granary
+`;
+    const map = loadNpubMapFromText(raw);
+    const result = validateNpubDatabase(raw);
+    expect(map.project.npub).toBe(PROJECT_NPUB);
+    expect(map.granary).toBeUndefined();
+    expect(result.errors).toEqual([]);
+  });
+
+  test("rejects incomplete unresolved research records", () => {
+    const result = validateNpubDatabase(`
+unresolved:
+  Granary:
+    checked_at: not-a-date
+    sources: []
+`);
+    expect(result.errors.some((error) => error.includes("Granary"))).toBe(true);
+  });
+
+  test("rejects malformed typed metadata and active/unresolved overlap", () => {
+    const result = validateNpubDatabase(`
+Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  outreach: "false"
+  evidence: [https://example.com/project, 42]
+unresolved:
+  project:
+    checked_at: 2026-08-02
+    reason: Contradictory stale unresolved record.
+    sources: [https://example.com/research]
+`);
+    expect(result.errors.some((error) => error.includes("outreach must be a boolean"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("every evidence item"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("also present in the active database"))).toBe(true);
+  });
+
+  test("applies outreach false and no_dm before recipient selection", () => {
+    const raw = `
+Project:
+  npub: ${PROJECT_NPUB}
+  identity_type: project
+  evidence: [https://example.com/project]
+Organization:
+  npub: ${PERSON_NPUB}
+  identity_type: organization
+  display_name: Example Org
+  outreach: false
+  evidence: [https://example.com/org]
+no_dm: [${PROJECT_NPUB}]
+`;
+    const map = loadNpubMapFromText(raw);
+    const noDm = loadNoDmFromText(raw);
+    expect(isOutreachAllowed(map.project, noDm)).toBe(false);
+    expect(isOutreachAllowed(map.organization, noDm)).toBe(false);
+    expect(isOutreachAllowed({ ...map.project, npub: PERSON_NPUB }, noDm)).toBe(true);
+  });
+});

--- a/tests/publish_mentions.test.ts
+++ b/tests/publish_mentions.test.ts
@@ -1,15 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { extractMentions } from "../scripts/publish";
+import type { NpubMap } from "../scripts/lib/npub-database";
 
-const npubs = {
-  mosaico: { npub: "npub1mosaico", mention_only: false },
-  amethyst: { npub: "npub1amethyst", mention_only: false },
-  gitworkshop: { npub: "npub1gitworkshop", mention_only: false },
-  fips: { npub: "npub1fips", mention_only: false },
-  nostur: { npub: "npub1nostur", mention_only: false },
-  "swift-nostr": { npub: "npub1swiftnostr", mention_only: false },
-  "lawallet-nwc": { npub: "npub1lawalletnwc", mention_only: false },
-  mill: { npub: "npub1mill", mention_only: false },
+function project(npub: string) {
+  return {
+    npub,
+    identity_type: "project" as const,
+    evidence: [],
+    outreach: true,
+    mention_only: false,
+    legacy: false,
+  };
+}
+
+const npubs: NpubMap = {
+  mosaico: project("npub1mosaico"),
+  amethyst: project("npub1amethyst"),
+  gitworkshop: project("npub1gitworkshop"),
+  fips: project("npub1fips"),
+  nostur: project("npub1nostur"),
+  "swift-nostr": project("npub1swiftnostr"),
+  "lawallet-nwc": project("npub1lawalletnwc"),
+  mill: project("npub1mill"),
 };
 
 describe("publish mention extraction", () => {
@@ -119,5 +131,73 @@ Text.
 
     expect(result.found.map((entry) => entry.name)).toEqual(["Mill"]);
     expect(result.missing).toEqual([]);
+  });
+
+  test("separates researched unresolved identities from unknown missing names", () => {
+    const body = `## Tagged Releases
+
+### Granary v11.0 adds NIP-71 support
+
+Text.
+`;
+    const result = extractMentions(body, npubs, {
+      granary: {
+        checked_at: "2026-08-02",
+        reason: "No verified identity.",
+        sources: ["https://github.com/snarfed/granary"],
+      },
+    });
+
+    expect(result.unresolved.map((entry) => entry.name)).toEqual(["Granary"]);
+    expect(result.missing).toEqual([]);
+  });
+
+  test("alias order cannot downgrade a project representative to an unlabeled individual", () => {
+    const shared = "npub1shared";
+    const identities: NpubMap = {
+      keep: {
+        ...project(shared),
+        identity_type: "maintainer",
+        person: "wksantiago",
+        mention_only: true,
+      },
+      wksantiago: {
+        ...project(shared),
+        identity_type: "individual",
+      },
+    };
+    const body = `## In Development
+
+### wksantiago updates signing
+
+Text.
+
+### Keep updates signing
+
+Text.
+`;
+    const result = extractMentions(body, identities);
+    expect(result.found).toHaveLength(1);
+    expect(result.found[0].name).toBe("Keep");
+    expect(result.found[0].identity_type).toBe("maintainer");
+  });
+
+  test("publishing exposes only outreach-eligible resolved recipients", () => {
+    const marmot = project("npub1marmot");
+    const sirius = { ...project("npub1sirius"), outreach: false };
+    const identities: NpubMap = { marmot, sirius };
+    const body = `## In Development
+
+### Marmot updates messaging
+
+Text.
+
+### Sirius updates signing
+
+Text.
+`;
+    const result = extractMentions(body, identities, {}, new Set(["npub1marmot"]));
+    expect(result.found.map((entry) => entry.name)).toEqual(["Marmot", "Sirius"]);
+    expect(result.outreachRecipients).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- add a typed identity model for project, organization, maintainer, lead-developer, and individual accounts
- validate npub checksums, 32-byte keys, typed metadata, evidence URLs, case-folded labels, role conflicts, unresolved research, and `no_dm`
- make publication fail closed on invalid identity data and render personal representatives with explicit person/role attribution
- separate resolved, researched-unresolved, and wholly missing identities; select aliases deterministically by semantic strength
- expose a deduplicated `mentions.outreachRecipients` list filtered by both `outreach: false` and `no_dm`

## Database audit and corrections

- removed the case-folding duplicate `Igloo desktop`
- replaced malformed YakiHonne, Nostr VPN/Hashtree, Vertex, and Pip mappings with evidence-bearing typed records
- removed checksum-invalid nsite and Dart NDK values instead of guessing replacements
- resolved Newsletter #30 identities for 21Meetup, Deepmarks, Nostr-relay, OpenETR, and SafeBox with primary/project evidence and signed relay support
- recorded researched unresolved identities for Granary, Heartwood, Napplet Toolchain/Nostr Applet Protocol, keep-android, swift-nostr-client, nsite, Dart NDK, and pakstr
- corrected project/person semantics for Kairos, Mill, Routstrd, Tim Bouma, and Pip

## Migration status

The compatibility loader retains existing scalar and `mention_only` records while reporting aggregate migration debt. Current validation reports:

```text
npub database: 305 entries, 160 valid unique pubkeys, 0 errors, 2 warnings
WARN: 163 legacy project entries lack explicit evidence
WARN: 126 legacy representative entries lack explicit person/role evidence
```

`--strict` intentionally remains red until those 289 legacy records are migrated with defensible evidence; this PR does not invent roles merely to eliminate warnings.

The repository currently has no tracked DM sender. `scripts/publish.ts` now supplies the policy-filtered recipient boundary that a future sender must consume, and the workflow documentation makes that requirement explicit.

## Verification

- `bun run check:npubs` — pass, 0 errors
- `bun test` — 21 pass, 0 fail
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 52 pass
- `bun audit` — no vulnerabilities
- `bun run build` — Hugo and Pagefind production build pass
- `git diff --cached --check` — pass
- added-line security scan — 0 secret, injection, eval/exec, pickle, or SQL-format findings
- Newsletter #30 extraction — 26 resolved, 25 outreach-eligible, 6 researched-unresolved, 0 missing; Marmot excluded by `no_dm`
- Newsletter #33 extraction — 28 resolved, 27 outreach-eligible, 2 researched-unresolved, 0 missing; MDK excluded by `no_dm`
- independent fail-closed re-review — pass, no security concerns or logic errors
