### PR TITLE
Sync #34 event examples with real relay-recovered events (9 translations)

### DIFF
--- a/content/de/newsletters/2026-08-05-newsletter.md
+++ b/content/de/newsletters/2026-08-05-newsletter.md
@@ -146,17 +146,17 @@ Die [NIP-50-Spezifikation](https://github.com/nostr-protocol/nips/blob/master/50
 
 Das unterscheidet sich vom exakten [NIP-01-Filtern](https://github.com/nostr-protocol/nips/blob/master/01.md). Ein `authors`- oder `#t`-Filter hat deterministische Match-Semantik, die ein Client direkt verifizieren kann, während ein Suchtreffer von einem Index und einem opaken Score abhängen kann. NIP-50 behält den signierten Event-Umschlag und den Relay-Transport von NIP-01 bei, akzeptiert aber Variationen bei Recall und Reihenfolge, um offene Abfragen zu ermöglichen.
 
-Das folgende Event ist ein illustratives Suchergebnis mit den [sieben NIP-01-Event-Feldern](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). Die wiederholten Hexadezimalwerte sind Platzhalter und keine gültige Signatur.
+Das folgende Event ist ein echtes Suchergebnis, das ein NIP-50-Suchrelay für eine Relay-Discovery-Abfrage zurückgegeben hat, mit den [sieben NIP-01-Event-Feldern](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) und einer gültigen Signatur.
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -174,21 +174,22 @@ Die [Kind-`9802`-Definition](https://github.com/nostr-protocol/nips/blob/master/
 
 NIP-84 unterscheidet sich von einem [NIP-23-Longform-Event](https://github.com/nostr-protocol/nips/blob/master/23.md), das einen ganzen Artikel als Kind `30023` veröffentlicht; ein Highlight zitiert oder zeigt in Material, das anderswo verbleiben kann. Es unterscheidet sich auch von einem [NIP-51-Lesezeichen-Set](https://github.com/nostr-protocol/nips/blob/master/51.md), das eine ersetzbare Sammlung von Referenzen speichert. NIP-84 macht jede Auswahl unabhängig signiert, attribuierbar, auffindbar und diskutierbar.
 
-Dieses illustrative Highlight enthält die [sieben NIP-01-Event-Felder](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). Seine Kennung und Signatur sind Platzhalter.
+Das folgende Highlight ist ein echtes Kind-`9802`-Event, das aus Primals iOS-Client veröffentlicht und aus öffentlichen Relays wiederhergestellt wurde. Es trägt die [sieben NIP-01-Event-Felder](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) mit gültiger Signatur, einen `a`-Tag, der auf ein [NIP-23-Langform-Event](https://github.com/nostr-protocol/nips/blob/master/23.md) zeigt, einen `p`-Tag zur Nennung des Artikelautors und einen `context`-Tag mit der umgebenden Passage.
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/en/newsletters/2026-08-05-newsletter.md
+++ b/content/en/newsletters/2026-08-05-newsletter.md
@@ -144,17 +144,17 @@ The [NIP-50 specification](https://github.com/nostr-protocol/nips/blob/master/50
 
 This differs from exact [NIP-01 filtering](https://github.com/nostr-protocol/nips/blob/master/01.md). An `authors` or `#t` filter has deterministic matching semantics that a client can verify directly, while a search match may depend on an index and an opaque score. NIP-50 retains NIP-01's signed event envelope and relay transport, but accepts variation in recall and ordering to make open-ended retrieval possible.
 
-The event below is an illustrative search result using the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). The repeated hexadecimal values are placeholders rather than a valid signature.
+The event below is a real search result returned by a NIP-50 search relay for a relay-discovery query, with the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) populated and a valid signature.
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -172,21 +172,22 @@ The [kind `9802` definition](https://github.com/nostr-protocol/nips/blob/master/
 
 NIP-84 differs from a [NIP-23 long-form event](https://github.com/nostr-protocol/nips/blob/master/23.md), which publishes an entire article as kind `30023`; a highlight quotes or points into material that may remain elsewhere. It also differs from a [NIP-51 bookmark set](https://github.com/nostr-protocol/nips/blob/master/51.md), which stores a replaceable collection of references. NIP-84 makes each selection independently signed, attributable, discoverable, and discussable.
 
-This illustrative highlight contains the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). Its identifier and signature are placeholders.
+The highlight below is a real kind `9802` event published from Primal's iOS client, recovered from public relays. It carries the [seven NIP-01 event fields](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) with a valid signature, an `a` tag pointing at a [NIP-23 long-form event](https://github.com/nostr-protocol/nips/blob/master/23.md), a `p` tag attributing the article's author, and a `context` tag preserving the surrounding passage.
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/es/newsletters/2026-08-05-newsletter.md
+++ b/content/es/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ El evento siguiente es un resultado de búsqueda ilustrativo que usa los [siete 
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ Este destacado ilustrativo contiene los [siete campos de evento de NIP-01](https
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/fr/newsletters/2026-08-05-newsletter.md
+++ b/content/fr/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ L'événement ci-dessous est un résultat de recherche illustratif utilisant les
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ Ce surlignage illustratif contient les [sept champs d'événement de NIP-01](htt
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/it/newsletters/2026-08-05-newsletter.md
+++ b/content/it/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ L'evento qui sotto è un risultato di ricerca illustrativo che usa i [sette camp
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ Questo highlight illustrativo contiene i [sette campi dell'evento di NIP-01](htt
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/ja/newsletters/2026-08-05-newsletter.md
+++ b/content/ja/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ description: "SandstrはモックデータでNostrクライアントのツアー
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ NIP-84は、記事全体をkind `30023`として公開する[NIP-23長文イベ�
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/ko/newsletters/2026-08-05-newsletter.md
+++ b/content/ko/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ description: "Sandstr는 목 데이터로 Nostr 클라이언트 투어를 제공
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ NIP-84는 전체 기사를 kind `30023`으로 게시하는 [NIP-23 장문 이벤
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/nl/newsletters/2026-08-05-newsletter.md
+++ b/content/nl/newsletters/2026-08-05-newsletter.md
@@ -146,17 +146,17 @@ De [NIP-50-specificatie](https://github.com/nostr-protocol/nips/blob/master/50.m
 
 Dit verschilt van exact [NIP-01-filteren](https://github.com/nostr-protocol/nips/blob/master/01.md). Een `authors`- of `#t`-filter heeft deterministische match-semantiek die een client direct kan verifiëren, terwijl een zoekmatch kan afhangen van een index en een opake score. NIP-50 behoudt de ondertekende event-envelop en het relay-transport van NIP-01, maar accepteert variatie in recall en volgorde om openvormig ophalen mogelijk te maken.
 
-Het onderstaande event is een illustratief zoekresultaat met de [zeven NIP-01-eventvelden](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). De herhaalde hexadecimale waarden zijn placeholders en geen geldige handtekening.
+Het onderstaande event is een echt zoekresultaat dat een NIP-50-zoekrelay heeft teruggegeven voor een relay-discovery-query, met de [zeven NIP-01-eventvelden](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) en een geldige handtekening.
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -174,21 +174,22 @@ De [kind `9802`-definitie](https://github.com/nostr-protocol/nips/blob/master/84
 
 NIP-84 verschilt van een [NIP-23-longform-event](https://github.com/nostr-protocol/nips/blob/master/23.md), dat een heel artikel publiceert als kind `30023`; een highlight citeert of wijst in materiaal dat elders kan blijven. Hij verschilt ook van een [NIP-51-bladwijzersets](https://github.com/nostr-protocol/nips/blob/master/51.md), die een vervangbare verzameling verwijzingen opslaat. NIP-84 maakt elke selectie onafhankelijk ondertekend, toeschrijfbaar, vindbaar en bespreekbaar.
 
-Deze illustratieve highlight bevat de [zeven NIP-01-eventvelden](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures). Zijn identificatie en handtekening zijn placeholders.
+De onderstaande highlight is een echt kind-`9802`-event, gepubliceerd vanuit Primals iOS-client en teruggevonden op publieke relays. Het draagt de [zeven NIP-01-eventvelden](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) met een geldige handtekening, een `a`-tag die naar een [NIP-23-longform-event](https://github.com/nostr-protocol/nips/blob/master/23.md) wijst, een `p`-tag die de auteur van het artikel vermeldt, en een `context`-tag met de omringende passage.
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/pt/newsletters/2026-08-05-newsletter.md
+++ b/content/pt/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ O evento abaixo é um resultado de busca ilustrativo usando os [sete campos de e
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ Este destaque ilustrativo contém os [sete campos de evento do NIP-01](https://g
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 

--- a/content/zh/newsletters/2026-08-05-newsletter.md
+++ b/content/zh/newsletters/2026-08-05-newsletter.md
@@ -150,13 +150,13 @@ description: "Sandstr 提供以模拟数据游览 Nostr 客户端的功能,nostr
 
 ```json
 {
-  "id": "0000000000000000000000000000000000000000000000000000000000000000",
-  "pubkey": "1111111111111111111111111111111111111111111111111111111111111111",
-  "created_at": 1785888000,
+  "id": "2943d6b43bcbf0ee4a8b4cac912111be0309607b8bb435ae40529989bea7f6c5",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1785771175,
   "kind": 1,
-  "tags": [["t", "nostr"]],
-  "content": "A comparison of Nostr search relays and their indexes.",
-  "sig": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+  "tags": [],
+  "content": "I've been working on a customizable client (mostly relay feeds, but a ton of other things and subtle details too). It's called Hallway for reasons I don't remember and it's a fork of Fevela which is a fork of Jumble, but very rewritten for speed and simplicity...",
+  "sig": "5b058b89dab9bd09d81bdc10eff95536125b87fbcbbc97f08d835c1272b2a3190cc3d340e42f54acb0d7e0e4b00355ab91292d0305c84a2d73b538319c0da12c"
 }
 ```
 
@@ -178,17 +178,18 @@ NIP-84 不同于 [NIP-23 长文事件](https://github.com/nostr-protocol/nips/bl
 
 ```json
 {
-  "id": "3333333333333333333333333333333333333333333333333333333333333333",
-  "pubkey": "4444444444444444444444444444444444444444444444444444444444444444",
-  "created_at": 1785888000,
+  "id": "0d57c07cfdfe8ec00711e2af88a666b61fc35c167b90b02dfb5db7ffba7b794a",
+  "pubkey": "07367baec8e73c076b14e47fba3b0d5c014d559d7986a7172a79a8a64419d7c2",
+  "created_at": 1785797755,
   "kind": 9802,
   "tags": [
-    ["a", "30023:6666666666666666666666666666666666666666666666666666666666666666:relay-search", "wss://relay.example"],
-    ["p", "6666666666666666666666666666666666666666666666666666666666666666", "wss://relay.example", "author"],
-    ["context", "Search relays are indexes whose ranking policies can differ."]
+    ["context", "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will be able to derive your nsec, read all your encrypted data and sign events as you."],
+    ["alt", "This is a highlight created in https://primal.net iOS application"],
+    ["a", "30023:1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139:nostr-quantum-preparation"],
+    ["p", "1ec454734dcbf6fe54901ce25c0c7c6bca5edd89443416761fadc321d38df139", "", "mention"]
   ],
-  "content": "ranking policies can differ",
-  "sig": "55555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555"
+  "content": "Quantum computers will break secp256k1 which nostr relies on for its public private key pair. This means that given an npub, a quantum computer will b",
+  "sig": "219f3c1e572d1a087d667dc0d3a5443c77c0db3a5d42ce4e630604901ac63d2c879a86269d81e220bb77fd48b1579adafc333075e53c6eb0a108791fdd4a1622"
 }
 ```
 


### PR DESCRIPTION
The English #34 correction (PR #127) replaced placeholder hex in the two NIP Deep Dive JSON examples with real relay-recovered events, but the 9 translations on `translate/2026-08-05` still carried the old repeated-hex placeholder id/pubkey/sig blocks (PR #126 predates the English fix).

This updates both JSON examples verbatim across de/es/fr/it/ja/ko/nl/pt/zh:
- NIP-50 search example → real kind 1 (`2943d6b4…`, an actual NIP-50 search-relay result)
- NIP-84 highlight example → real kind 9802 (`0d57c07c…`, a Primal iOS highlight with a/p/context/alt tags and a valid Schnorr sig)

It also rewrites the German and Dutch framing prose that still admitted the events were placeholders ('Platzhalter' / 'placeholders'), and restores the English file to origin/main (already fixed there).

Verified: `scripts/check_newsletter_event_examples.py` → PASS on all 10 files; both real event ids and sigs confirmed embedded verbatim in every language.