### PR TITLE
Cut placeholder JSON event blocks from #32 NIP-42/43 deep dive

### DIFF
--- a/content/de/newsletters/2026-07-22-newsletter.md
+++ b/content/de/newsletters/2026-07-22-newsletter.md
@@ -151,22 +151,7 @@ Ein Relay zu betreiben, das nicht für alle offen ist, bedeutete früher, alles 
 
 [NIP-42](/de/topics/nip-42/) beantwortet eine Frage: Wer ist auf dieser Verbindung? Ein Relay, das Lese- oder Schreibzugriffe beschränken will, sendet beim Verbindungsaufbau oder bei Bedarf, wenn eine Anfrage Authentifizierung erfordert, eine `AUTH`-Nachricht mit einem Challenge-String. Ein Client antwortet mit seiner eigenen `AUTH`-Nachricht, die ein signiertes ephemeres Event des kind 22242 enthält, und das Relay antwortet mit einer `OK`-Nachricht, genau als wäre das Auth-Event ein gewöhnlicher Schreibvorgang. Die Authentifizierung gilt dann für die Dauer der Verbindung. Eine Folge von `AUTH`-Nachrichten kann mehrere pubkeys auf einer Verbindung authentifizieren.
 
-Das signierte Auth-Event sieht so aus:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+Das signierte Auth-Event ist ein kompaktes Objekt aus `pubkey`, `created_at`, kind 22242, einem `relay`-Tag, einem `challenge`-Tag, leerem `content` und einer `sig` über der Event-`id`. Da kind 22242 ephemer ist — Relays dürfen es niemals speichern oder broadcasten — existiert kein veröffentlichtes Beispiel, das sich einbetten ließe; der Feldweg unten deckt ab, was es trägt.
 
 Der `pubkey` ist die zu beweisende Identität, da das Relay die `sig` über der Event-`id` gegen ihn verifiziert. Kind 22242 liegt im ephemeren Bereich: Das Event ist ein Berechtigungsnachweis auf Verbindungsebene, den Relays niemals speichern oder an andere Clients broadcasten dürfen. Ein `relay`-Tag bindet die Signatur an eine Relay-URL, sodass ein erbeutetes Auth-Event nicht gegen ein anderes Relay wiedergegeben werden kann, während das `challenge`-Tag es an den konkreten Challenge-String dieser Verbindung bindet und eine spätere Wiedergabe verhindert. Sein `created_at` muss nahe an der aktuellen Zeit liegen, innerhalb eines Fensters von ungefähr zehn Minuten, sodass ein veraltetes Auth-Event von selbst abläuft. Ein leeres `content`-Feld bestätigt, dass nichts veröffentlicht wird.
 
@@ -176,22 +161,7 @@ Die Spec definiert außerdem zwei maschinenlesbare Präfixe, die Gating für Cli
 
 [NIP-43](/de/topics/nip-43/) beantwortet die Folgefrage: Jetzt, wo das Relay weiß, wer du bist — was darfst du tun? Wo NIP-42 ein Handshake auf einer bestehenden Verbindung ist, ist NIP-43 ein Satz veröffentlichter Events, die den Mitgliedschaftsstatus beschreiben und Nutzern erlauben, dessen Änderung zu beantragen. Auf der Relay-Seite listet ein kind-13534-Event, signiert vom Pubkey im `self`-Feld des [NIP-11](/de/topics/nip-11/)-Dokuments des Relays, ein `member`-Tag pro Pubkey, mit optionalen Rollenargumenten, die auf als kind 33534 veröffentlichte Rollendefinitionen zeigen. Kind 8000 kündigt das Hinzufügen eines Mitglieds an und kind 8001 das Entfernen, beide signiert vom selben Relay-Schlüssel mit einem `p`-Tag für das betroffene Mitglied. Auf der Nutzerseite ist kind 28934 eine Beitrittsanfrage, die einen Einladungscode in einem `claim`-Tag trägt, kind 28935 ist ein ephemeres Invite-Code-Event, das das Relay on-the-fly erzeugt, wenn ein Nutzer einen Claim anfordert, und kind 28936 ist eine Austrittsanfrage.
 
-Eine Beitrittsanfrage sieht so aus:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Eine Beitrittsanfrage ist ein ähnlich kleines Objekt, und bislang implementiert kein öffentliches Relay NIP-43, sodass es kein echtes kind-28934-Event zum Einbetten gibt; der Feldweg unten deckt ab, was es trägt.
 
 Der `pubkey` ist der Nutzer, der um Aufnahme bittet, und kind 28934 markiert das Event als Beitrittsanfrage. Sein `-`-Tag ist der [NIP-70](/de/topics/nip-70/)-Protected-Event-Marker und weist Relays an, das Event nur von seinem Autor anzunehmen. Ein `claim`-Tag trägt den out-of-band erhaltenen Einladungscode, und `created_at` muss innerhalb weniger Minuten um die aktuelle Zeit liegen, damit eine alte Anfrage nicht wiedergegeben werden kann. Relays beantworten den Claim mit einer `OK`-Nachricht, verwenden das NIP-42-Präfix `restricted:` für Fehler wie einen abgelaufenen oder ungültigen Code, aktualisieren die kind:13534-Liste und können ein kind:8000-Add-Member-Event veröffentlichen. Mitgliedschaft wird bewusst nicht aus einem einzelnen Event abgeleitet: Die Spec behandelt die vom Relay signierte Liste als eine Eingabe, und ein Client sollte sowohl kind:13534 des Relays als auch die eigenen Events des Mitglieds heranziehen, um dessen aktuellen Mitgliedschaftsstatus zu bestimmen. Clients dürfen Join-, Invite- oder Leave-Anfragen nur an Relays senden, die dieses NIP im Abschnitt `supported_nips` ihres NIP-11-Dokuments ausweisen; [nostreams PR #676](https://github.com/Cameri/nostream/pull/676) ist die Relay-seitige Maschinerie, die aus diesen Request-Kinds tatsächliche Mitgliedschaftsänderungen macht.
 

--- a/content/en/newsletters/2026-07-22-newsletter.md
+++ b/content/en/newsletters/2026-07-22-newsletter.md
@@ -149,22 +149,7 @@ Running a relay that is not open to everyone used to mean inventing everything y
 
 [NIP-42](/en/topics/nip-42/) answers one question: who is on this connection? A relay that wants to gate reads or writes sends an `AUTH` message carrying a challenge string, at connect time or on demand when a request needs authentication. A client replies with its own `AUTH` message containing a signed ephemeral event, kind 22242, and the relay answers with an `OK` message exactly as if the auth event were an ordinary write. Authentication then holds for the duration of the connection. A sequence of `AUTH` messages can authenticate several pubkeys on one connection.
 
-Here is the signed auth event:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+The signed auth event is a compact object: a `pubkey`, a `created_at`, kind 22242, a `relay` tag, a `challenge` tag, empty `content`, and a `sig` over the event `id`. Because kind 22242 is ephemeral — relays must never store or broadcast it — no published example exists to embed; the field walk below covers what it carries.
 
 The `pubkey` is the identity being proved, since the relay verifies the `sig` over the event `id` against it. Kind 22242 sits in the ephemeral range: the event is a connection-level credential, and relays must never store it or broadcast it to other clients. A `relay` tag binds the signature to one relay URL so a captured auth event cannot be replayed against a different relay, while the `challenge` tag binds it to the specific challenge string issued on this connection and blocks later replay. Its `created_at` must be close to the current time, within roughly a ten-minute window, so a stale auth event expires on its own. An empty `content` field confirms that nothing is being published.
 
@@ -174,22 +159,7 @@ The spec also defines two machine-readable prefixes that make gating visible to 
 
 [NIP-43](/en/topics/nip-43/) answers the follow-up question: now that the relay knows who you are, what are you allowed to do? Where NIP-42 is a handshake on a live connection, NIP-43 is a set of published events that describe membership state and let users ask to change it. On the relay side, a kind 13534 event, signed by the pubkey in the relay's [NIP-11](/en/topics/nip-11/) `self` field, lists one `member` tag per pubkey, with optional role arguments pointing at role definitions published as kind 33534. Kind 8000 announces a member being added and kind 8001 announces a removal, both signed by the same relay key with a `p` tag for the affected member. On the user side, kind 28934 is a join request carrying an invite code in a `claim` tag, kind 28935 is an ephemeral invite-code event the relay generates on the fly when a user requests a claim, and kind 28936 is a leave request.
 
-A join request looks like this:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+A join request is a similarly small object, and no public relay implements NIP-43 yet, so there is no real kind 28934 event to embed; the field walk below covers what it carries.
 
 The `pubkey` is the user asking for admission, and kind 28934 marks the event as a join request. Its `-` tag is the [NIP-70](/en/topics/nip-70/) protected-event marker, telling relays to accept the event only from its author. A `claim` tag carries the invite code obtained out of band, and `created_at` must be now, plus or minus a few minutes, so an old request cannot be replayed. Relays answer the claim with an `OK` message, reuse the NIP-42 `restricted:` prefix for failures such as an expired or invalid code, update the kind 13534 list, and may publish a kind 8000 add-member event. Membership is deliberately not derived from a single event: the spec treats the relay-signed list as one input, and a client deciding whether someone is currently a member should consult both the relay's kind 13534 and the member's own events. Clients must only send join, invite, or leave requests to relays that advertise this NIP in the `supported_nips` section of their NIP-11 document, and [nostream's PR #676](https://github.com/Cameri/nostream/pull/676) is the relay-side machinery that turns those request kinds into actual membership changes.
 

--- a/content/es/newsletters/2026-07-22-newsletter.md
+++ b/content/es/newsletters/2026-07-22-newsletter.md
@@ -150,22 +150,7 @@ Operar un relay que no está abierto a todos solía significar inventarlo todo u
 
 [NIP-42](/es/topics/nip-42/) responde una pregunta: ¿quién está en esta conexión? Un relay que quiere restringir lecturas o escrituras envía un mensaje `AUTH` con una cadena de desafío, al conectarse o bajo demanda cuando una solicitud necesita autenticación. El cliente responde con su propio mensaje `AUTH` que contiene un evento efímero firmado, kind 22242, y el relay contesta con un mensaje `OK` exactamente como si el evento de autenticación fuera una escritura ordinaria. La sesión autenticada se mantiene entonces durante la conexión, y un cliente puede autenticar varios pubkeys en una conexión con una secuencia de mensajes `AUTH`, cada uno de los cuales el relay trata como autenticado.
 
-El evento de autenticación firmado tiene este aspecto:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+El evento de autenticación firmado es un objeto compacto: un `pubkey`, un `created_at`, kind 22242, una etiqueta `relay`, una etiqueta `challenge`, un `content` vacío y una `sig` sobre el `id` del evento. Como kind 22242 es efímero —los relays nunca deben almacenarlo ni retransmitirlo— no existe ningún ejemplo publicado que incrustar; el recorrido por los campos de abajo cubre lo que contiene.
 
 El `pubkey` es la identidad que se está probando, ya que el relay verifica la `sig` sobre el `id` del evento contra él. El `kind` 22242 se sitúa en el rango efímero: el evento es una credencial a nivel de conexión, y los relays nunca deben almacenarlo ni difundirlo a otros clientes. La etiqueta `relay` vincula la firma a una URL de relay para que un evento de autenticación capturado no pueda reproducirse contra otro relay, y la etiqueta `challenge` lo vincula a la cadena de desafío concreta que el relay emitió en esta conexión, bloqueando la reproducción de una autenticación capturada en una conexión posterior. El `created_at` debe estar cerca de la hora actual, dentro de una ventana de unos diez minutos, de modo que un evento de autenticación viejo expire por sí solo. El campo `content` está vacío; no se publica nada.
 
@@ -175,22 +160,7 @@ La spec también define dos prefijos legibles por máquina que hacen visible la 
 
 [NIP-43](/es/topics/nip-43/) responde la pregunta siguiente: ahora que el relay sabe quién eres, ¿qué puedes hacer? Donde NIP-42 es un handshake en una conexión viva, NIP-43 es un conjunto de eventos publicados que describen el estado de membresía y permiten a los usuarios pedir cambiarlo. En el lado del relay, un evento kind 13534, firmado por el pubkey del campo `self` del documento [NIP-11](/es/topics/nip-11/) del relay, lista una etiqueta `member` por pubkey, con argumentos de rol opcionales que apuntan a definiciones de rol publicadas como kind 33534. El kind 8000 anuncia la incorporación de un miembro y el kind 8001 anuncia una baja, ambos firmados por la misma clave del relay con una etiqueta `p` para el miembro afectado. En el lado del usuario, el kind 28934 es una solicitud de unión que lleva un código de invitación en una etiqueta `claim`, el kind 28935 es un evento efímero de código de invitación que el relay genera al vuelo cuando un usuario solicita un claim, y el kind 28936 es una solicitud de salida.
 
-Una solicitud de unión tiene este aspecto:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Una solicitud de unión es un objeto igualmente pequeño, y todavía ningún relay público implementa NIP-43, por lo que no hay ningún evento kind 28934 real que incrustar; el recorrido por los campos de abajo cubre lo que contiene.
 
 El `pubkey` es el usuario que pide admisión, y el kind 28934 marca el evento como solicitud de unión. La etiqueta `-` es el marcador de evento protegido [NIP-70](/es/topics/nip-70/), que indica a los relays que no acepten este evento de nadie salvo de su autor. La etiqueta `claim` lleva el código de invitación que el usuario obtuvo fuera de banda, y `created_at` debe ser ahora, más o menos unos minutos, de modo que una solicitud vieja no pueda reproducirse. El relay responde al claim con un mensaje `OK`, reutilizando el prefijo `restricted:` de NIP-42 para fallos como un código expirado o inválido, y debería entonces actualizar su lista kind 13534 y puede publicar un evento kind 8000 de incorporación de miembro. La membresía deliberadamente no se deriva de un único evento: la spec dice que la lista firmada por el relay no debería considerarse exhaustiva ni autoritativa, y un cliente que decida si alguien es actualmente miembro debería consultar tanto el kind 13534 del relay como los propios eventos del miembro. Los clientes solo deben enviar solicitudes de unión, invitación o salida a relays que anuncien este NIP en la sección `supported_nips` de su documento NIP-11, y el [PR #676 de nostream](https://github.com/Cameri/nostream/pull/676) es la maquinaria del lado del relay que convierte esos kinds de solicitud en cambios reales de membresía.
 

--- a/content/fr/newsletters/2026-07-22-newsletter.md
+++ b/content/fr/newsletters/2026-07-22-newsletter.md
@@ -149,22 +149,7 @@ Faire tourner un relay qui n'est pas ouvert à tous signifiait autrefois tout in
 
 [NIP-42](/fr/topics/nip-42/) répond à une question : qui est sur cette connexion ? Un relay qui veut contrôler les lectures ou les écritures envoie un message `AUTH` portant une chaîne de défi, au moment de la connexion ou à la demande quand une requête nécessite une authentification. Le client répond avec son propre message `AUTH` contenant un event éphémère signé, kind 22242, et le relay répond avec un message `OK` exactement comme si l'event d'authentification était une écriture ordinaire. L'authentification reste ensuite valable pendant toute la durée de la connexion. Une séquence de messages `AUTH` peut authentifier plusieurs pubkeys sur une même connexion.
 
-L'event d'authentification signé ressemble à ceci :
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+L'event d'authentification signé est un objet compact : un `pubkey`, un `created_at`, kind 22242, un tag `relay`, un tag `challenge`, un `content` vide et une `sig` sur l'`id` de l'event. kind 22242 étant éphémère — les relais ne doivent jamais le stocker ni le diffuser — aucun exemple publié n'existe à intégrer ; le tour des champs ci-dessous couvre ce qu'il contient.
 
 Le `pubkey` est l'identité qui est prouvée, puisque le relay vérifie la `sig` sur l'`id` de l'event par rapport à lui. Le `kind` 22242 se situe dans la plage éphémère : l'event est un justificatif au niveau de la connexion, et les relays ne doivent jamais le stocker ni le diffuser à d'autres clients. Le tag `relay` lie la signature à une URL de relay afin qu'un event d'authentification capturé ne puisse pas être rejoué contre un relay différent, et le tag `challenge` le lie à la chaîne de défi spécifique que le relay a émise sur cette connexion, bloquant le rejeu d'une authentification capturée sur une connexion ultérieure. Le `created_at` doit être proche de l'heure actuelle, dans une fenêtre d'environ dix minutes, de sorte qu'un event d'authentification périmé expire de lui-même. Le champ `content` est vide ; rien n'est publié.
 
@@ -174,22 +159,7 @@ La spécification définit aussi deux préfixes lisibles par machine qui rendent
 
 [NIP-43](/fr/topics/nip-43/) répond à la question suivante : maintenant que le relay sait qui vous êtes, qu'êtes-vous autorisé à faire ? Là où NIP-42 est une poignée de main sur une connexion active, NIP-43 est un ensemble d'events publiés qui décrivent l'état d'appartenance et permettent aux utilisateurs de demander à le changer. Côté relay, un event kind 13534, signé par le pubkey du champ `self` du [NIP-11](/fr/topics/nip-11/) du relay, liste un tag `member` par pubkey, avec des arguments de rôle optionnels pointant vers des définitions de rôles publiées en kind 33534. Kind 8000 annonce l'ajout d'un membre et kind 8001 annonce un retrait, tous deux signés par la même clé de relay avec un tag `p` pour le membre concerné. Côté utilisateur, kind 28934 est une demande d'adhésion portant un code d'invitation dans un tag `claim`, kind 28935 est un event de code d'invitation éphémère que le relay génère à la volée quand un utilisateur demande un claim, et kind 28936 est une demande de départ.
 
-Une demande d'adhésion ressemble à ceci :
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Une demande d'adhésion est un objet tout aussi petit, et aucun relais public n'implémente encore NIP-43, donc il n'existe aucun event kind 28934 réel à intégrer ; le tour des champs ci-dessous couvre ce qu'il contient.
 
 Le `pubkey` est l'utilisateur qui demande l'admission, et kind 28934 marque l'event comme une demande d'adhésion. Son tag `-` est le marqueur d'event protégé de [NIP-70](/fr/topics/nip-70/), indiquant aux relays de n'accepter l'event que de son auteur. Un tag `claim` porte le code d'invitation obtenu hors bande, et `created_at` doit correspondre à l'heure actuelle, à quelques minutes près, afin qu'une ancienne demande ne puisse pas être rejouée. Les relays répondent à la demande avec un message `OK`, réutilisent le préfixe `restricted:` de NIP-42 pour les échecs tels qu'un code expiré ou invalide, mettent à jour la liste kind 13534 et peuvent publier un event kind 8000 d'ajout de membre. L'appartenance n'est volontairement pas déduite d'un seul event : la spécification considère la liste signée par le relay comme une source parmi d'autres, et un client qui détermine si une personne est membre doit consulter à la fois le kind 13534 du relay et les propres events du membre. Les clients ne doivent envoyer de demandes d'adhésion, d'invitation ou de départ qu'aux relays qui annoncent ce NIP dans la section `supported_nips` de leur document NIP-11, et la [PR #676 de nostream](https://github.com/Cameri/nostream/pull/676) fournit le mécanisme côté relay qui transforme ces kinds de requêtes en changements d'appartenance réels.
 

--- a/content/it/newsletters/2026-07-22-newsletter.md
+++ b/content/it/newsletters/2026-07-22-newsletter.md
@@ -150,22 +150,7 @@ Gestire un relay non aperto a tutti un tempo significava inventare tutto da soli
 
 [NIP-42](/it/topics/nip-42/) risponde a una domanda: chi si trova su questa connessione? Un relay che vuole limitare le letture o le scritture invia un messaggio `AUTH` contenente una stringa di sfida, al momento della connessione o quando una richiesta richiede l'autenticazione. Un client risponde con un proprio messaggio `AUTH` contenente un evento effimero firmato, kind 22242, e il relay risponde con un messaggio `OK` come se l'evento di autenticazione fosse una normale scrittura. L'autenticazione resta valida per la durata della connessione. Una sequenza di messaggi `AUTH` può autenticare più pubkey sulla stessa connessione.
 
-Ecco l'evento di autenticazione firmato:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+L'evento di autenticazione firmato è un oggetto compatto: un `pubkey`, un `created_at`, kind 22242, un tag `relay`, un tag `challenge`, un `content` vuoto e una `sig` sull'`id` dell'evento. Poiché kind 22242 è effimero — i relay non devono mai memorizzarlo né ritrasmetterlo — non esiste alcun esempio pubblicato da incorporare; la panoramica dei campi qui sotto copre ciò che contiene.
 
 Il `pubkey` è l'identità di cui si dimostra il possesso, poiché il relay verifica la `sig` sull'`id` dell'evento rispetto a quella chiave. Il kind 22242 rientra nell'intervallo effimero: l'evento è una credenziale a livello di connessione e i relay non devono mai archiviarlo né trasmetterlo ad altri client. Un tag `relay` lega la firma all'URL di un relay, così un evento di autenticazione intercettato non può essere riutilizzato contro un relay diverso, mentre il tag `challenge` lo lega alla specifica stringa di sfida emessa su questa connessione e blocca i riutilizzi successivi. Il suo `created_at` deve essere vicino all'ora corrente, entro una finestra di circa dieci minuti, così un evento di autenticazione obsoleto scade da solo. Il campo `content` vuoto conferma che non viene pubblicato nulla.
 
@@ -175,22 +160,7 @@ La specifica definisce anche due prefissi leggibili dalle macchine che rendono v
 
 [NIP-43](/it/topics/nip-43/) risponde alla domanda successiva: ora che il relay sa chi sei, cosa ti è permesso fare? Dove NIP-42 è un handshake su una connessione attiva, NIP-43 è un insieme di eventi pubblicati che descrivono lo stato di appartenenza e consentono agli utenti di chiedere di cambiarlo. Sul lato relay, un evento kind 13534, firmato dal pubkey nel campo `self` del documento [NIP-11](/it/topics/nip-11/) del relay, elenca un tag `member` per pubkey, con argomenti di ruolo opzionali che puntano a definizioni di ruolo pubblicate come kind 33534. Il kind 8000 annuncia l'aggiunta di un membro e il kind 8001 annuncia una rimozione, entrambi firmati dalla stessa chiave del relay con un tag `p` per il membro interessato. Sul lato utente, il kind 28934 è una richiesta di adesione che trasporta un codice di invito in un tag `claim`, il kind 28935 è un evento effimero con codice di invito che il relay genera al volo quando un utente richiede un claim, e il kind 28936 è una richiesta di uscita.
 
-Una richiesta di adesione ha questo aspetto:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Una richiesta di adesione è un oggetto altrettanto piccolo, e nessun relay pubblico implementa ancora NIP-43, quindi non c'è alcun evento kind 28934 reale da incorporare; la panoramica dei campi qui sotto copre ciò che contiene.
 
 Il `pubkey` è l'utente che chiede l'ammissione e il kind 28934 identifica l'evento come richiesta di adesione. Il suo tag `-` è il marcatore di evento protetto di [NIP-70](/it/topics/nip-70/), che indica ai relay di accettare l'evento soltanto dal suo autore. Un tag `claim` contiene il codice di invito ottenuto fuori banda e `created_at` deve corrispondere all'ora corrente, con uno scarto di pochi minuti, così una vecchia richiesta non può essere riutilizzata. I relay rispondono al claim con un messaggio `OK`, riutilizzano il prefisso `restricted:` di NIP-42 per errori come un codice scaduto o non valido, aggiornano la lista kind 13534 e possono pubblicare un evento kind 8000 di aggiunta del membro. L'appartenenza non deriva deliberatamente da un singolo evento: la specifica considera la lista firmata dal relay come uno degli elementi disponibili e un client che deve stabilire se qualcuno è attualmente membro dovrebbe consultare sia il kind 13534 del relay sia gli eventi del membro. I client devono inviare richieste di adesione, invito o uscita soltanto ai relay che dichiarano questo NIP nella sezione `supported_nips` del proprio documento NIP-11, mentre il [PR #676 di nostream](https://github.com/Cameri/nostream/pull/676) fornisce il meccanismo lato relay che trasforma questi kind di richiesta in effettive modifiche dell'appartenenza.
 

--- a/content/ja/newsletters/2026-07-22-newsletter.md
+++ b/content/ja/newsletters/2026-07-22-newsletter.md
@@ -149,22 +149,7 @@ TypeScript relay 実装の [nostream](https://github.com/Cameri/nostream) は今
 
 [NIP-42](/ja/topics/nip-42/) は 1 つの問いに答えます。この接続にいるのは誰か? 読み取りや書き込みをゲートしたい relay は、接続時またはリクエストが認証を必要とする際にオンデマンドで、チャレンジ文字列を運ぶ `AUTH` メッセージを送信します。クライアントは署名済みの一時 event、kind 22242 を含む自身の `AUTH` メッセージで応答し、relay は認証 event が通常の書き込みであるかのように正確に `OK` メッセージで応えます。認証されたセッションは接続の間保持され、クライアントは一連の `AUTH` メッセージで 1 つの接続上で複数の pubkey を認証でき、それぞれを relay は認証済みとして扱います。
 
-署名済みの認証 event は次のようになります:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+署名済みの認証 event はコンパクトなオブジェクトです: `pubkey`、`created_at`、kind 22242、`relay` タグ、`challenge` タグ、空の `content`、そして event の `id` に対する `sig` です。kind 22242 はエフェメラル — リレーは保存もブロードキャストもしてはならない — ため、埋め込める公開済みの例は存在しません。以下のフィールド解説がその内容をカバーします。
 
 `pubkey` は証明されるアイデンティティで、relay は event `id` に対する `sig` をそれに照らして検証します。kind 22242 は一時的な範囲にあり、この event は接続レベルのクレデンシャルであり、relay はそれを保存したり他のクライアントにブロードキャストしたりしてはいけません。`relay` tag は署名を 1 つの relay URL に束縛し、キャプチャされた認証 event が別の relay に対してリプレイされるのを防ぎ、`challenge` tag はそれをこの接続で relay が発行した特定のチャレンジ文字列に束縛し、後の接続でのキャプチャされた認証のリプレイをブロックします。`created_at` は現在時刻に近く、おおよそ 10 分のウィンドウ内でなければならず、古い認証 event は自然に失効します。`content` フィールドは空で、何も公開されていません。
 
@@ -174,22 +159,7 @@ TypeScript relay 実装の [nostream](https://github.com/Cameri/nostream) は今
 
 [NIP-43](/ja/topics/nip-43/) は続く問いに答えます。relay があなたが誰かを知った今、あなたは何を許されているか? NIP-42 がライブ接続上のハンドシェイクであるのに対し、NIP-43 はメンバーシップ状態を記述し、ユーザーがその変更を求めることを可能にする公開 event のセットです。relay 側では、relay の [NIP-11](/ja/topics/nip-11/) `self` フィールドの pubkey によって署名された kind 13534 event が、pubkey ごとに 1 つの `member` tag をリストし、オプションのロール引数は kind 33534 として公開されたロール定義を指します。kind 8000 はメンバーの追加を、kind 8001 は削除を告知し、どちらも影響を受けるメンバーの `p` tag とともに同じ relay 鍵で署名されます。ユーザー側では、kind 28934 は `claim` tag に招待コードを運ぶ参加リクエスト、kind 28935 はユーザーがクレームを要求したときに relay がその場で生成する一時的な招待コード event、kind 28936 は脱退リクエストです。
 
-参加リクエストは次のようになります:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+参加リクエストも同様に小さなオブジェクトですが、NIP-43 を実装する公開リレーはまだないため、埋め込める実際の kind 28934 event は存在しません。以下のフィールド解説がその内容をカバーします。
 
 `pubkey` は参加を求めるユーザーで、kind 28934 がこの event を参加リクエストとして示します。`-` tag は [NIP-70](/ja/topics/nip-70/) の保護された event マーカーで、relay にこの event を作者以外から受け付けないよう伝えます。`claim` tag はユーザーが帯域外で入手した招待コードを運び、`created_at` は現在時刻から数分以内でなければならず、古いリクエストはリプレイできません。relay はクレームに `OK` メッセージで応答し、期限切れや無効なコードなどの失敗には NIP-42 の `restricted:` プレフィックスを再利用し、その後 kind 13534 リストを更新し、kind 8000 のメンバー追加 event を公開することができます。メンバーシップは意図的に単一の event から導出されません。仕様は relay 署名のリストを網羅的または権威的と見なすべきではないと述べ、誰かが現在メンバーかどうかを判断するクライアントは relay の kind 13534 とメンバー自身の event の両方を参照すべきです。クライアントは参加、招待、脱退リクエストを、NIP-11 ドキュメントの `supported_nips` セクションでこの NIP を広告する relay にのみ送信しなければならず、[nostream の PR #676](https://github.com/Cameri/nostream/pull/676) はこれらのリクエスト kind を実際のメンバーシップ変更に変える relay 側の仕組みです。
 

--- a/content/ko/newsletters/2026-07-22-newsletter.md
+++ b/content/ko/newsletters/2026-07-22-newsletter.md
@@ -149,22 +149,7 @@ TypeScript relay 구현인 [nostream](https://github.com/Cameri/nostream)은 이
 
 [NIP-42](/ko/topics/nip-42/)는 한 가지 질문에 답합니다. 이 연결에는 누가 있는가? 읽기나 쓰기를 제한하려는 relay는 연결 시점이나 요청에 인증이 필요할 때 challenge 문자열을 담은 `AUTH` 메시지를 보냅니다. 클라이언트는 서명된 임시 이벤트 kind 22242를 담은 자체 `AUTH` 메시지로 응답하고, relay는 auth 이벤트가 일반 쓰기인 것처럼 `OK` 메시지로 답합니다. 인증은 연결이 유지되는 동안 유효합니다. 여러 `AUTH` 메시지를 차례로 보내면 하나의 연결에서 여러 pubkey를 인증할 수 있습니다.
 
-서명된 auth 이벤트는 다음과 같습니다:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+서명된 auth 이벤트는 `pubkey`, `created_at`, kind 22242, `relay` 태그, `challenge` 태그, 빈 `content`, 그리고 이벤트 `id`에 대한 `sig`로 이루어진 컴팩트한 객체입니다. kind 22242는 임시(ephemeral) 이벤트이므로 — 릴리이는 이를 저장하거나 브로드캐스트해서는 안 됩니다 — 포함할 수 있는 공개된 예시가 존재하지 않습니다. 아래의 필드 설명이 그 내용을 다룹니다.
 
 relay가 이벤트 `id`의 `sig`를 `pubkey`로 검증하므로, `pubkey`가 증명 대상 신원입니다. Kind 22242는 임시 범위에 속합니다. 이 이벤트는 연결 수준 자격 증명이므로 relay는 저장하거나 다른 클라이언트에 broadcast해서는 안 됩니다. `relay` tag는 서명을 하나의 relay URL에 결합해 가로챈 auth 이벤트가 다른 relay에서 재사용되지 않게 합니다. `challenge` tag는 현재 연결에서 발급된 특정 challenge 문자열에 결합해 이후 재사용을 막습니다. `created_at`은 약 10분 범위 안에서 현재 시각과 가까워야 하므로 오래된 auth 이벤트는 자동으로 만료됩니다. 빈 `content` 필드는 아무 내용도 발행하지 않음을 확인합니다.
 
@@ -174,22 +159,7 @@ relay가 이벤트 `id`의 `sig`를 `pubkey`로 검증하므로, `pubkey`가 증
 
 [NIP-43](/ko/topics/nip-43/)은 후속 질문에 답합니다. 이제 relay가 당신이 누구인지 알았으니, 당신은 무엇을 할 수 있는가? NIP-42가 라이브 연결에서의 핸드셰이크라면, NIP-43은 멤버십 상태를 설명하고 사용자가 이를 변경하도록 요청할 수 있게 하는 발행된 이벤트의 집합입니다. relay 측에서, relay의 [NIP-11](/ko/topics/nip-11/) `self` 필드의 pubkey가 서명한 kind 13534 이벤트는 pubkey당 하나의 `member` tag를 나열하며, kind 33534로 발행된 역할 정의를 가리키는 선택적 역할 인수가 있습니다. Kind 8000은 멤버가 추가되는 것을 알리고 kind 8001은 제거를 알리며, 둘 다 영향받는 멤버를 위한 `p` tag와 함께 같은 relay 키로 서명됩니다. 사용자 측에서, kind 28934는 `claim` tag에 초대 코드를 담은 가입 요청이고, kind 28935는 사용자가 claim을 요청할 때 relay가 즉석에서 생성하는 일회성 초대 코드 이벤트이며, kind 28936은 탈퇴 요청입니다.
 
-가입 요청은 다음과 같습니다:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+가입 요청 역시 비슷하게 작은 객체이며, 아직 NIP-43을 구현한 공개 릴리이가 없어 포함할 수 있는 실제 kind 28934 이벤트가 없습니다. 아래의 필드 설명이 그 내용을 다룹니다.
 
 `pubkey`는 가입을 요청하는 사용자이고, kind 28934는 이벤트를 가입 요청으로 표시합니다. `-` tag는 [NIP-70](/ko/topics/nip-70/) 보호 이벤트 marker로, relay가 작성자에게서 직접 받은 이벤트만 수락하게 합니다. `claim` tag에는 별도 경로로 받은 초대 코드가 들어갑니다. `created_at`은 현재 시각에서 몇 분 이내여야 하므로 오래된 요청은 재사용할 수 없습니다. relay는 `OK` 메시지로 claim에 응답하고, 만료되거나 잘못된 코드 같은 실패에는 NIP-42의 `restricted:` 접두사를 재사용하며, kind 13534 리스트를 갱신하고 kind 8000 add-member 이벤트를 발행할 수 있습니다. 멤버십은 의도적으로 단일 이벤트에서 파생하지 않습니다. 명세는 relay가 서명한 리스트를 하나의 입력으로 취급하며, 현재 멤버 여부를 판단하는 클라이언트는 relay의 kind 13534와 멤버 본인의 이벤트를 모두 확인해야 합니다. 클라이언트는 NIP-11 문서의 `supported_nips` 섹션에서 이 NIP를 지원한다고 알리는 relay에만 가입, 초대, 탈퇴 요청을 보내야 합니다. [nostream의 PR #676](https://github.com/Cameri/nostream/pull/676)은 이러한 request kind를 실제 멤버십 변경으로 처리하는 relay 측 로직입니다.
 

--- a/content/nl/newsletters/2026-07-22-newsletter.md
+++ b/content/nl/newsletters/2026-07-22-newsletter.md
@@ -152,22 +152,7 @@ Een relay draaien die niet voor iedereen open is betekende vroeger alles zelf ui
 
 [NIP-42](/nl/topics/nip-42/) beantwoordt één vraag: wie zit er op deze verbinding? Een relay dat lees- of schrijfrechten wil begrenzen stuurt een `AUTH`-bericht met een challenge-string, bij het verbinden of op verzoek wanneer een aanvraag authenticatie vereist. Een client antwoordt met zijn eigen `AUTH`-bericht met een ondertekend efemeer event, kind 22242, en het relay antwoordt met een `OK`-bericht precies alsof het auth-event een gewone schrijfbewerking was. De authenticatie geldt vervolgens voor de duur van de verbinding. Een reeks `AUTH`-berichten kan meerdere pubkeys op één verbinding authenticeren.
 
-Hier is het ondertekende auth-event:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+Het ondertekende auth-event is een compact object: een `pubkey`, een `created_at`, kind 22242, een `relay`-tag, een `challenge`-tag, lege `content` en een `sig` over de event-`id`. Omdat kind 22242 ephemeral is — relays mogen het nooit opslaan of uitzenden — bestaat er geen gepubliceerd voorbeeld om in te bedden; de veldoorloop hieronder dekt wat het bevat.
 
 De `pubkey` is de identiteit die wordt bewezen, aangezien het relay de `sig` over het event-`id` ertegen verifieert. Kind 22242 zit in het efemere bereik: het event is een credential op verbindingsniveau, en relays mogen het nooit opslaan of naar andere clients uitzenden. Een `relay`-tag bindt de handtekening aan één relay-URL zodat een onderschept auth-event niet tegen een ander relay kan worden afgespeeld, terwijl de `challenge`-tag hem bindt aan de specifieke challenge-string die op deze verbinding is uitgegeven en later afspelen blokkeert. De `created_at` moet dicht bij de huidige tijd liggen, binnen een venster van ongeveer tien minuten, zodat een verouderd auth-event vanzelf verloopt. Een leeg `content`-veld bevestigt dat niets wordt gepubliceerd.
 
@@ -177,22 +162,7 @@ De specificatie definieert ook twee machineleesbare voorvoegsels die begrenzing 
 
 [NIP-43](/nl/topics/nip-43/) beantwoordt de vervolgvraag: nu het relay weet wie je bent, wat mag je doen? Waar NIP-42 een handshake op een live verbinding is, is NIP-43 een set gepubliceerde events die de lidmaatschapsstatus beschrijven en gebruikers laten vragen die te wijzigen. Aan de relaykant toont een kind 13534-event, ondertekend door de pubkey in het `self`-veld van het [NIP-11](/nl/topics/nip-11/)-document van het relay, één `member`-tag per pubkey, met optionele rolargumenten die verwijzen naar roldefinities gepubliceerd als kind 33534. Kind 8000 kondigt een toegevoegd lid aan en kind 8001 kondigt een verwijdering aan, beide ondertekend door dezelfde relaysleutel met een `p`-tag voor het betrokken lid. Aan de gebruikerskant is kind 28934 een deelnameverzoek dat een uitnodigingscode draagt in een `claim`-tag, is kind 28935 een efemeer uitnodigingscode-event dat het relay ter plaatse genereert wanneer een gebruiker een claim aanvraagt, en is kind 28936 een vertrekverzoek.
 
-Een deelnameverzoek ziet er zo uit:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Een deelnameverzoek is een vergelijkbaar klein object, en nog geen enkele publieke relay implementeert NIP-43, dus er is geen echt kind 28934-event om in te bedden; de veldoorloop hieronder dekt wat het bevat.
 
 De `pubkey` is de gebruiker die om toelating vraagt, en kind 28934 markeert het event als deelnameverzoek. De `-`-tag is de [NIP-70](/nl/topics/nip-70/)-markering voor beschermde events, die relays vertelt dit event van niemand anders dan de auteur te accepteren. De `claim`-tag draagt de uitnodigingscode die de gebruiker out-of-band heeft verkregen, en `created_at` moet nu zijn, plus of min een paar minuten, zodat een oud verzoek niet kan worden afgespeeld. Het relay beantwoordt de claim met een `OK`-bericht, waarbij het het NIP-42-`restricted:`-voorvoegsel hergebruikt voor mislukkingen zoals een verlopen of ongeldige code, en zou vervolgens zijn kind 13534-lijst moeten bijwerken en kan een kind 8000-lid-toevoegingsevent publiceren. Lidmaatschap wordt bewust niet uit één enkel event afgeleid: de specificatie zegt dat de door het relay ondertekende lijst niet als exhaustief of gezaghebbend moet worden beschouwd, en een client die bepaalt of iemand momenteel lid is zou zowel het kind 13534 van het relay als de eigen events van het lid moeten raadplegen. Clients mogen deelname-, uitnodigings- of vertrekverzoeken alleen sturen naar relays die deze NIP adverteren in de `supported_nips`-sectie van hun NIP-11-document, en [nostreams PR #676](https://github.com/Cameri/nostream/pull/676) is de relay-side-machinerie die die verzoek-kinds omzet in daadwerkelijke lidmaatschapswijzigingen.
 

--- a/content/pt/newsletters/2026-07-22-newsletter.md
+++ b/content/pt/newsletters/2026-07-22-newsletter.md
@@ -149,22 +149,7 @@ Rodar um relay que não é aberto a todos costumava significar inventar tudo por
 
 O [NIP-42](/pt/topics/nip-42/) responde a uma pergunta: quem está nesta conexão? Um relay que quer restringir leituras ou escritas envia uma mensagem `AUTH` carregando uma string de desafio, no momento da conexão ou sob demanda quando uma requisição precisa de autenticação. Um cliente responde com sua própria mensagem `AUTH` contendo um evento efêmero assinado, kind 22242, e o relay responde com uma mensagem `OK` exatamente como se o evento de autenticação fosse uma escrita comum. A autenticação permanece válida durante a conexão. Uma sequência de mensagens `AUTH` pode autenticar vários pubkeys em uma única conexão.
 
-Este é o evento de autenticação assinado:
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+O evento de autenticação assinado é um objeto compacto: um `pubkey`, um `created_at`, kind 22242, uma tag `relay`, uma tag `challenge`, `content` vazio e uma `sig` sobre o `id` do evento. Como kind 22242 é efêmero — os relays nunca devem armazená-lo nem retransmiti-lo — não existe nenhum exemplo publicado para incorporar; o percurso pelos campos abaixo cobre o que ele contém.
 
 O `pubkey` é a identidade sendo provada, já que o relay verifica a `sig` sobre o `id` do evento em relação a ele. O kind 22242 está na faixa efêmera: o evento é uma credencial no nível da conexão, e os relays nunca devem armazená-lo nem transmiti-lo a outros clientes. Uma tag `relay` vincula a assinatura a uma URL de relay para que um evento de autenticação capturado não possa ser reutilizado contra um relay diferente, enquanto a tag `challenge` o vincula à string de desafio específica emitida nesta conexão e impede reutilizações posteriores. O `created_at` deve estar próximo da hora atual, dentro de uma janela de aproximadamente dez minutos, para que um evento de autenticação antigo expire por conta própria. Um campo `content` vazio confirma que nada está sendo publicado.
 
@@ -174,22 +159,7 @@ A especificação também define dois prefixos legíveis por máquina que tornam
 
 O [NIP-43](/pt/topics/nip-43/) responde à pergunta seguinte: agora que o relay sabe quem você é, o que você tem permissão de fazer? Onde o NIP-42 é um handshake em uma conexão ativa, o NIP-43 é um conjunto de eventos publicados que descrevem o estado de associação e permitem que usuários peçam para alterá-lo. Do lado do relay, um evento kind 13534, assinado pelo pubkey no campo `self` do [NIP-11](/pt/topics/nip-11/) do relay, lista uma tag `member` por pubkey, com argumentos de papel opcionais apontando para definições de papéis publicadas como kind 33534. Kind 8000 anuncia um membro sendo adicionado e kind 8001 anuncia uma remoção, ambos assinados pela mesma chave do relay com uma tag `p` para o membro afetado. Do lado do usuário, kind 28934 é uma requisição de entrada carregando um código de convite em uma tag `claim`, kind 28935 é um evento efêmero de código de convite que o relay gera na hora quando um usuário solicita um claim, e kind 28936 é uma requisição de saída.
 
-Uma requisição de entrada se parece com isto:
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+Uma requisição de entrada é um objeto igualmente pequeno, e nenhum relay público ainda implementa o NIP-43, portanto não há nenhum evento kind 28934 real para incorporar; o percurso pelos campos abaixo cobre o que ele contém.
 
 O `pubkey` é o usuário pedindo admissão, e kind 28934 marca o evento como uma requisição de entrada. Sua tag `-` é o marcador de evento protegido do [NIP-70](/pt/topics/nip-70/), orientando os relays a aceitar o evento apenas de seu autor. Uma tag `claim` carrega o código de convite obtido fora de banda, e `created_at` deve corresponder ao momento atual, com alguns minutos de tolerância, para que uma solicitação antiga não possa ser reutilizada. Os relays respondem ao claim com uma mensagem `OK`, reutilizam o prefixo `restricted:` do NIP-42 para falhas como um código expirado ou inválido, atualizam a lista kind 13534 e podem publicar um evento kind 8000 de adição de membro. A associação deliberadamente não é derivada de um único evento: a especificação trata a lista assinada pelo relay como uma das entradas, e um cliente que decide se alguém é membro no momento deve consultar tanto o kind 13534 do relay quanto os eventos do próprio membro. Os clientes só devem enviar solicitações de entrada, convite ou saída a relays que anunciem este NIP na seção `supported_nips` de seu documento NIP-11, e o [PR #676 do nostream](https://github.com/Cameri/nostream/pull/676) é o mecanismo do lado do relay que transforma esses kinds de solicitação em mudanças reais de associação.
 

--- a/content/zh/newsletters/2026-07-22-newsletter.md
+++ b/content/zh/newsletters/2026-07-22-newsletter.md
@@ -150,22 +150,7 @@ TypeScript relay 实现 [nostream](https://github.com/Cameri/nostream) 本周合
 
 [NIP-42](/zh/topics/nip-42/) 回答一个问题：这条连接上是谁？想要门控读取或写入的 relay 会发送一条携带 challenge 字符串的 `AUTH` 消息，可以在连接建立时发送，也可以在请求需要认证时按需发送。客户端以自己的 `AUTH` 消息回复，其中包含一个签名的临时 event，kind 22242，relay 则以 `OK` 消息作答，就如同这个认证 event 是一次普通写入。认证在连接存续期间保持有效。一系列 `AUTH` 消息可以在一条连接上认证多个 pubkey。
 
-签名的认证 event 如下所示：
-
-```json
-{
-  "id": "4ef6f2c0b1a84c9a3d0f9c58e2a1b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
-  "pubkey": "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5",
-  "created_at": 1753195800,
-  "kind": 22242,
-  "tags": [
-    ["relay", "wss://relay.example.com/"],
-    ["challenge", "challengestringhere"]
-  ],
-  "content": "",
-  "sig": "8b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1"
-}
-```
+签名的认证 event 是一个紧凑的对象：一个 `pubkey`、一个 `created_at`、kind 22242、一个 `relay` 标签、一个 `challenge` 标签、空的 `content`，以及对该 event 的 `id` 的 `sig`。由于 kind 22242 是临时的——中继绝不能存储或广播它——因此不存在可嵌入的已发布示例；下面的字段说明涵盖了它所携带的内容。
 
 `pubkey` 是被证明的身份，因为 relay 会根据它验证 event `id` 上的 `sig`。`kind` 22242 位于临时范围：该 event 是连接级凭据，relay 绝不能存储它或将其广播给其他客户端。`relay` tag 将签名绑定到一个 relay URL，使被截获的认证 event 无法对另一个 relay 重放；`challenge` tag 将其绑定到 relay 在这条连接上签发的特定挑战字符串，阻止被截获的认证在之后的连接上重放。`created_at` 必须接近当前时间，大致在十分钟窗口之内，因此陈旧的认证 event 会自行过期。`content` 字段为空；没有任何内容被发布。
 
@@ -175,22 +160,7 @@ TypeScript relay 实现 [nostream](https://github.com/Cameri/nostream) 本周合
 
 [NIP-43](/zh/topics/nip-43/) 回答后续问题：既然 relay 知道你是谁了，你被允许做什么？NIP-42 是在一条活跃连接上的握手，NIP-43 则是一组描述成员资格状态并让用户请求变更它的已发布 event。在 relay 一侧，由 relay 的 [NIP-11](/zh/topics/nip-11/) `self` 字段中的 pubkey 签名的 kind 13534 event，为每个 pubkey 列出一个 `member` tag，并可选地带有指向以 kind 33534 发布的角色定义的角色参数。Kind 8000 宣告一名成员被加入，kind 8001 宣告一次移除，两者都由同一把 relay 密钥签名，并以 `p` tag 标明受影响的成员。在用户一侧，kind 28934 是携带 `claim` tag 中邀请码的加入请求，kind 28935 是用户请求 claim 时 relay 即时生成的临时邀请码 event，kind 28936 是退出请求。
 
-一个加入请求如下所示：
-
-```json
-{
-  "id": "9f0e1d2c3b4a59687a6b5c4d3e2f1098a7b6c5d4e3f2019a8b7c6d5e4f3021a9b8",
-  "pubkey": "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958",
-  "created_at": 1753195900,
-  "kind": 28934,
-  "tags": [
-    ["-"],
-    ["claim", "invite-code-from-operator"]
-  ],
-  "content": "",
-  "sig": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2"
-}
-```
+加入请求也是一个类似的小对象，而且目前还没有任何公共中继实现 NIP-43，因此没有可嵌入的真实 kind 28934 event；下面的字段说明涵盖了它所携带的内容。
 
 `pubkey` 是请求准入的用户，kind 28934 将该 event 标记为加入请求。`-` tag 是 [NIP-70](/zh/topics/nip-70/) 受保护 event 标记，告诉 relay 只接受作者本人提交的该 event。`claim` tag 承载在带外获得的邀请码，`created_at` 必须是现在（前后几分钟之内），因此旧请求无法被重放。relay 以 `OK` 消息回应 claim，对过期或无效邀请码等失败情况复用 NIP-42 的 `restricted:` 前缀，更新 kind 13534 列表，并可发布 kind 8000 的加入成员 event。成员资格被刻意设计为不从单个 event 推导：规范将 relay 签名的列表视为一项输入，客户端在判断某人当前是否是成员时应同时参考 relay 的 kind 13534 和成员自己的 event。客户端只能向在其 NIP-11 文档的 `supported_nips` 部分宣告支持该 NIP 的 relay 发送加入、邀请或退出请求，而 [nostream 的 PR #676](https://github.com/Cameri/nostream/pull/676) 正是将这些请求 kind 转化为实际成员资格变更的 relay 侧机制。
 


### PR DESCRIPTION
Issue #32 (2026-07-22) shipped two fabricated JSON event examples with sequential-hex signatures — the same defect class as #34. A relay-reality audit (multi-agent review) confirmed neither kind has a real instance to embed: kind 22242 (NIP-42 auth) is ephemeral and relays must not store/broadcast it (zero on 6 relays); kind 28934 (NIP-43 join request) returned zero across 14 public relays — NIP-43 is not yet deployed. Per NewsletterAgent's rule ('if none found after genuine search, cut the block — never ship placeholders'), both blocks are cut and the field walk folded into the surrounding prose, which already explained every field. Covers the English file AND all 9 translations (the placeholders also shipped merged in PR #114). `check_newsletter_event_examples.py` + style checker PASS on all 10 files; production build clean.