### PR TITLE
Replace placeholder JSON events with real relay events in #34 deep dives

### DIFF
--- a/content/en/newsletters/2026-08-05-newsletter.md
+++ b/content/en/newsletters/2026-08-05-newsletter.md
@@ -144,17 +144,17 @@ The [NIP-50 specification](https://github.com/nostr-protocol/nips/blob/master/50
 
 This differs from exact [NIP-01 filtering](https://github.com/nostr-protocol/nips/blob/master/01.md). An `authors` or `#t` filter has deterministic matching semantics that a client can verify directly, while a search match may depend on an index and an opaque score. NIP-50 retains NIP-01's signed event envelope and relay transport, but accepts variation in recall and ordering to make open-ended retrieval possible.
 
-The event below is an illustrative search result using the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). The repeated hexadecimal values are placeholders rather than a valid signature.
+The event below is a real search result returned by a NIP-50 search relay for a relay-discovery query, with the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) populated and a valid signature.
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -172,21 +172,22 @@ The [kind `9802` definition](https://github.com/nostr-protocol/nips/blob/master/
 
 NIP-84 differs from a [NIP-23 long-form event](https://github.com/nostr-protocol/nips/blob/master/23.md), which publishes an entire article as kind `30023`; a highlight quotes or points into material that may remain elsewhere. It also differs from a [NIP-51 bookmark set](https://github.com/nostr-protocol/nips/blob/master/51.md), which stores a replaceable collection of references. NIP-84 makes each selection independently signed, attributable, discoverable, and discussable.
 
-This illustrative highlight contains the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). Its identifier and signature are placeholders.
+The highlight below is a real kind `9802` event published from Primal's iOS client, recovered from public relays. It carries the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) with a valid signature, an `a` tag pointing at a [NIP-23 long-form event](https://github.com/nostr-protocol/nips/blob/master/23.md), a `p` tag attributing the article's author, and a `context` tag preserving the surrounding passage.
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 


### PR DESCRIPTION
Both NIP Deep Dives in issue #34 shipped placeholder JSON events (repeated-hex ids/sigs, prose admitting they were placeholders). This replaces them with real events recovered from public relays:

- **NIP-50 deep dive** (search result example): real kind 1 event `2943d6b4…f6c5` — an actual NIP-50 search-relay result with a valid signature
- **NIP-84 deep dive** (highlight example): real kind 9802 event `0d57c07c…794a` — published from Primal iOS, carries `a`/`p`/`context`/`alt` tags and a valid Schnorr signature

Gates: `check_newsletter_style.py` PASS, `check_newsletter_paragraph_links.py` PASS, `hugo --buildFuture` clean.

After merge, the kind 30023 long-form event will be re-signed and re-broadcast under the same `newsletter-34` d-tag (NIP-23 addressable replacement) so relay content matches the corrected site.