### PR TITLE
Add translations for Newsletter #35 and topic pages

### DIFF
--- a/content/de/newsletters/2026-08-12-newsletter.md
+++ b/content/de/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Post-Quanten-Identitätstools, stärkere verschlüsselte Nachrichten und Signierung, portable Community-Einstellungen und Protokollarbeit über NIPs und Concord hinweg."
+---
+
+Willkommen zurück bei [Nostr Compass](https://nostrcompass.org), eurem wöchentlichen Wegweiser für Nostr.
+
+**Diese Woche:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) fügt Post-Quanten-Schlüssel und optional geschützte Nachrichten neben bestehenden Nostr-Identitäten hinzu. [Divine](https://github.com/divinevideo/divine-mobile) verschärft Kontoisolation, Validierung privater Nachrichten und Veröffentlichungsbestätigung; [MDK](https://github.com/marmot-protocol/mdk) stärkt Konvergenz und Wiederherstellung verschlüsselter Gruppen; und [Amber](https://github.com/greenart7c3/Amber) macht gruppierte Signierentscheidungen explizit. Releases verbessern Wallet-Verbindungen, verschlüsselten Chat, soziale Discovery, Gerätesynchronisation und Remote-Signing, während die Protokollarbeit Identität und verschlüsselte Communities abdeckt. Die Deep Dives erklären authentifizierte Löschanfragen und dezentrale Meldungen.
+
+## Top-Storys
+
+### nostr-wot-extension 0.4.0 fügt Post-Quanten-Schlüssel neben einer Nostr-Identität hinzu
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) ist eine Browser-Erweiterung zum Verwalten von Nostr-Identitäten und zum Signieren. Konten, die aus einem 24-Wort-Seed erstellt wurden, können nun ML-KEM-1024-Verschlüsselungs- und ML-DSA-87-Signierschlüssel neben ihrem bestehenden Nostr-Schlüssel ableiten. Ein Ein-Klick-Ablauf veröffentlicht eine Attestierung des Kinds `10203`, die den Nostr-Public-Key an beide Post-Quanten-Public-Keys bindet und einen ML-DSA-Besitznachweis enthält. Konten, die aus einer 12-Wort-Mnemonik, einem bloßen `nsec`, einem Remote-Signer oder einem schreibgeschützten Schlüssel importiert wurden, können den Ableitungsablauf nicht nutzen, und die Erweiterung erklärt diese Einschränkung in der Kontenansicht.
+
+Das Release fügt außerdem optionale Post-Quanten-Direktnachrichten hinzu. Es kombiniert das ML-KEM-gemeinsame Geheimnis mit dem bestehenden [NIP-44-Verschlüsselungs-Gesprächsschlüssel](https://github.com/nostr-protocol/nips/blob/master/44.md) über HKDF und behält die normalen NIP-59-Metadaten-verbergenden Gift-Wrap-Schichten für die Relay-Zustellung bei. Die Verschlüsselung fällt nach der Opt-in-Entscheidung eines Empfängers nie stillschweigend zurück, während die Entschlüsselung automatisch den passenden Pfad wählt. Das schützt den neuen Nachrichtenpfad vor späterer Wiederherstellung eines heutigen Nostr-Private-Keys, ersetzt aber keine secp256k1-Event-Signaturen; das Release überlässt diese größere Migration ausdrücklich künftiger Abstimmung mit Relays und Clients.
+
+### Divine Mobile 1.0.19 verschärft Konten, private Nachrichten und Veröffentlichung
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) ist ein mobiler Kurzvideo-Client, der Videos über Nostr veröffentlicht und abruft. Sein Kontowechsler baut jede angemeldete Identität nun um einen kontobezogenen Container herum auf, und eine Veröffentlichungskorrektur verhindert, dass ein Video unter dem falschen Konto gesendet wird. Relay-Veröffentlichungspfade warten nun auf eine `OK`-Antwort mit expliziter Erfolgssemantik, während ein Relay-`CLOSED`-Frame seine eigene ausstehende Abfrage beenden kann, statt die Anfrage hängen zu lassen.
+
+Die [Behandlung privater Nachrichten](https://github.com/divinevideo/divine-mobile/pull/6368) lehnt nicht authentifizierte Rumor-Felder und unsignierte Seals ab, stellt vier Fälle fehlender Nachrichten wieder her und leitet Gruppenunterhaltungen vollständig gefolgter Teilnehmer in den Posteingang. Das Release bewahrt außerdem die Tags adressierbarer Video-Events, wenn Listen aktualisiert werden, und verarbeitet beobachtete Löschanfragen, sodass entfernte Videos aus dem lokalen Zustand verschwinden. Diese Änderungen folgen der Arbeit an pro-Relay-Abfrage-Timeouts aus der letzten Woche, verlagern den Fokus aber von Abrufisolation zu Identitätsgrenzen, Nachrichtenvalidierung und Veröffentlichungsbestätigung.
+
+### MDK 0.9.11 härtet Marmot-Gruppenkonvergenz und -wiederherstellung ab
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) ist ein Rust-Entwicklungskit für Marmot, ein verschlüsseltes Gruppennachrichtenprotokoll über Nostr. Das Release baut ein größeres Konvergenz- und Wiederherstellungssystem um die Gruppenzustandsmaschine: veraltete Konvergenzdurchläufe öffnen wieder am aktuellen Gruppentip, eingehende Capability-Projektionen committen atomar, zurückgestellte Nachrichten erhalten begrenzte Lebensdauern über Neustarts hinweg, und commit-adressierte Checkpoints helfen, eigene Commit-Forks einer Identität wiederherzustellen. Nicht stabile Sends können in die Warteschlange gelegt und wiederhergestellt werden, während ein Epochen-Stall-Pfad zu Backfill eskaliert und gesendete Nachrichten Konvergenzarbeit überleben.
+
+[Speicher- und Host-Integrationen](https://github.com/marmot-protocol/mdk/pull/1201) erhalten eine parallele Härtung. MDK löscht beschnittene SQLite-Projektionen sicher, nullt importierte Private Keys, NIP-49-verschlüsselte Schlüssel-Export-Zwischenstände und OpenMLS-Serialisierungspuffer und redigiert Gruppenbildschlüssel aus Debug-Ausgaben. Kontenimport kann nach Unterbrechung fortgesetzt werden, iOS- und Android-Privatspeicherpfade sind repariert, und Hosts können Speicher vor dem Suspendieren explizit schließen. Neue leichtgewichtige Roster- und lokale Mitgliedschaftsprojektionen reduzieren, was Anwendungen lesen müssen, während der Hermes-Connector mehrere agentengenerierte Bilder als ein Marmot-Album zustellen kann.
+
+### Nostria 4.1.67 erweitert die Verwaltung verschlüsselter Communities
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) ist ein Web- und Desktop-Social-Client für Nostr. Er baut auf den experimentellen NIP-29-relay-verwalteten Gruppen und Concord-verschlüsselten Communities auf, die in 4.1.53 eingeführt wurden, und fügt Community-Auflösung, Icon- und Banner-Verwaltung, verschlüsselte Foto-Uploads mit komprimierten Vorschauen, einen vollständigen Reaktions-Picker und ein Dual-Pane-Layout hinzu, das eine Community geöffnet hält, während der Nutzer Notizen oder Artikel liest. Das Release fügt außerdem Thread-Nachrichten und einen kombinierten Hub für öffentliche, Gruppen- und private Chats hinzu.
+
+### Amber 6.4.0 macht jede gruppierte Signierentscheidung explizit
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) ist ein Android-Signer, der Nostr-Private-Keys von den Signaturen anfordernden Anwendungen trennt. Sein neu gestalteter Multi-Request-Bildschirm bietet Approve- und Deny-Steuerungen für jede Anfrage und jede Gruppe und ersetzt den bisherigen Auswahl-und-Bestätigen-Ablauf. Abgelehnte Anfragen, die über Ambers relay-vermittelte Bunker-Schnittstelle gesendet werden, erhalten nun ordentliche Fehlerantworten, sodass der anfragende Client Ablehnung von einem hängenden Signer unterscheiden kann.
+
+[Ambers getaggte Quelle](https://github.com/greenart7c3/Amber/tree/v6.4.0) fügt außerdem lokalisierte, menschenlesbare Labels für 113 weitere Event-Kinds in jeder ausgelieferten Locale hinzu. Die Ergänzungen umfassen Concord-Gruppen-Events, NIP-51-Git-Repository-Lesezeichen und NIP-53-Raum-Präsenz-Events und geben Nutzern mehr Kontext über unbekannte Daten, bevor sie eine Signatur genehmigen. Eine Concurrent-Map-Absicherung behebt außerdem einen Relay-Abonnement-Absturz, der eine `NegativeArraySizeException` auslösen konnte.
+
+### Safebox Acorn trennt eine portable Wiederherstellungskomponente von der Web-App
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) ist eine eigenständige Python-Komponente und Command-Line-Schnittstelle zum Schutz nutzerkontrollierter Schlüssel, Mittel und Datensätze mit Nostr-gestütztem Zustand. Das Auslagern von Acorn aus der breiteren Safebox-Webanwendung lässt ein anderes Python-Projekt die Runtime installieren und deren Schlüssel-, Nostr-Profil-, Relay-, Record-, Cashu-, Lightning- und kryptografische Helfer nutzen, ohne die Web-Oberfläche mitzunehmen. Ihre aktuellen Record-Schutz-Primitive können einen frischen 256-Bit-Schlüssel erzeugen, einen aus separat gelieferter Entropie ableiten und den exakten Schlüssel als checksummte 24-Wort-Wiederherstellungsphrase kodieren.
+
+Der [Wiederherstellungs- und Kontinuitätsleitfaden](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) des Projekts rahmt Acorn als austauschbare Protokollkomponente innerhalb einer Haushalts- oder Community-Safebox. Das Design hält verschlüsselten Zustand über ein lokales Relay und unabhängige Replikas verfügbar, sodass Wiederherstellung nicht von einem Gerät, einer Anwendung, einem Relay, einer Mint oder einem Dienstanbieter abhängt. Die Dokumentation ist vorsichtig mit der gegenwärtigen Grenze: Verschlüsselung geschützter Records ist noch in Planung, daher sollten Anwendungen Records nicht vom neuen Record-Schutz-Schlüssel abhängig machen, bis dieses Profil implementiert und geprüft wurde.
+
+
+## Releases
+
+### Mostro Core 0.14.2 ändert den verschlüsselten Chat-Umschlag
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) ist die Rust-Bibliothek gemeinsamer Typen und Peer-to-Peer-Funktionen, die vom Mostro-Exchange-Daemon und seinen Clients genutzt wird. [Version 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) ersetzt gift-wrapped Chat-Nachrichten durch Kind-14-Umschläge, die separate Gesprächsverschlüsselungs- und Signierschlüssel aus dem gemeinsamen Geheimnis der Peers ableiten. Der neue Reader validiert Autor, Signatur, Empfänger, Zeitstempel und Inhaltsgröße, während Legacy-Gift-Wrap-Helfer verfügbar bleiben, damit Clients während der Migration beide Formate lesen können.
+
+### Mostro 0.18.1 startet einen Cashu-Escrow-Pfad und härtet den Daemon ab
+
+[Mostro](https://github.com/MostroP2P/mostro) ist ein Peer-to-Peer-Lightning-Exchange-Daemon, der Orders über Nostr koordiniert. [Version 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) legt die Grundlage für ein Cashu-Escrow-Backend, einschließlich Konfiguration, Datenbankhelfern, Mint-Integration, Startup-Verdrahtung und der ersten Lock-Aktion. Er kann außerdem Preise nutzen, die ein vertrauenswürdiger Node über Nostr ankündigt, und wirbt Proof-of-Work-Anforderungen für den Erstkontakt in seinem ersetzbaren Info-Event aus. Das Release aktualisiert seine Nostr-Abhängigkeit für einen NIP-44-Denial-of-Service-Fix, entfernt Private Keys aus Restore-Session-Logs, lehnt nicht autorisierte kooperative Stornierungsnachrichten ab, härtet LNURL-Abrufe gegen serverseitige Request-Forgery und Hänger ab, validiert Auszahlungs-Invoices und stellt Hold-Invoice-Abonnements nach einem Neustart wieder her.
+
+### LaWallet NWC 2.3.0 fügt Nostr-Benachrichtigungen und Zap-Receipts hinzu
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) ist eine Open-Source-Lightning-Address-Plattform, die Wallets über [Nostr Wallet Connect](/de/topics/nip-47/) verbindet. [Version 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) lässt jede Wallet empfangene und weitergeleitete Benachrichtigungen als konfigurierbare Nostr-Events senden, einschließlich eines Empfänger-`p`-Tags, ausgewählter Relays, templatisierter Inhalte und optionaler [NIP-44](/de/topics/nip-44/)-Verschlüsselung; Wiederholungen nutzen dieselbe signierte Event-ID. Er akzeptiert außerdem Zap-Anfragen und veröffentlicht nach der Abwicklung signierte [NIP-57](/de/topics/nip-57/)-Kind-9735-Receipts, während eine neue Address-Capability-Ansicht zeigt, ob die aufgelöste Adresse NIP-05, NIP-57 und verwandte Lightning-Address-Protokolle unterstützt.
+
+### nostr-double-ratchet TypeScript 0.0.166 bindet öffentliche Einladungen an Session-Keys
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) stellt TypeScript- und Rust-Primitive für Ende-zu-Ende-verschlüsselte Direkt- und Gruppennachrichten über Nostr-Relays bereit. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) verlangt, dass eine Einladungsantwort den Besitz ihres Session-Keys nachweist, und verhindert so, dass eine wiederverwendbare öffentliche Einladung eine Nostr-Identität an die Session einer anderen Partei bindet. Das Release lehnt außerdem fehlerhafte Rumor-Felder ab und verschärft die Payload-Validierung; bestehende Sessions funktionieren weiter, aber ein aktualisierter Einladender lehnt beweislose Antworten älterer Eingeladener ab.
+
+### cln-nip47 0.2.0 erweitert und isoliert NWC-Anfragen
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) ist ein Core-Lightning-Plugin, das einen Node Wallets über [Nostr Wallet Connect](/de/topics/nip-47/) bereitstellt. [Version 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) fügt NWC-Methoden zum Erstellen, Stornieren und Abwickeln von Hold-Invoices plus eine `hold_invoice_accepted`-Benachrichtigung hinzu und wirbt die Methodenmenge aus, die der verbundene Node tatsächlich unterstützt. Transaktionslisten-Antworten enden nun bei 500 Einträgen und etwa 128 kB, Anfrage-Events werden nach Event-ID dedupliziert, und die fehlgeschlagene Benachrichtigung eines Clients verhindert nicht mehr die Zustellung an andere Clients. Das Release entfernt außerdem die beiden Multi-Payment-Methoden, die nicht mehr Teil der NWC-Spezifikation sind.
+
+### ClipRelay 0.1.3 stellt Relay- und Signer-Verbindungen nach Leerlaufphasen wieder her
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) synchronisiert die Zwischenablage eines Nutzers zwischen Geräten über Nostr-Relays und verschlüsselt den Inhalt für dieselbe Identität mit [NIP-44](/de/topics/nip-44/). Die passenden [Desktop-](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3)- und [Android-](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3)-Releases in Version 0.1.3 fügen ein Textfeld hinzu, um getippten Text direkt in die Zwischenablage eines anderen Geräts zu senden. Sie testen außerdem die Lebendigkeit mit echten Relay-Roundtrips nach Leerlaufphasen, eskalieren von erneuter Abonnement bis zu Socket-Ersatz und einem neu aufgebauten Verbindungspool, während hängende [NIP-46](/de/topics/nip-46/)-Signer-Aufrufe nun time-outen und automatisch neu aufgebaut werden.
+
+### NoorNote 1.3.2 verlagert Artikel-Discovery in den Social Graph
+
+[NoorNote](https://github.com/77elements/noornote) ist ein Nostr-Client für Social Posts, verschlüsselte Nachrichten, Longform-Artikel und andere Event-Typen für Web, Desktop und Android. [Version 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) ersetzt seinen flachen globalen Artikel-Feed durch Discovery aus Kontakten ersten, zweiten und dritten Grades und gibt Lesern eine am Follow-Graph verwurzelte Artikel-Timeline. Er fasst außerdem Stöße wiedergegebener Direktnachrichten unbekannter Absender zu einer rollierenden Benachrichtigung zusammen, statt einen Stapel Toasts zu erzeugen, wenn Relay-Historie eintrifft.
+
+### Bray 2.4.0 fügt einen kompakten Remote-Signing-Dialekt hinzu
+
+[Bray](https://github.com/forgesworn/bray) ist ein Nostr-MCP-Server, der Software-Agenten und Menschen Werkzeuge für Relay-Zugriff, Identität, Veröffentlichung und Remote-Signing gibt. [Version 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) akzeptiert eine Signieranfrage, deren Event ein Objekt ist, sowie die von [NIP-46](/de/topics/nip-46/) genutzte stringifizierte Form, und fügt `sign_event_compact` hinzu, das nur Event-ID, Signatur, Public Key und Zeitstempel zurückgibt. Dieses kleinere Anfrage- und Antwortformat reduziert den Speicherverbrauch für ressourcenarme Hardware-Signer, während der Standard-`sign_event`-Ablauf unverändert bleibt und beide Dialekte eine Signatur über die ID des empfangenen Events erzeugen.
+
+
+## Neu entdeckt
+
+### Pact bringt gegenseitig zugestimmte Agent-Bindungen nach Nostr
+
+[Pact](https://github.com/bobodread876/pact), diese Woche neu entdeckt, ist eine frühe Beziehungsebene für Software-Agenten, aufgebaut auf MATE.md und einem NIP-BD-Transport-Entwurf. Seine signierten, gegenseitig zugestimmten Bindungen werden von den eigenen Schlüsseln der Agenten gehalten und können über Nostr veröffentlicht werden, während private Bindungen [NIP-59](/de/topics/nip-59/)-Gift-Wrapping nutzen. Das Monorepo umfasst einen MCP-Server, ein TypeScript-SDK, einen Command-Line-Client, einen selbst hostbaren Daemon und eine Web-Oberfläche. Seine jüngste Repository-Aktivität liegt vor dem wöchentlichen Fenster dieser Ausgabe, daher ist dies ein Discovery-Hinweis und kein Anspruch auf ein neues Release.
+
+
+## Unveröffentlichte Änderungen
+
+### nostrord hält Gruppen-Stummschaltung zwischen Geräten synchron
+
+[nostrord](https://github.com/nostrord/nostrord) ist ein plattformübergreifender Client für relay-verwaltete Communities. [PR #250](https://github.com/nostrord/nostrord/pull/250) speichert die Stummschaltungsentscheidungen eines Kontos pro Gruppe in einem selbst verschlüsselten [NIP-78](/de/topics/nip-78/)-Kind-`30078`-Event (anwendungsspezifische Daten), sodass eine auf einem Gerät getroffene Einstellung dem Nutzer auf ein anderes folgen kann, ohne die Gruppenliste dem Relay preiszugeben. Der ersetzbare Datensatz nutzt Neueste-Event-Reihenfolge, lauscht auf Live-Änderungen und rollt die Oberfläche zurück, wenn Signieren oder Veröffentlichen fehlschlägt, statt den lokalen Zustand desynchron zu lassen. Stummgeschaltete Gruppen tragen nicht mehr zu sichtbaren Ungelesen-Summen bei, behalten aber ihre Ungelesen-Position für den nächsten Besuch.
+
+### Amethyst schließt Concords Einladungs-Lebenszyklus ab
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) ist ein Android-Nostr-Client, dessen Unterstützung verschlüsselter Communities das Concord-Protokoll implementiert. [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) lässt Einladungslinks eine Community-Neugründung überleben, indem ihre Bundles an denselben adressierbaren Koordinaten neu ausgestellt werden, während eine Ban-Prüfung verhindert, dass ein entferntes Mitglied diesen Wiederherstellungspfad nutzt. Er implementiert außerdem die verschlüsselte CORD-05-Einladungsliste sowohl in der App als auch im `amy`-Command-Line-Client, fügt pro Link Widerrufs-Tombstones hinzu und verlangt Relay-Bestätigung, bevor der einzige gespeicherte Signierschlüssel gelöscht wird, der einen Link stilllegen kann. Dieselbe Arbeit gibt `amy` die Control-Key-Zustellung, Neugründung, Rekeying und Wiederherstellungspfad für gestrandete Mitglieder, die spätere Community-Epochen folgen müssen.
+
+### Buzz trägt das Erscheinungsbild jeder Community über Desktop und Mobile
+
+[Buzz](https://github.com/block/buzz) ist ein Nostr-basierter Community-Workspace mit Desktop- und Mobile-Clients. Gemergte Desktop-[PR #3653](https://github.com/block/buzz/pull/3653) und Mobile-[PR #3767](https://github.com/block/buzz/pull/3767) speichern Theme, Akzent und Systemmodus-Wahl jeder Community als verschlüsselten NIP-78-Datensatz auf dem Relay dieser Community. Beide Clients teilen dieselbe versionierte Payload und halten identitätsbezogene lokale Caches, sodass Community- oder Kontowechsel nicht das falsche Erscheinungsbild anwenden können, während das Relay nicht verfügbar ist. Ersatz-Reihenfolge, abgesicherte Schreibvorgänge und erneute Abonnement nach geschlossener Verbindung lassen die beiden Clients nach dem Wiederverbinden wieder konvergieren.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) folgte vor dem Issue-Cutoff mit einem Performance- und Zuverlässigkeitsdurchlauf. Er entfernt Regressionen nach 0.5.9, beschleunigt das Laden von Kanälen, begrenzt die anfängliche Timeline-Aufbewahrung, bündelt Read-State-Persistenz, bewahrt frische Kanal-Timelines und verhindert, dass der Relay-Ingest-Worker bei Reaktionen auf Projekt-Events abstürzt. Er fügt außerdem das Senden einer Thread-Nachricht an einen Kanal hinzu und grenzt die Desktop-Suche auf den beabsichtigten Umfang ein.
+
+
+## NIP-Updates und Protokoll-Spezifikationsarbeit
+
+### NIPs
+
+[NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435) ist eine offene Änderung an NIP-34, das Git-Repository-Zusammenarbeit über Nostr-Events standardisiert. Sie fügt einem Pull-Request-Event einen optionalen `b`-Tag hinzu, damit der Autor einen Zielbranch außerhalb des Repository-Defaults benennen kann. Der Vorschlag entspricht Unterstützung, die bereits in ngit und GitWorkshop implementiert ist, ist aber noch nicht in die Spezifikation aufgenommen.
+
+[NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434) ist ein offener Vorschlag für Post-Quanten-Identitätsschlüssel. Er leitet Post-Quanten-Verschlüsselungs- und Signierschlüssel neben dem bestehenden secp256k1-Schlüssel aus einem NIP-06-Mnemonik-Schlüsselableitungs-Seed ab und bindet die Public Keys dann mit einer Attestierung des Kinds `10203` an die Nostr-Identität. Der Entwurf beschränkt seinen Anspruch darauf, die Vertraulichkeit früherer Nachrichten zu schützen, falls secp256k1 später bricht; er ersetzt nicht die heutigen Event-Signaturen.
+
+[NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431) ist eine offene NIP-07-Änderung für Browser-Signer. Ein Client könnte den Public Key, den er erwartet, Signier- oder Verschlüsselungsanfragen anhängen und den Signer verpflichten, dieses Konto zu nutzen oder den Aufruf abzulehnen. Das würde verhindern, dass eine Seite stillschweigend unter einer anderen Identität weitermacht, nachdem der Nutzer im Signer das Konto gewechselt hat.
+
+[NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813) bleibt nach substantieller Arbeit im Fenster ein offener Double-Ratchet-Vorschlag. Er spezifiziert forward-secret verschlüsselte Unterhaltungen, deren Schlüssel sich mit Nachrichten weiterentwickeln, mit einer Implementierung, die bereits in der nostr-double-ratchet-Bibliothek und Iris verfügbar ist. Er ist weiterhin ein Entwurf, kein gemergtes NIP.
+
+[NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433) wurde im Fenster geöffnet und ohne Merge geschlossen. Er schlug vor, NIP-42-Relay-Fehler zu klären, sodass `auth-required` bedeuten würde, dass eine weitere Authentifizierung das Ergebnis ändern könnte, während `restricted` bedeuten würde, dass dies nicht möglich ist. Die Unterscheidung adressierte Verbindungen, die für einen Schlüssel authentifiziert waren, aber für einen anderen noch keine Autorisierung hatten; der geschlossene Status bedeutet, dass die Formulierung nicht in die Spezifikation aufgenommen wurde.
+
+[NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378), zuvor noch als Vorschlag behandelt, ist nun ohne Merge geschlossen. Seine vorgeschlagenen Agent-Passports, Discovery-, Task-, Marketplace-, Invoice- und Connection-Events bleiben daher außerhalb des NIP-Sets.
+
+[NIPs Commit 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) hat eine rein dokumentarische Korrektur an NIP-29 gemergt. Er fügt dem Gruppenmetadaten-Beispiel einen `previous`-Tag hinzu und zeigt, wie ein Ersatz-Event das Event identifizieren kann, das es ersetzt. Das klärt ein Beispiel und führt kein neues Protokollfeature ein.
+
+### Concord und CORDs
+
+[CORD PR #18](https://github.com/concord-protocol/concord/pull/18) würde verschlüsselte Community Lists über Kind-`33302`-Events sharden, das 50-Mitgliedschafts-Limit entfernen und ausgeschiedene Einträge beschneiden, um Relay-Limits einzuhalten. Zwei weitere offene Vorschläge fügen [private Mention-Locators](https://github.com/concord-protocol/concord/pull/16) und ein [Pause-Signal](https://github.com/concord-protocol/concord/pull/17) hinzu, das Chat aussetzt, ohne Nachrichten zu verwerfen.
+
+[CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15) wurde am 6. August gemergt und beschränkt Schreibvorgänge auf die Kontrollebene einer Community. Owner und Staff halten ein neues `control_root`-Signiergeheimnis, während alle Mitglieder den abgeleiteten Public Key und Read Key behalten, die Moderationszustand verifizieren und entschlüsseln. Der Write Key ist eine Spam-Barriere, kein Ersatz für die inneren Actor-Signaturen und Roster-Prüfungen, die Autorität etablieren.
+
+[CORD PR #12](https://github.com/concord-protocol/concord/pull/12), zuvor als offener Entwurf behandelt, ist nun ohne Merge geschlossen. Sein Kontrollebenen-Anteil wurde durch die engere gemergte CORD-02-Änderung oben ersetzt, während restricted-write-Kanäle und das übrige Entwurfsmaterial nicht in die Spezifikation aufgenommen wurden.
+
+## NIP Deep Dive
+
+### Event-Löschanfragen (NIP-09)
+
+[NIP-09](/de/topics/nip-09/), definiert in der [primären Spezifikation](https://github.com/nostr-protocol/nips/blob/master/09.md), gibt einem Event-Autor einen signierten Weg, Relays und Clients zu bitten, eines oder mehrere Events dieses Autors nicht mehr auszuliefern. Es löscht nicht jede Kopie. Es trägt die Absicht des Autors durch dasselbe Relay-Netzwerk, das das ursprüngliche Event verteilt hat.
+
+Die Anfrage ist ein gewöhnliches signiertes Kind-`5`-Event. Seine Tags enthalten eine oder mehrere `e`-Referenzen auf konkrete Event-IDs oder `a`-Referenzen auf adressierbare Event-Koordinaten, und die [NIP-09-Tag-Regeln](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) sagen, dass für jedes referenzierte Event-Kind ein `k`-Tag enthalten sein sollte. Der optionale `content` kann den Grund erklären. Für eine `a`-Referenz sollte ein Relay jede Version an dieser Koordinate entfernen, deren Zeitstempel nicht später als `created_at` der Anfrage ist, was verhindert, dass eine alte Löschanfrage eine spätere Ersetzung unterdrückt.
+
+[Autorschaft ist die Sicherheitsgrenze](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Ein Relay sollte ein referenziertes Event nur dann nicht mehr veröffentlichen, wenn sein `pubkey` dem `pubkey` der Löschanfrage entspricht, und ein Client muss diese Prüfung durchführen, bevor er ein Event ausblendet. Ein Relay besitzt das referenzierte Event möglicherweise nicht und kann die Beziehung daher bei Annahme der Anfrage nicht validieren, sodass Clients Relay-Annahme nicht als Beweis behandeln können, dass die Löschung autorisiert war. Die Spezifikation bittet Relays außerdem, die Kind-`5`-Anfrage aufzubewahren, weil ein anderer Client das ursprüngliche Event bereits halten und die Anfrage später sehen kann.
+
+Hier ist ein [signiertes Kind-`5`-Event](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+Löschung bleibt eine kooperative Policy, keine Widerrufung eines signierten Objekts. Ein Relay, Cache, Screenshot oder Offline-Client kann die ursprünglichen Bytes bewahren, und das Löschen der Kind-`5`-Anfrage selbst macht sie nicht rückgängig. Clients können das Ziel ausblenden, als disowned markieren oder den Anfragegrund anzeigen, sollten Nutzern aber sagen, dass universelle Löschung nicht garantiert werden kann. Das unterscheidet sich von [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md), wo ein `expiration`-Tag Relays bittet, ein Event nach einer beim Veröffentlichen gewählten Zeit nicht mehr zu speichern. NIP-09 behandelt eine spätere Autorenentscheidung und kann auf bereits verteilte Events zeigen.
+
+Aktuelle Implementierungen wenden diese Policy auf unterschiedlichen Ebenen an. [Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623) entfernt gelöschte Videos aus dem Event-Store des Clients, [strfry PR #251](https://github.com/hoytech/strfry/pull/251) erweitert gültige Löschanfragen auf Gift-Wrap-Empfänger, und [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) deklariert NIP-09-Unterstützung in seinem Client. [nostrords Gruppenclient](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) liefert einen weiteren aktuellen Implementierungspfad.
+
+### Meldungen (NIP-56)
+
+[NIP-56](/de/topics/nip-56/), definiert in der [primären Spezifikation](https://github.com/nostr-protocol/nips/blob/master/56.md), standardisiert eine signierte Meldung über ein Konto, ein Event oder einen referenzierten Blob. Sie trennt das Meldungssignal von der Moderationsentscheidung und erlaubt jedem Client oder Relay zu wählen, welchen Meldenden es vertraut und welche Reaktion zu seiner Policy passt.
+
+Eine Meldung nutzt Kind `1984` und muss das gemeldete Konto in einem `p`-Tag identifizieren. Die Meldung einer Notiz erfordert außerdem ein `e`-Tag für die Event-ID. Der dritte Wert des Tags trägt eine der spezifizierten Kategorien: `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation` oder `other`. Eine Meldung über einen Blob kann seinen Hash in einem `x`-Tag, ein `e`-Tag für das Event, das den Blob referenzierte, und optional ein `server`-Tag für einen Ort nutzen. Optionale `L`- und `l`-Tags aus [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) können ein namespaced Label hinzufügen, wenn die feste Kategorieliste nicht präzise genug ist.
+
+[Das Event beweist nur, dass ein Schlüssel eine Behauptung aufgestellt hat](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). Der gemeldete Inhalt wird nicht falsch, illegal oder entfernbar allein deshalb, weil ein gültiges Kind `1984` existiert, und ein offenes Relay kann anonyme Meldungen nicht sicher als Stimmen zählen. Die Spezifikation rät von automatischer Relay-Moderation ab, weil Meldungen leicht zu manipulieren sind, erlaubt Relay-Administratoren aber, auf Meldungen von Moderatoren zu reagieren, denen sie bereits vertrauen. Ein Client kann Meldungen stattdessen über den Social Graph eines Nutzers gewichten, etwa indem er Inhalte verwischt, nachdem mehrere vertrauenswürdige Kontakte dasselbe Konto markiert haben.
+
+Hier ist ein [signiertes Kind-`1984`-Event](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 und NIP-09 lösen unterschiedliche Probleme](https://github.com/nostr-protocol/nips/tree/master). Eine Kind-`1984`-Meldung kann das Konto oder Event einer anderen Person anvisieren, verleiht aber keine Löschbefugnis. Eine Kind-`5`-Anfrage drückt die Absicht des ursprünglichen Autors aus und ist nur gegen die eigenen Events dieses Autors gültig. Keines garantiert Entfernung: NIP-56 delegiert die Aktion bewusst an lokale Moderationspolicy, während NIP-09 davon abhängt, dass Relays und Clients eine authentifizierte Anfrage respektieren.
+
+Implementierungen legen diese Entscheidungen in unterschiedlichen Produkten offen. [Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591) korrigiert die Meldungszustellung in einem Kurzvideo-Client, [Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) liest Meldungen als begrenzten Kontext für Marketplace-Teilnehmer, und [nostrords NIP-56-Modul](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) veröffentlicht und verarbeitet Meldungs-Events. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) listet außerdem aktuelle NIP-56-Unterstützung.
+
+
+---
+
+Sende eine NIP-17-DM, um ein Projekt oder eine Nachricht über das [Nostr-Compass-Projekt](https://github.com/andotherstuff/nostr-compass) zu teilen.

--- a/content/es/newsletters/2026-08-12-newsletter.md
+++ b/content/es/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,203 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Herramientas de identidad poscuántica, mensajería cifrada y firma más robustas, ajustes comunitarios portátiles y trabajo de protocolo en NIPs y Concord."
+---
+
+Bienvenidos de nuevo a [Nostr Compass](https://nostrcompass.org), tu guía semanal de Nostr.
+
+**Esta semana:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) añade claves poscuánticas y mensajes protegidos opcionales junto a identidades de Nostr existentes. [Divine](https://github.com/divinevideo/divine-mobile) refuerza el aislamiento de cuentas, la validación de mensajes privados y la confirmación de publicación; [MDK](https://github.com/marmot-protocol/mdk) fortalece la convergencia y recuperación de grupos cifrados; y [Amber](https://github.com/greenart7c3/Amber) hace explícitas las decisiones de firma agrupadas. Las versiones mejoran las conexiones de monedero, el chat cifrado, el descubrimiento social, la sincronización entre dispositivos y la firma remota, mientras que el trabajo de protocolo abarca identidad y comunidades cifradas. Los análisis en profundidad explican las solicitudes de borrado autenticadas y las denuncias descentralizadas.
+
+## Historias Principales
+
+### nostr-wot-extension 0.4.0 añade claves poscuánticas junto a una identidad de Nostr
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) es una extensión de navegador para gestionar identidades de Nostr y firmar. Las cuentas creadas a partir de una semilla de 24 palabras pueden derivar ahora claves de cifrado ML-KEM-1024 y de firma ML-DSA-87 junto a su clave de Nostr existente. Un flujo de un clic publica una atestación de kind `10203` que vincula la pubkey de Nostr con ambas pubkeys poscuánticas e incluye una prueba de posesión ML-DSA. Las cuentas importadas desde un mnemónico de 12 palabras, un `nsec` sin envoltorio, un firmante remoto o una clave de solo lectura no pueden usar el flujo de derivación, y la extensión explica esa limitación en la vista de cuenta.
+
+La versión también añade mensajes directos poscuánticos opcionales. Combina el secreto compartido ML-KEM con la [clave de conversación cifrada de NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) existente mediante HKDF, y mantiene las capas normales de gift-wrap de [NIP-59](/es/topics/nip-59/) (envolturas que ocultan metadatos) para la entrega por relay. El cifrado nunca recurre silenciosamente a un camino anterior después de que el destinatario opte por el nuevo, mientras que el descifrado selecciona automáticamente la ruta adecuada. Esto protege la nueva ruta de mensajes frente a una recuperación posterior de una clave privada de Nostr actual, pero no sustituye las firmas de eventos secp256k1; la versión deja explícitamente esa migración mayor para una futura coordinación con relays y clientes.
+
+### Divine Mobile 1.0.19 refuerza cuentas, mensajes privados y publicación
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) es un cliente móvil de vídeo corto que publica y recupera vídeos a través de Nostr. Su selector de cuentas construye ahora cada identidad iniciada en torno a un contenedor con alcance de cuenta, y una corrección de publicación evita que un vídeo se envíe bajo la cuenta equivocada. Las rutas de publicación en relay esperan ahora una respuesta `OK` con semántica explícita de éxito, mientras que un frame `CLOSED` del relay puede terminar su propia consulta pendiente en lugar de dejar la petición colgada.
+
+[El manejo de mensajes privados](https://github.com/divinevideo/divine-mobile/pull/6368) rechaza campos rumor no autenticados y sellos sin firmar, restaura cuatro casos de mensajes faltantes y enruta las conversaciones de grupo de participantes totalmente seguidos hacia la bandeja de entrada. La versión también conserva las tags de eventos de vídeo direccionables cuando se actualizan las listas y consume las solicitudes de borrado observadas para que los vídeos eliminados desaparezcan del estado local. Esos cambios siguen al trabajo de tiempo de espera por consulta de relay cubierto la semana pasada, pero desplazan el foco del aislamiento de recuperación hacia los límites de identidad, la validación de mensajes y la confirmación de publicación.
+
+### MDK 0.9.11 refuerza la convergencia y recuperación de grupos Marmot
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) es un kit de desarrollo en Rust para Marmot, un protocolo de mensajería de grupo cifrada transportado sobre Nostr. La versión construye un sistema mayor de convergencia y recuperación en torno a la máquina de estados del grupo: los pasos de convergencia obsoletos se reabren en la punta actual del grupo, las proyecciones de capacidad entrantes se confirman de forma atómica, los mensajes diferidos reciben vidas acotadas entre reinicios, y los puntos de control direccionados por commit ayudan a recuperar las propias bifurcaciones de commit de una identidad. Los envíos no estables pueden encolarse y recuperarse, mientras que una ruta de estancamiento de época escala a backfill y los mensajes enviados sobreviven al trabajo de convergencia.
+
+[El almacenamiento y las integraciones de host](https://github.com/marmot-protocol/mdk/pull/1201) reciben un refuerzo paralelo. MDK elimina de forma segura las proyecciones SQLite podadas, pone a cero las claves privadas importadas, los intermedios de exportación de claves cifradas NIP-49 y los búferes de serialización OpenMLS, y redacta las claves de imagen de grupo de la salida de depuración. La importación de cuentas puede reanudarse tras una interrupción, se reparan las rutas de almacenamiento privado en iOS y Android, y los hosts pueden cerrar explícitamente el almacenamiento antes de la suspensión. Nuevas proyecciones ligeras de roster y membresía local reducen lo que las aplicaciones deben leer, mientras que el conector Hermes puede entregar varias imágenes generadas por agentes como un álbum Marmot.
+
+### Nostria 4.1.67 amplía la administración de comunidades cifradas
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) es un cliente social web y de escritorio para Nostr. Se apoya en los grupos gestionados por relays experimentales de [NIP-29](/es/topics/nip-29/) (grupos gestionados por relays) y las comunidades cifradas Concord introducidas en 4.1.53, añadiendo disolución de comunidad, administración de icono y banner, subidas de fotos cifradas con vistas previas comprimidas, un selector completo de reacciones y un diseño de doble panel que mantiene una comunidad abierta mientras el usuario lee notas o artículos. La versión también añade mensajería en hilos y un hub combinado para chats públicos, de grupo y privados.
+
+### Amber 6.4.0 hace explícita cada decisión de firma agrupada
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) es un firmante Android que mantiene las claves privadas de Nostr separadas de las aplicaciones que solicitan firmas. Su pantalla rediseñada de solicitudes múltiples ofrece controles Aprobar y Denegar para cada petición y cada grupo, sustituyendo al flujo anterior de selección y confirmación. Las solicitudes denegadas enviadas a través de la interfaz bunker mediada por relay de Amber reciben ahora respuestas de error adecuadas, de modo que el cliente solicitante puede distinguir un rechazo de un firmante estancado.
+
+[El código etiquetado de Amber](https://github.com/greenart7c3/Amber/tree/v6.4.0) también añade etiquetas localizadas y legibles para 113 kinds de evento más en cada locale publicado. Las adiciones incluyen eventos de grupo Concord, marcadores de repositorio Git de [NIP-51](/es/topics/nip-51/) (listas curadas de eventos) y eventos de presencia en sala de [NIP-53](/es/topics/nip-53/) (actividades en vivo), dando a los usuarios más contexto sobre datos desconocidos antes de aprobar una firma. Una guarda de mapa concurrente también corrige un fallo de suscripción a relay que podía producir un `NegativeArraySizeException`.
+
+
+### Safebox Acorn separa un componente de recuperación portátil de la aplicación web
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) es un componente Python independiente y una interfaz de línea de comandos para salvaguardar claves, fondos y registros controlados por el usuario con estado respaldado por Nostr. Extraer Acorn de la aplicación web Safebox más amplia permite a otro proyecto Python instalar el runtime y usar sus ayudantes de clave, perfil de Nostr, relay, registro, Cashu, Lightning y criptografía sin asumir la interfaz web. Sus primitivas actuales de protección de registros pueden generar una clave fresca de 256 bits, derivar una a partir de entropía suministrada por separado, y codificar la clave exacta como una frase de recuperación de 24 palabras con suma de comprobación.
+
+La [guía de recuperación y continuidad](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) del proyecto enmarca Acorn como el componente de protocolo reemplazable dentro de un Safebox doméstico o comunitario. El diseño mantiene el estado cifrado disponible a través de un relay local y réplicas independientes para que la recuperación no dependa de un solo dispositivo, aplicación, relay, mint o proveedor de servicio. La documentación es cuidadosa con el límite actual: el cifrado de registros protegidos sigue en diseño, por lo que las aplicaciones no deberían hacer depender los registros de la nueva clave de protección de registros hasta que ese perfil se haya implementado y revisado.
+
+
+## Versiones
+
+### Mostro Core 0.14.2 cambia el sobre del chat cifrado
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) es la biblioteca Rust de tipos compartidos y funciones entre pares usada por el daemon de intercambio Mostro y sus clientes. La [versión 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) sustituye los mensajes de chat gift-wrap por sobres de kind 14 que usan claves separadas de cifrado de conversación y de firma derivadas del secreto compartido de los pares. El nuevo lector valida el autor, la firma, el destinatario, la marca temporal y el tamaño del contenido, mientras que los ayudantes legacy de gift-wrap siguen disponibles para que los clientes puedan leer ambos formatos durante la migración.
+
+### Mostro 0.18.1 inicia una ruta de escrow Cashu y refuerza el daemon
+
+[Mostro](https://github.com/MostroP2P/mostro) es un daemon de intercambio Lightning entre pares que coordina órdenes a través de Nostr. La [versión 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) sienta las bases de un backend de escrow Cashu, incluyendo configuración, ayudantes de base de datos, integración con mint, cableado de arranque y la primera acción de bloqueo. También puede usar precios anunciados por un nodo de confianza sobre Nostr y anuncia requisitos de prueba de trabajo para el primer contacto en su evento de información reemplazable. La versión actualiza su dependencia de Nostr por una corrección de denegación de servicio de NIP-44, elimina claves privadas de los registros de sesión de restauración, rechaza mensajes de cancelación cooperativa no autorizados, refuerza las obtenciones LNURL contra falsificación de peticiones del lado del servidor y bloqueos, valida facturas de pago y restaura las suscripciones a facturas retenidas tras un reinicio.
+
+### LaWallet NWC 2.3.0 añade notificaciones de Nostr y recibos de zap
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) es una plataforma Lightning Address de código abierto que conecta monederos a través de [Nostr Wallet Connect](/es/topics/nip-47/) (conexión de monedero por Nostr). La [versión 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) permite a cada monedero enviar notificaciones de recibidos y reenviados como eventos de Nostr configurables, incluyendo una tag `p` del destinatario, relays seleccionados, contenido con plantilla y cifrado opcional de [NIP-44](/es/topics/nip-44/) (cifrado de mensajes); los reintentos reutilizan el mismo ID de evento firmado. También acepta solicitudes de zap y publica recibos firmados de kind 9735 de [NIP-57](/es/topics/nip-57/) (zaps) tras la liquidación, mientras que una nueva vista de capacidades de dirección muestra si la dirección resuelta admite NIP-05, NIP-57 y protocolos Lightning Address relacionados.
+
+### nostr-double-ratchet TypeScript 0.0.166 vincula invitaciones públicas a claves de sesión
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) proporciona primitivas TypeScript y Rust para mensajería directa y de grupo cifrada de extremo a extremo sobre relays de Nostr. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) exige que una respuesta a invitación demuestre la propiedad de su clave de sesión, evitando que una invitación pública reutilizable vincule una identidad de Nostr a la sesión de otra parte. La versión también rechaza campos rumor malformados y refuerza la validación de cargas; las sesiones existentes siguen funcionando, pero un invitador actualizado rechaza respuestas sin prueba de invitados antiguos.
+
+### cln-nip47 0.2.0 amplía y aísla las peticiones NWC
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) es un plugin de Core Lightning que expone un nodo a monederos a través de [Nostr Wallet Connect](/es/topics/nip-47/) (conexión de monedero por Nostr). La [versión 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) añade métodos NWC para crear, cancelar y liquidar facturas retenidas más una notificación `hold_invoice_accepted`, y anuncia el conjunto de métodos que el nodo conectado admite realmente. Las respuestas de lista de transacciones se detienen ahora en 500 entradas y unos 128 kB, los eventos de petición se desduplican por ID de evento, y la notificación fallida de un cliente ya no impide la entrega a otros clientes. La versión también elimina los dos métodos de multipago que ya no forman parte de la especificación NWC.
+
+### ClipRelay 0.1.3 restaura las conexiones de relay y firmante tras periodos de inactividad
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) sincroniza el portapapeles de un usuario entre dispositivos a través de relays de Nostr, cifrando el contenido hacia la misma identidad con [NIP-44](/es/topics/nip-44/) (cifrado de mensajes). Las versiones [de escritorio](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) y [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 correspondientes añaden un cuadro de texto para enviar texto escrito directamente al portapapeles de otro dispositivo. También prueban la actividad con idas y vueltas reales al relay tras periodos de inactividad, escalando desde la resuscripción hasta la sustitución del socket y un pool de conexiones reconstruido, mientras que las llamadas estancadas al firmante [NIP-46](/es/topics/nip-46/) (firma remota mediada por relays) agotan ahora el tiempo de espera y se reconstruyen automáticamente.
+
+### NoorNote 1.3.2 traslada el descubrimiento de artículos al grafo social
+
+[NoorNote](https://github.com/77elements/noornote) es un cliente de Nostr para publicaciones sociales, mensajes cifrados, artículos de formato largo y otros tipos de evento en web, escritorio y Android. La [versión 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) sustituye su feed global plano de artículos por descubrimiento extraído de contactos de primer, segundo y tercer grado, ofreciendo a los lectores una línea temporal de artículos arraigada en su grafo de seguimiento. También colapsa ráfagas de mensajes directos reproducidos de remitentes desconocidos en una sola notificación continua en lugar de producir una pila de avisos a medida que llega el historial del relay.
+
+### Bray 2.4.0 añade un dialecto compacto de firma remota
+
+[Bray](https://github.com/forgesworn/bray) es un servidor MCP de Nostr que ofrece a agentes de software y personas herramientas para acceso a relays, identidad, publicación y firma remota. La [versión 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) acepta una solicitud de firma cuyo evento es un objeto además de la forma serializada en cadena usada por [NIP-46](/es/topics/nip-46/) (firma remota mediada por relays), y añade `sign_event_compact`, que devuelve solo el ID del evento, la firma, la pubkey y la marca temporal. Ese formato de petición y respuesta más pequeño reduce el uso de memoria para firmantes de hardware restringidos, mientras que el flujo estándar `sign_event` permanece sin cambios y ambos dialectos producen una firma sobre el ID del evento recibido.
+
+
+## Recién descubiertos
+
+### Pact aporta vínculos de agentes con consentimiento mutuo a Nostr
+
+[Pact](https://github.com/bobodread876/pact), descubierto esta semana, es una capa de relaciones en fase temprana para agentes de software construida sobre MATE.md y un transporte borrador NIP-BD. Sus vínculos firmados con consentimiento mutuo los retienen las propias claves de los agentes y pueden publicarse sobre Nostr, mientras que los vínculos privados usan gift-wrap de [NIP-59](/es/topics/nip-59/) (envolturas que ocultan metadatos). El monorepo incluye un servidor MCP, SDK TypeScript, cliente de línea de comandos, daemon autoalojable e interfaz web. Su actividad más reciente en el repositorio es anterior a la ventana semanal de este número, por lo que esto es una nota de descubrimiento y no una afirmación de nueva versión.
+
+
+## Cambios sin publicar
+
+### nostrord mantiene sincronizado el silenciamiento de grupos entre dispositivos
+
+[nostrord](https://github.com/nostrord/nostrord) es un cliente multiplataforma para comunidades gestionadas por relays. El [PR #250](https://github.com/nostrord/nostrord/pull/250) almacena las elecciones de silenciamiento por grupo de cada cuenta en un evento autocifrado de kind `30078` de [NIP-78](/es/topics/nip-78/) (datos específicos de aplicación), de modo que un ajuste hecho en un dispositivo puede seguir al usuario a otro sin revelar la lista de grupos al relay. El registro reemplazable usa ordenación por evento más reciente, escucha cambios en vivo y revierte la interfaz cuando falla la firma o la publicación en lugar de dejar el estado local desincronizado. Los grupos silenciados también dejan de contribuir totales de no leídos visibles mientras conservan su posición de no leído para la próxima visita.
+
+### Amethyst completa el ciclo de vida de invitaciones de Concord
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) es un cliente Android de Nostr cuyo soporte de comunidades cifradas implementa el protocolo Concord. El [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) permite que los enlaces de invitación sobrevivan a un refounding de comunidad reemitiendo sus paquetes en las mismas coordenadas direccionables, mientras que una comprobación de expulsión impide que un miembro eliminado use esa ruta de recuperación. También implementa la lista de invitaciones cifrada CORD-05 tanto en la aplicación como en el cliente de línea de comandos `amy`, añade lápidas de revocación por enlace, y exige confirmación del relay antes de eliminar la única clave de firma almacenada que puede retirar un enlace. El mismo trabajo dota a `amy` de las rutas de entrega de clave de control, refounding, rekeying y recuperación de miembros aislados necesarias para seguir épocas comunitarias posteriores.
+
+### Buzz lleva la apariencia de cada comunidad entre escritorio y móvil
+
+[Buzz](https://github.com/block/buzz) es un espacio de trabajo comunitario basado en Nostr con clientes de escritorio y móvil. Los PR fusionados de escritorio [#3653](https://github.com/block/buzz/pull/3653) y móvil [#3767](https://github.com/block/buzz/pull/3767) almacenan el tema, el acento y la elección de modo del sistema de cada comunidad como un registro cifrado NIP-78 en el relay de esa comunidad. Ambos clientes comparten la misma carga versionada y mantienen cachés locales con alcance de identidad, de modo que cambiar de comunidad o de cuenta no puede aplicar la apariencia equivocada mientras el relay no esté disponible. El orden de reemplazo, las escrituras protegidas y la resuscripción tras una conexión cerrada permiten que los dos clientes converjan de nuevo tras reconectar.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) llegó antes del corte del número con un pase de rendimiento y fiabilidad. Elimina regresiones introducidas tras 0.5.9, acelera la carga de canales, acota la retención inicial de la línea temporal, coalesce la persistencia del estado de lectura, preserva líneas temporales de canal frescas y evita que el worker de ingestión del relay falle con reacciones a eventos de proyecto. También añade el envío de un mensaje de hilo a un canal y restringe la búsqueda de escritorio al alcance previsto.
+
+
+## Actualizaciones de NIPs y trabajo de especificación del protocolo
+
+### NIPs
+
+[El PR de NIPs #2435](https://github.com/nostr-protocol/nips/pull/2435) es una enmienda abierta a NIP-34 (colaboración en repositorios git mediante eventos de Nostr). Añade una tag `b` opcional a un evento de pull request para que el autor pueda nombrar una rama destino distinta de la predeterminada del repositorio. La propuesta coincide con soporte ya implementado en ngit y GitWorkshop, pero aún no ha entrado en la especificación.
+
+[El PR de NIPs #2434](https://github.com/nostr-protocol/nips/pull/2434) es una propuesta abierta de claves de identidad poscuánticas. Deriva claves poscuánticas de cifrado y firma junto a la clave secp256k1 existente a partir de una semilla de derivación de claves mnemónicas de NIP-06, y vincula las pubkeys a la identidad de Nostr con una atestación de kind `10203`. El borrador limita su reclamo a proteger la confidencialidad de mensajes anteriores si secp256k1 se rompe más adelante; no sustituye las firmas de eventos actuales.
+
+[El PR de NIPs #2431](https://github.com/nostr-protocol/nips/pull/2431) es una enmienda abierta de NIP-07 (firmantes de navegador). Un cliente podría adjuntar la pubkey que espera a las peticiones de firma o cifrado, exigiendo al firmante usar esa cuenta o rechazar la llamada. Esto evitaría que una página continuara silenciosamente bajo una identidad distinta después de que el usuario cambie de cuenta en el firmante.
+
+[El PR de NIPs #1813](https://github.com/nostr-protocol/nips/pull/1813) sigue siendo una propuesta abierta de double-ratchet tras trabajo sustantivo durante la ventana. Especifica conversaciones cifradas con secreto hacia adelante cuyas claves avanzan con los mensajes, con una implementación ya disponible en la biblioteca nostr-double-ratchet e Iris. Sigue siendo un borrador, no un NIP fusionado.
+
+[El PR de NIPs #2433](https://github.com/nostr-protocol/nips/pull/2433) se abrió y cerró sin fusionar durante la ventana. Proponía aclarar los errores de relay de NIP-42 para que `auth-required` significara que otra autenticación podría cambiar el resultado, mientras que `restricted` significaría que no podría. La distinción abordaba conexiones autenticadas para una clave pero aún sin autorización para otra; el estado cerrado significa que la redacción no entró en la especificación.
+
+[El PR de NIPs #2378](https://github.com/nostr-protocol/nips/pull/2378), cubierto previamente mientras aún estaba propuesto, se ha cerrado ahora sin fusionar. Sus eventos propuestos de pasaportes de agente, descubrimiento, tareas, marketplace, facturas y conexiones permanecen por tanto fuera del conjunto de NIPs.
+
+[El commit de NIPs 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) fusionó una corrección solo documental de NIP-29. Añade una tag `previous` al ejemplo de metadatos de grupo, mostrando cómo un evento de reemplazo puede identificar el evento que sustituye. Esto aclara un ejemplo y no introduce una nueva característica de protocolo.
+
+### Concord y CORDs
+
+[El PR de CORD #18](https://github.com/concord-protocol/concord/pull/18) fragmentaría las listas comunitarias cifradas en eventos de kind `33302`, eliminaría el límite de 50 membresías y podaría entradas retiradas para mantenerse dentro de los límites del relay. Otras dos propuestas abiertas añaden [localizadores de mención privada](https://github.com/concord-protocol/concord/pull/16) y una [señal de pausa](https://github.com/concord-protocol/concord/pull/17) que suspende el chat sin descartar mensajes.
+
+[El PR de CORD-02 #15](https://github.com/concord-protocol/concord/pull/15) se fusionó el 6 de agosto y restringe las escrituras al plano de control de una comunidad. Propietarios y personal retienen un nuevo secreto de firma `control_root`, mientras que todos los miembros conservan la pubkey derivada y la clave de lectura necesarias para verificar y descifrar el estado de moderación. La clave de escritura es una barrera antispam, no un sustituto de las firmas internas de actor y las comprobaciones de roster que establecen la autoridad.
+
+[El PR de CORD #12](https://github.com/concord-protocol/concord/pull/12), cubierto previamente como borrador abierto, se ha cerrado ahora sin fusionar. Su porción de plano de control fue reemplazada por la enmienda CORD-02 fusionada más estrecha arriba, mientras que los canales de escritura restringida y el resto del material borrador no entraron en la especificación.
+
+## Análisis en profundidad de NIPs
+
+### Solicitudes de borrado de eventos (NIP-09)
+
+[NIP-09](/es/topics/nip-09/) (solicitudes de borrado de eventos), definido por la [especificación principal](https://github.com/nostr-protocol/nips/blob/master/09.md), ofrece al autor de un evento una forma firmada de pedir a relays y clientes que dejen de servir uno o más de los eventos de ese autor. No borra cada copia. Transporta la intención del autor a través de la misma red de relays que distribuyó el evento original.
+
+La solicitud es un evento firmado ordinario de kind `5`. Sus tags contienen una o más referencias `e` a IDs de evento concretos o referencias `a` a coordenadas de eventos direccionables, y las [reglas de tags de NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) indican que debería incluir una tag `k` por cada kind de evento referenciado. El `content` opcional puede explicar el motivo. Para una referencia `a`, un relay debería eliminar toda versión en esa coordenada cuya marca temporal no sea posterior al `created_at` de la solicitud, lo que evita que una solicitud de borrado antigua suprima un reemplazo posterior.
+
+[La autoría es el límite de seguridad](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Un relay debería dejar de publicar un evento referenciado solo cuando su `pubkey` coincide con la `pubkey` de la solicitud de borrado, y un cliente debe realizar esa comprobación antes de ocultar un evento. Un relay puede no poseer el evento referenciado y por tanto ser incapaz de validar la relación al aceptar la solicitud, de modo que los clientes no pueden tratar la aceptación del relay como prueba de que el borrado fue autorizado. La especificación también pide a los relays conservar la solicitud de kind `5` porque otro cliente puede ya tener el evento original y encontrar la solicitud más tarde.
+
+Aquí hay un [evento firmado de kind `5`](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+El borrado sigue siendo una política cooperativa, no revocación de un objeto firmado. Un relay, caché, captura de pantalla o cliente sin conexión puede conservar los bytes originales, y borrar la solicitud de kind `5` no la deshace. Los clientes pueden ocultar el objetivo, marcarlo como desautorizado o mostrar el motivo de la solicitud, pero deberían decir a los usuarios que no puede garantizarse un borrado universal. Esto difiere de [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) (expiración de eventos), donde una tag `expiration` pide a los relays dejar de almacenar un evento tras un momento elegido al publicarlo. NIP-09 maneja una decisión posterior del autor y puede apuntar a eventos ya distribuidos.
+
+Las implementaciones actuales aplican esa política en distintas capas. [Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623) elimina vídeos borrados del almacén de eventos del cliente, [strfry PR #251](https://github.com/hoytech/strfry/pull/251) extiende las solicitudes de borrado válidas a destinatarios gift-wrap, y [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) declara soporte de NIP-09 en su cliente. [El cliente de grupo de nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) ofrece otra ruta de implementación actual.
+
+### Denuncias (NIP-56)
+
+[NIP-56](/es/topics/nip-56/) (eventos de denuncia), definido por la [especificación principal](https://github.com/nostr-protocol/nips/blob/master/56.md), estandariza una denuncia firmada sobre una cuenta, un evento o un blob referenciado. Separa la señal de denuncia de la decisión de moderación, permitiendo a cada cliente o relay elegir qué denunciantes confía y qué respuesta encaja con su política.
+
+Una denuncia usa kind `1984` y debe identificar la cuenta denunciada en una tag `p`. Denunciar una nota también requiere una tag `e` para el ID del evento. El tercer valor de la tag lleva una de las categorías especificadas: `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation` o `other`. Una denuncia sobre un blob puede usar su hash en una tag `x`, una tag `e` para el evento que referenció el blob, y una tag `server` opcional para una ubicación. Las tags opcionales `L` y `l` de [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) (etiquetado) pueden añadir una etiqueta con espacio de nombres cuando la lista fija de categorías no es lo bastante precisa.
+
+[El evento prueba solo que una clave hizo una alegación](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). El contenido denunciado no se vuelve falso, ilegal o eliminable meramente porque exista un kind `1984` válido, y un relay abierto no puede contar con seguridad denuncias anónimas como votos. La especificación desaconseja la moderación automática del relay porque las denuncias son fáciles de manipular, a la vez que permite a los administradores de relay actuar sobre denuncias de moderadores en los que ya confían. Un cliente puede en cambio ponderar denuncias a través del grafo social de un usuario, por ejemplo difuminando contenido tras varios contactos de confianza que marquen la misma cuenta.
+
+Aquí hay un [evento firmado de kind `1984`](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 y NIP-09 resuelven problemas distintos](https://github.com/nostr-protocol/nips/tree/master). Una denuncia de kind `1984` puede apuntar a la cuenta o evento de otra persona, pero no confiere autoridad de borrado. Una solicitud de kind `5` expresa la intención del autor original y solo es válida contra los propios eventos de ese autor. Ninguno garantiza eliminación: NIP-56 delega deliberadamente la acción a la política de moderación local, mientras que NIP-09 depende de que relays y clientes honren una solicitud autenticada.
+
+Las implementaciones exponen esas elecciones en productos distintos. [Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591) corrige la entrega de denuncias en un cliente de vídeo corto, [Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) lee denuncias como contexto acotado para participantes de marketplace, y [el módulo NIP-56 de nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) publica y procesa eventos de denuncia. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) también lista soporte actual de NIP-56.
+
+
+---
+
+Envía un DM por NIP-17 para compartir un proyecto o noticia a través del [proyecto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/fr/newsletters/2026-08-12-newsletter.md
+++ b/content/fr/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Outils d'identité post-quantique, messagerie chiffrée et signature renforcées, paramètres communautaires portables, et travail protocolaire sur les NIP et Concord."
+---
+
+Bienvenue dans [Nostr Compass](https://nostrcompass.org), votre guide hebdomadaire de Nostr.
+
+**Cette semaine :** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) ajoute des clés post-quantiques et des messages protégés sur opt-in à côté des identités Nostr existantes. [Divine](https://github.com/divinevideo/divine-mobile) resserre l'isolation des comptes, la validation des messages privés et la confirmation de publication ; [MDK](https://github.com/marmot-protocol/mdk) renforce la convergence et la récupération des groupes chiffrés ; et [Amber](https://github.com/greenart7c3/Amber) rend explicites les décisions de signature groupées. Les versions améliorent les connexions de portefeuille, le chat chiffré, la découverte sociale, la synchronisation entre appareils et la signature distante, tandis que le travail protocolaire couvre l'identité et les communautés chiffrées. Les analyses approfondies expliquent les demandes de suppression authentifiées et le signalement décentralisé.
+
+## À la une
+
+### nostr-wot-extension 0.4.0 ajoute des clés post-quantiques à côté d'une identité Nostr
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) est une extension de navigateur pour gérer des identités Nostr et signer. Les comptes créés à partir d'une seed de 24 mots peuvent désormais dériver des clés de chiffrement ML-KEM-1024 et de signature ML-DSA-87 aux côtés de leur clé Nostr existante. Un flux en un clic publie une attestation de kind `10203` qui lie la pubkey Nostr aux deux clés publiques post-quantiques et inclut une preuve de possession ML-DSA. Les comptes importés depuis une mnémonique de 12 mots, un `nsec` nu, un signataire distant ou une clé en lecture seule ne peuvent pas utiliser le flux de dérivation, et l'extension explique cette limitation dans la vue du compte.
+
+La version ajoute aussi des messages directs post-quantiques sur opt-in. Elle combine le secret partagé ML-KEM avec la [clé de conversation de message chiffré NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) existante via HKDF, puis conserve les couches normales de gift wrap [NIP-59](/fr/topics/nip-59/) (enveloppes masquant les métadonnées) pour la livraison par relais. Le chiffrement ne retombe jamais silencieusement après qu'un destinataire a opté, tandis que le déchiffrement sélectionne automatiquement le chemin approprié. Cela protège le nouveau chemin de message contre une récupération ultérieure d'une clé privée Nostr actuelle, mais ne remplace pas les signatures d'événements secp256k1 ; la version laisse explicitement cette migration plus large à une coordination future avec les relais et les clients.
+
+### Divine Mobile 1.0.19 resserre les comptes, les messages privés et la publication
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) est un client mobile de vidéo courte qui publie et récupère des vidéos via Nostr. Son sélecteur de compte construit désormais chaque identité connectée autour d'un conteneur propre au compte, et une correction de publication empêche une vidéo d'être envoyée sous le mauvais compte. Les chemins de publication vers les relais attendent maintenant une réponse `OK` avec une sémantique de succès explicite, tandis qu'une trame `CLOSED` du relais peut mettre fin à sa propre requête en attente au lieu de la laisser pendante.
+
+La [gestion des messages privés](https://github.com/divinevideo/divine-mobile/pull/6368) rejette les champs rumor non authentifiés et les seals non signés, rétablit quatre cas de messages manquants, et achemine les conversations de groupe des participants entièrement suivis vers la boîte de réception. La version préserve aussi les tags des événements vidéo adressables lors de la mise à jour des listes et consomme les demandes de suppression observées pour que les vidéos retirées disparaissent de l'état local. Ces changements suivent le travail de délai d'expiration par requête couvert la semaine dernière, mais déplacent l'accent de l'isolation de la récupération vers les frontières d'identité, la validation des messages et la confirmation de publication.
+
+### MDK 0.9.11 renforce la convergence et la récupération des groupes Marmot
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) est une boîte à outils de développement Rust pour Marmot, un protocole de messagerie de groupe chiffrée transporté sur Nostr. La version construit un système de convergence et de récupération plus large autour de la machine à états du groupe : les passes de convergence périmées rouvrent à la pointe actuelle du groupe, les projections de capacité entrantes s'engagent de façon atomique, les messages différés reçoivent des durées de vie bornées entre les redémarrages, et les points de contrôle adressés par commit aident à récupérer les propres fourches de commit d'une identité. Les envois non stables peuvent être mis en file d'attente et récupérés, tandis qu'un chemin de blocage d'époque escalade vers le backfill et les messages envoyés survivent au travail de convergence.
+
+Le [stockage et les intégrations hôtes](https://github.com/marmot-protocol/mdk/pull/1201) reçoivent un durcissement parallèle. MDK supprime de façon sécurisée les projections SQLite élaguées, zéroïse les clés privées importées, les intermédiaires d'export de clés chiffrées NIP-49 et les tampons de sérialisation OpenMLS, et masque les clés d'image de groupe dans la sortie de débogage. L'import de compte peut reprendre après interruption, les chemins de stockage privé iOS et Android sont réparés, et les hôtes peuvent fermer explicitement le stockage avant la suspension. De nouvelles projections légères de roster et d'appartenance locale réduisent ce que les applications doivent lire, tandis que le connecteur Hermes peut livrer plusieurs images générées par agent comme un album Marmot.
+
+### Nostria 4.1.67 étend l'administration des communautés chiffrées
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) est un client social web et de bureau pour Nostr. Il s'appuie sur les groupes gérés par relais expérimentaux [NIP-29](/fr/topics/nip-29/) (groupes gérés par relais) et les communautés chiffrées Concord introduits en 4.1.53, en ajoutant la dissolution de communauté, l'administration de l'icône et de la bannière, les téléversements de photos chiffrés avec aperçus compressés, un sélecteur de réactions complet, et une disposition à double volet qui garde une communauté ouverte pendant que l'utilisateur lit des notes ou des articles. La version ajoute aussi la messagerie filée et un hub combiné pour les chats publics, de groupe et privés.
+
+### Amber 6.4.0 rend explicite chaque décision de signature groupée
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) est un signataire Android qui garde les clés privées Nostr séparées des applications demandant des signatures. Son écran multi-requêtes repensé fournit des contrôles Approuver et Refuser pour chaque requête et chaque groupe, remplaçant le flux précédent de sélection et confirmation. Les requêtes refusées envoyées via l'interface bunker relayée d'Amber reçoivent désormais des réponses d'erreur appropriées, de sorte que le client demandeur peut distinguer un rejet d'un signataire bloqué.
+
+La [source étiquetée d'Amber](https://github.com/greenart7c3/Amber/tree/v6.4.0) ajoute aussi des libellés localisés et lisibles par un humain pour 113 kinds d'événements supplémentaires dans chaque locale livrée. Les ajouts couvrent les événements de groupe Concord, les marque-pages de dépôt Git NIP-51, et les événements de présence de salon NIP-53, donnant aux utilisateurs plus de contexte sur des données inconnues avant d'approuver une signature. Un garde de map concurrente corrige aussi un crash d'abonnement au relais qui pouvait produire une `NegativeArraySizeException`.
+
+### Safebox Acorn sépare un composant de récupération portable de l'application web
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) est un composant Python autonome et une interface en ligne de commande pour sauvegarder des clés, des fonds et des enregistrements contrôlés par l'utilisateur avec un état adossé à Nostr. Extraire Acorn de l'application web Safebox plus large permet à un autre projet Python d'installer le runtime et d'utiliser ses helpers de clé, profil Nostr, relais, enregistrement, Cashu, Lightning et cryptographiques sans prendre l'interface web. Ses primitives actuelles de protection d'enregistrement peuvent générer une clé fraîche de 256 bits, en dériver une à partir d'entropie fournie séparément, et encoder la clé exacte comme phrase de récupération de 24 mots avec somme de contrôle.
+
+Le [guide de récupération et de continuité](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) du projet présente Acorn comme le composant protocolaire remplaçable à l'intérieur d'un Safebox domestique ou communautaire. La conception garde l'état chiffré disponible via un relais local et des répliques indépendantes pour que la récupération ne dépende pas d'un seul appareil, application, relais, mint ou fournisseur de service. La documentation est prudente sur la frontière actuelle : le chiffrement des enregistrements protégés reste en conception, de sorte que les applications ne devraient pas faire dépendre les enregistrements de la nouvelle clé de protection d'enregistrement tant que ce profil n'a pas été implémenté et revu.
+
+
+## Versions
+
+### Mostro Core 0.14.2 modifie l'enveloppe de chat chiffré
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) est la bibliothèque Rust de types partagés et de fonctions pair-à-pair utilisée par le daemon d'échange Mostro et ses clients. La [version 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) remplace les messages de chat gift wrap par des enveloppes de kind 14 qui utilisent des clés de chiffrement de conversation et de signature distinctes dérivées du secret partagé des pairs. Le nouveau lecteur valide l'auteur, la signature, le destinataire, l'horodatage et la taille du contenu, tandis que les helpers gift wrap hérités restent disponibles pour que les clients puissent lire les deux formats pendant la migration.
+
+### Mostro 0.18.1 amorce un chemin d'escrow Cashu et durcit le daemon
+
+[Mostro](https://github.com/MostroP2P/mostro) est un daemon d'échange Lightning pair-à-pair qui coordonne les ordres via Nostr. La [version 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) pose les bases d'un backend d'escrow Cashu, incluant configuration, helpers de base de données, intégration mint, câblage au démarrage et la première action de verrouillage. Il peut aussi utiliser des prix annoncés par un nœud de confiance sur Nostr et annonce des exigences de preuve de travail pour le premier contact dans son événement info remplaçable. La version met à jour sa dépendance Nostr pour une correction de déni de service NIP-44, retire les clés privées des journaux de session de restauration, rejette les messages d'annulation coopérative non autorisés, durcit les requêtes LNURL contre la falsification de requête côté serveur et les blocages, valide les factures de paiement, et rétablit les abonnements aux factures en attente après un redémarrage.
+
+### LaWallet NWC 2.3.0 ajoute les notifications Nostr et les reçus de zap
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) est une plateforme Lightning Address open source qui connecte les portefeuilles via [Nostr Wallet Connect](/fr/topics/nip-47/). La [version 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) permet à chaque portefeuille d'envoyer des notifications reçues et transférées comme événements Nostr configurables, incluant un tag `p` destinataire, des relais sélectionnés, un contenu modélisé, et un chiffrement [NIP-44](/fr/topics/nip-44/) optionnel ; les nouvelles tentatives réutilisent le même ID d'événement signé. Il accepte aussi les requêtes de zap et publie des reçus signés [NIP-57](/fr/topics/nip-57/) de kind 9735 après règlement, tandis qu'une nouvelle vue de capacité d'adresse indique si l'adresse résolue prend en charge NIP-05, NIP-57 et les protocoles Lightning Address associés.
+
+### nostr-double-ratchet TypeScript 0.0.166 lie les invitations publiques aux clés de session
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) fournit des primitives TypeScript et Rust pour la messagerie directe et de groupe chiffrée de bout en bout via des relais Nostr. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) exige qu'une réponse d'invitation prouve la possession de sa clé de session, empêchant une invitation publique réutilisable de lier une identité Nostr à la session d'une autre partie. La version rejette aussi les champs rumor malformés et resserre la validation des charges utiles ; les sessions existantes continuent de fonctionner, mais un inviteur mis à jour rejette les réponses sans preuve des invités plus anciens.
+
+### cln-nip47 0.2.0 étend et isole les requêtes NWC
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) est un plugin Core Lightning qui expose un nœud aux portefeuilles via [Nostr Wallet Connect](/fr/topics/nip-47/). La [version 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) ajoute des méthodes NWC pour créer, annuler et régler des factures en attente plus une notification `hold_invoice_accepted`, et annonce l'ensemble de méthodes que le nœud connecté prend réellement en charge. Les réponses de liste de transactions s'arrêtent maintenant à 500 entrées et environ 128 kB, les événements de requête sont dédupliqués par ID d'événement, et l'échec de notification d'un client n'empêche plus la livraison aux autres clients. La version retire aussi les deux méthodes multi-paiement qui ne font plus partie de la spécification NWC.
+
+### ClipRelay 0.1.3 rétablit les connexions relais et signataire après les périodes d'inactivité
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) synchronise le presse-papiers d'un utilisateur entre appareils via des relais Nostr, en chiffrant le contenu vers la même identité avec [NIP-44](/fr/topics/nip-44/). Les versions [desktop](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) et [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 correspondantes ajoutent une zone de texte pour envoyer du texte saisi directement vers le presse-papiers d'un autre appareil. Elles testent aussi la vivacité avec de vrais allers-retours relais après des périodes d'inactivité, en escaladant du réabonnement au remplacement de socket et à un pool de connexions reconstruit, tandis que les appels signataire [NIP-46](/fr/topics/nip-46/) (signature distante relayée) bloqués expirent maintenant et se reconstruisent automatiquement.
+
+### NoorNote 1.3.2 déplace la découverte d'articles dans le graphe social
+
+[NoorNote](https://github.com/77elements/noornote) est un client Nostr pour publications sociales, messages chiffrés, articles longs et autres kinds d'événements sur web, bureau et Android. La [version 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) remplace son fil d'articles global plat par une découverte tirée des contacts de premier, deuxième et troisième degré, offrant aux lecteurs une chronologie d'articles enracinée dans leur graphe de suivi. Elle regroupe aussi les rafales de messages directs rejoués d'expéditeurs inconnus en une notification continue au lieu de produire une pile de toasts à l'arrivée de l'historique du relais.
+
+### Bray 2.4.0 ajoute un dialecte compact de signature distante
+
+[Bray](https://github.com/forgesworn/bray) est un serveur MCP Nostr qui donne aux agents logiciels et aux personnes des outils pour l'accès aux relais, l'identité, la publication et la signature distante. La [version 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) accepte une requête de signature dont l'événement est un objet ainsi que la forme stringifiée utilisée par [NIP-46](/fr/topics/nip-46/), et ajoute `sign_event_compact`, qui ne renvoie que l'ID d'événement, la signature, la pubkey et l'horodatage. Ce format de requête et de réponse plus petit réduit l'utilisation mémoire pour les signataires matériels contraints, tandis que le flux standard `sign_event` reste inchangé et les deux dialectes produisent une signature sur l'ID de l'événement reçu.
+
+
+## Nouvelles découvertes
+
+### Pact apporte des liens d'agents mutuellement consentis à Nostr
+
+[Pact](https://github.com/bobodread876/pact), nouvellement découvert cette semaine, est une couche relationnelle précoce pour agents logiciels construite sur MATE.md et un transport brouillon NIP-BD. Ses liens signés et mutuellement consentis sont détenus par les propres clés des agents et peuvent être publiés sur Nostr, tandis que les liens privés utilisent le gift wrap [NIP-59](/fr/topics/nip-59/). Le monorepo inclut un serveur MCP, un SDK TypeScript, un client en ligne de commande, un daemon auto-hébergeable et une interface web. Sa dernière activité de dépôt précède la fenêtre hebdomadaire de ce numéro, il s'agit donc d'une note de découverte plutôt que d'une affirmation de nouvelle version.
+
+
+## Changements non publiés
+
+### nostrord garde le mutisme de groupe synchronisé entre appareils
+
+[nostrord](https://github.com/nostrord/nostrord) est un client multiplateforme pour communautés gérées par relais. La [PR #250](https://github.com/nostrord/nostrord/pull/250) stocke les choix de mutisme par groupe de chaque compte dans un événement auto-chiffré [NIP-78](/fr/topics/nip-78/) (données spécifiques à l'application) de kind `30078`, de sorte qu'un réglage fait sur un appareil peut suivre l'utilisateur sur un autre sans révéler la liste de groupes au relais. L'enregistrement remplaçable utilise l'ordre du plus récent événement, écoute les changements en direct, et annule l'interface en cas d'échec de signature ou de publication au lieu de laisser l'état local désynchronisé. Les groupes muets cessent aussi de contribuer aux totaux de non-lus visibles tout en conservant leur position de non-lu pour la prochaine visite.
+
+### Amethyst complète le cycle de vie des invitations Concord
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) est un client Nostr Android dont le support de communautés chiffrées implémente le protocole Concord. La [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) permet aux liens d'invitation de survivre à un refondage de communauté en réémettant leurs bundles aux mêmes coordonnées adressables, tandis qu'une vérification de bannissement empêche un membre retiré d'utiliser ce chemin de récupération. Elle implémente aussi la liste d'invitations chiffrée CORD-05 sur l'application et le client en ligne de commande `amy`, ajoute des tombstones de révocation par lien, et exige la confirmation du relais avant de supprimer la seule clé de signature stockée pouvant retirer un lien. Le même travail donne à `amy` les chemins de livraison de clé de contrôle, refondage, rekeying et récupération de membres isolés nécessaires pour suivre les époques communautaires ultérieures.
+
+### Buzz transporte l'apparence de chaque communauté entre bureau et mobile
+
+[Buzz](https://github.com/block/buzz) est un espace de travail communautaire basé sur Nostr avec clients bureau et mobile. Les PR desktop fusionnées [PR #3653](https://github.com/block/buzz/pull/3653) et mobile [PR #3767](https://github.com/block/buzz/pull/3767) stockent le thème, l'accent et le choix de mode système de chaque communauté comme enregistrement chiffré NIP-78 sur le relais de cette communauté. Les deux clients partagent la même charge utile versionnée et conservent des caches locaux propres à l'identité, de sorte que changer de communauté ou de compte ne peut pas appliquer la mauvaise apparence pendant que le relais est indisponible. L'ordre de remplacement, les écritures protégées et le réabonnement après une connexion fermée permettent aux deux clients de converger à nouveau après reconnexion.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) a suivi avant la date limite du numéro avec une passe de performance et de fiabilité. Il supprime les régressions introduites après 0.5.9, accélère le chargement des canaux, borne la rétention initiale de la chronologie, fusionne la persistance de l'état de lecture, préserve les chronologies de canaux fraîches, et empêche le worker d'ingestion relais de crasher sur les réactions aux événements de projet. Il ajoute aussi l'envoi d'un message de fil vers un canal et restreint la recherche desktop à la portée prévue.
+
+
+## Mises à jour des NIP et travail de spécification du protocole
+
+### NIPs
+
+La [PR NIPs #2435](https://github.com/nostr-protocol/nips/pull/2435) est un amendement ouvert à [NIP-34](/fr/topics/nip-34/) (collaboration sur dépôts git via Nostr). Elle ajoute un tag `b` optionnel à un événement de pull request pour que l'auteur puisse nommer une branche cible autre que la branche par défaut du dépôt. La proposition correspond à un support déjà implémenté dans ngit et GitWorkshop, mais n'est pas entrée dans la spécification.
+
+La [PR NIPs #2434](https://github.com/nostr-protocol/nips/pull/2434) est une proposition ouverte pour des clés d'identité post-quantiques. Elle dérive des clés de chiffrement et de signature post-quantiques aux côtés de la clé secp256k1 existante à partir d'une seed de dérivation de clé mnémonique NIP-06, puis lie les clés publiques à l'identité Nostr avec une attestation de kind `10203`. Le brouillon limite sa revendication à la protection de la confidentialité des messages antérieurs si secp256k1 est un jour cassé ; il ne remplace pas les signatures d'événements actuelles.
+
+La [PR NIPs #2431](https://github.com/nostr-protocol/nips/pull/2431) est un amendement ouvert à [NIP-07](/fr/topics/nip-07/) (signataires de navigateur). Un client pourrait joindre la pubkey qu'il attend aux requêtes de signature ou de chiffrement, exigeant que le signataire utilise ce compte ou rejette l'appel. Cela empêcherait une page de continuer silencieusement sous une identité différente après que l'utilisateur change de compte dans le signataire.
+
+La [PR NIPs #1813](https://github.com/nostr-protocol/nips/pull/1813) reste une proposition double-ratchet ouverte après un travail substantiel pendant la fenêtre. Elle spécifie des conversations chiffrées à secret avant avec des clés qui avancent avec les messages, avec une implémentation déjà disponible dans la bibliothèque nostr-double-ratchet et Iris. C'est encore un brouillon, pas un NIP fusionné.
+
+La [PR NIPs #2433](https://github.com/nostr-protocol/nips/pull/2433) s'est ouverte et fermée sans fusion pendant la fenêtre. Elle proposait de clarifier les erreurs de relais NIP-42 pour que `auth-required` signifierait qu'une autre authentification pourrait changer le résultat, tandis que `restricted` signifierait qu'elle ne le pourrait pas. La distinction concernait des connexions authentifiées pour une clé mais encore sans autorisation pour une autre ; le statut fermé signifie que la formulation n'est pas entrée dans la spécification.
+
+La [PR NIPs #2378](https://github.com/nostr-protocol/nips/pull/2378), couverte précédemment alors qu'elle était encore proposée, s'est maintenant fermée sans fusion. Ses événements proposés de passeports d'agent, découverte, tâche, marketplace, facture et connexion restent donc en dehors de l'ensemble des NIP.
+
+Le [commit NIPs 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) a fusionné une correction documentation-only de NIP-29. Il ajoute un tag `previous` à l'exemple de métadonnées de groupe, montrant comment un événement de remplacement peut identifier l'événement qu'il supplante. Cela clarifie un exemple et n'introduit pas de nouvelle fonctionnalité protocolaire.
+
+### Concord et CORDs
+
+La [PR CORD #18](https://github.com/concord-protocol/concord/pull/18) fragmenterait les listes de communauté chiffrées sur des événements de kind `33302`, supprimerait la limite de 50 adhésions, et élaguerait les entrées retirées pour rester dans les limites des relais. Deux autres propositions ouvertes ajoutent des [localisateurs de mention privée](https://github.com/concord-protocol/concord/pull/16) et un [signal de pause](https://github.com/concord-protocol/concord/pull/17) qui suspend le chat sans jeter les messages.
+
+La [PR CORD-02 #15](https://github.com/concord-protocol/concord/pull/15) a fusionné le 6 août et restreint les écritures au plan de contrôle d'une communauté. Les propriétaires et le staff détiennent un nouveau secret de signature `control_root`, tandis que tous les membres conservent la pubkey dérivée et la clé de lecture nécessaires pour vérifier et déchiffrer l'état de modération. La clé d'écriture est une barrière anti-spam, pas un substitut aux signatures d'acteur internes et aux vérifications de roster qui établissent l'autorité.
+
+La [PR CORD #12](https://github.com/concord-protocol/concord/pull/12), couverte précédemment comme brouillon ouvert, s'est maintenant fermée sans fusion. Sa portion plan de contrôle a été supplantée par l'amendement CORD-02 fusionné plus étroit ci-dessus, tandis que les canaux à écriture restreinte et les autres éléments du brouillon ne sont pas entrés dans la spécification.
+
+## Analyse approfondie de NIP
+
+### Demandes de suppression d'événements (NIP-09)
+
+[NIP-09](/fr/topics/nip-09/) (demandes de suppression d'événements), défini par la [spécification principale](https://github.com/nostr-protocol/nips/blob/master/09.md), donne à l'auteur d'un événement un moyen signé de demander aux relais et aux clients d'arrêter de servir un ou plusieurs de ses événements. Cela n'efface pas chaque copie. Cela transporte l'intention de l'auteur via le même réseau de relais qui a distribué l'événement original.
+
+La requête est un événement signé ordinaire de kind `5`. Ses tags contiennent une ou plusieurs références `e` vers des ID d'événements spécifiques ou des références `a` vers des coordonnées d'événements adressables, et les [règles de tags NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) indiquent qu'il devrait inclure un tag `k` pour chaque kind d'événement référencé. Le `content` optionnel peut expliquer la raison. Pour une référence `a`, un relais devrait retirer chaque version à cette coordonnée dont l'horodatage n'est pas postérieur au `created_at` de la requête, ce qui empêche une ancienne demande de suppression de supprimer un remplacement ultérieur.
+
+[L'auteur est la frontière de sécurité](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Un relais devrait arrêter de publier un événement référencé seulement lorsque sa `pubkey` correspond à la `pubkey` de la demande de suppression, et un client doit effectuer cette vérification avant de masquer un événement. Un relais peut ne pas posséder l'événement référencé et donc être incapable de valider la relation lors de l'acceptation de la requête, de sorte que les clients ne peuvent pas traiter l'acceptation par le relais comme preuve que la suppression était autorisée. La spécification demande aussi aux relais de conserver la requête de kind `5` parce qu'un autre client peut déjà détenir l'événement original et rencontrer la requête plus tard.
+
+Voici un [événement signé de kind `5`](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943) :
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+La suppression reste une politique coopérative, pas une révocation d'un objet signé. Un relais, cache, capture d'écran ou client hors ligne peut conserver les octets originaux, et supprimer la requête de kind `5` elle-même ne l'annule pas. Les clients peuvent masquer la cible, la marquer comme désavouée, ou afficher la raison de la requête, mais devraient informer les utilisateurs qu'une suppression universelle ne peut pas être garantie. Cela diffère de [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) (expiration d'événement), où un tag `expiration` demande aux relais d'arrêter de stocker un événement après un moment choisi lors de la publication. NIP-09 gère une décision ultérieure de l'auteur et peut pointer vers des événements déjà distribués.
+
+Les implémentations actuelles appliquent cette politique à différentes couches. La [PR Divine #6623](https://github.com/divinevideo/divine-mobile/pull/6623) retire les vidéos supprimées du magasin d'événements du client, la [PR strfry #251](https://github.com/hoytech/strfry/pull/251) étend les demandes de suppression valides aux destinataires gift wrap, et [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) déclare le support NIP-09 dans son client. Le [client de groupe de nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) fournit un autre chemin d'implémentation actuel.
+
+### Signalement (NIP-56)
+
+[NIP-56](/fr/topics/nip-56/) (événements de signalement), défini par la [spécification principale](https://github.com/nostr-protocol/nips/blob/master/56.md), standardise un signalement signé sur un compte, un événement ou un blob référencé. Il sépare le signal de signalement de la décision de modération, permettant à chaque client ou relais de choisir quels rapporteurs il fait confiance et quelle réponse convient à sa politique.
+
+Un signalement utilise le kind `1984` et doit identifier le compte signalé dans un tag `p`. Signaler une note exige aussi un tag `e` pour l'ID d'événement. La troisième valeur du tag porte l'une des catégories spécifiées : `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation`, ou `other`. Un signalement sur un blob peut utiliser son hachage dans un tag `x`, un tag `e` pour l'événement qui a référencé le blob, et un tag `server` optionnel pour un emplacement. Les tags `L` et `l` optionnels de [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) (étiquetage) peuvent ajouter un libellé avec espace de noms lorsque la liste de catégories fixe n'est pas assez précise.
+
+[L'événement prouve seulement qu'une clé a fait une allégation](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). Le contenu signalé ne devient pas faux, illégal ou supprimable simplement parce qu'un kind `1984` valide existe, et un relais ouvert ne peut pas compter en toute sécurité des signalements anonymes comme des votes. La spécification déconseille la modération automatique par relais parce que les signalements sont faciles à manipuler, tout en permettant aux administrateurs de relais d'agir sur les signalements de modérateurs en qui ils ont déjà confiance. Un client peut au contraire pondérer les signalements via le graphe social d'un utilisateur, par exemple en floutant le contenu après que plusieurs contacts de confiance signalent le même compte.
+
+Voici un [événement signé de kind `1984`](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2) :
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 et NIP-09 résolvent des problèmes différents](https://github.com/nostr-protocol/nips/tree/master). Un signalement de kind `1984` peut cibler le compte ou l'événement de quelqu'un d'autre, mais ne confère aucune autorité de suppression. Une requête de kind `5` exprime l'intention de l'auteur original et n'est valide que contre les propres événements de cet auteur. Aucun ne garantit la suppression : NIP-56 délède délibérément l'action à la politique de modération locale, tandis que NIP-09 dépend des relais et des clients honorant une requête authentifiée.
+
+Les implémentations exposent ces choix dans différents produits. La [PR Divine #6591](https://github.com/divinevideo/divine-mobile/pull/6591) corrige la livraison de signalement dans un client de vidéo courte, la [PR Conduit #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) lit les signalements comme contexte borné pour les participants de marketplace, et le [module NIP-56 de nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) publie et traite les événements de signalement. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) liste aussi le support NIP-56 actuel.
+
+
+---
+
+Envoyez un DM NIP-17 pour partager un projet ou une actualité via le [projet Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/it/newsletters/2026-08-12-newsletter.md
+++ b/content/it/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,203 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Strumenti di identità post-quantum, messaggistica cifrata e firma più robuste, impostazioni comunitarie portabili e lavoro sul protocollo su NIP e Concord."
+---
+
+Bentornati su [Nostr Compass](https://nostrcompass.org), la vostra guida settimanale a Nostr.
+
+**Questa settimana:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) aggiunge chiavi post-quantum e messaggi protetti opt-in accanto alle identità Nostr esistenti. [Divine](https://github.com/divinevideo/divine-mobile) rafforza l'isolamento degli account, la validazione dei messaggi privati e la conferma di pubblicazione; [MDK](https://github.com/marmot-protocol/mdk) rafforza convergenza e recupero dei gruppi cifrati; e [Amber](https://github.com/greenart7c3/Amber) rende esplicite le decisioni di firma raggruppate. Le release migliorano connessioni ai wallet, chat cifrata, scoperta sociale, sincronizzazione tra dispositivi e firma remota, mentre il lavoro sul protocollo copre identità e comunità cifrate. Gli approfondimenti spiegano richieste di cancellazione autenticate e segnalazioni decentralizzate.
+
+## Storie principali
+
+### nostr-wot-extension 0.4.0 aggiunge chiavi post-quantum accanto a un'identità Nostr
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) è un'estensione del browser per gestire identità Nostr e firmare. Gli account creati da un seed a 24 parole possono ora derivare chiavi di crittografia ML-KEM-1024 e di firma ML-DSA-87 accanto alla chiave Nostr esistente. Un flusso con un clic pubblica un'attestazione di kind `10203` che lega la chiave pubblica Nostr a entrambe le chiavi pubbliche post-quantum e include una proof of possession ML-DSA. Gli account importati da un mnemonic a 12 parole, un `nsec` nudo, un firmatario remoto o una chiave read-only non possono usare il flusso di derivazione, e l'estensione spiega tale limitazione nella vista dell'account.
+
+La release aggiunge anche messaggi diretti post-quantum opt-in. Combina il shared secret ML-KEM con la [chiave di conversazione del messaggio cifrato NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) esistente tramite HKDF, poi mantiene i normali strati gift-wrap NIP-59 per nascondere i metadati nella consegna via relay. La crittografia non ricade mai silenziosamente dopo che un destinatario ha optato, mentre la decrittazione seleziona automaticamente il percorso appropriato. Questo protegge il nuovo percorso dei messaggi contro un successivo recupero di una chiave privata Nostr odierna, ma non sostituisce le firme degli eventi secp256k1; la release lascia esplicitamente quella migrazione più ampia a un futuro coordinamento con relay e client.
+
+### Divine Mobile 1.0.19 rafforza account, messaggi privati e pubblicazione
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) è un client mobile di video brevi che pubblica e recupera video tramite Nostr. Il selettore di account ora costruisce ogni identità connessa attorno a un container scoped per account, e una correzione alla pubblicazione impedisce che un video venga inviato sotto l'account sbagliato. I percorsi di pubblicazione sui relay attendono ora una risposta `OK` con semantica di successo esplicita, mentre un frame relay `CLOSED` può terminare la propria query in sospeso invece di lasciare la richiesta appesa.
+
+La [gestione dei messaggi privati](https://github.com/divinevideo/divine-mobile/pull/6368) rifiuta campi rumor non autenticati e seal non firmati, ripristina quattro casi di messaggi mancanti e instrada le conversazioni di gruppo da partecipanti completamente seguiti nella inbox. La release preserva anche i tag sugli eventi video indirizzabili quando le liste vengono aggiornate e consuma le richieste di cancellazione osservate così che i video rimossi scompaiano dallo stato locale. Queste modifiche seguono il lavoro sui timeout per query per relay trattato la scorsa settimana, ma spostano il focus dall'isolamento del recupero ai confini dell'identità, alla validazione dei messaggi e alla conferma di pubblicazione.
+
+### MDK 0.9.11 rafforza convergenza e recupero dei gruppi Marmot
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) è un kit di sviluppo Rust per Marmot, un protocollo di messaggistica di gruppo cifrata trasportato su Nostr. La release costruisce un sistema più ampio di convergenza e recupero attorno alla macchina a stati del gruppo: i passaggi di convergenza obsoleti si riaprono alla punta corrente del gruppo, le proiezioni delle capability in ingresso vengono committate atomicamente, i messaggi differiti ricevono durate di vita limitate tra i riavvii, e i checkpoint indirizzati per commit aiutano a recuperare i fork di commit propri di un'identità. Gli invii non stabili possono essere accodati e recuperati, mentre un percorso di stallo dell'epoca scala verso backfill e i messaggi inviati sopravvivono al lavoro di convergenza.
+
+[Storage e integrazioni host](https://github.com/marmot-protocol/mdk/pull/1201) ricevono un passaggio parallelo di hardening. MDK elimina in modo sicuro le proiezioni SQLite potate, azzera le chiavi private importate, gli intermedi di export delle chiavi cifrate NIP-49 e i buffer di serializzazione OpenMLS, e redige le chiavi delle immagini di gruppo dall'output di debug. L'import dell'account può riprendere dopo un'interruzione, i percorsi di storage privato iOS e Android sono riparati, e gli host possono chiudere esplicitamente lo storage prima della sospensione. Nuove proiezioni leggere del roster e dell'appartenenza locale riducono ciò che le applicazioni devono leggere, mentre il connettore Hermes può consegnare diverse immagini generate da agent come un unico album Marmot.
+
+### Nostria 4.1.67 espande l'amministrazione delle comunità cifrate
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) è un client social web e desktop per Nostr. Si basa sui gruppi sperimentali [NIP-29](/it/topics/nip-29/) (gruppi gestiti da relay) e sulle comunità cifrate Concord introdotti in 4.1.53, aggiungendo scioglimento della comunità, amministrazione di icona e banner, caricamenti di foto cifrati con anteprime compresse, un selettore completo di reazioni e un layout a doppio pannello che mantiene aperta una comunità mentre l'utente legge note o articoli. La release aggiunge anche messaggistica in thread e un hub combinato per chat pubbliche, di gruppo e private.
+
+### Amber 6.4.0 rende esplicita ogni decisione di firma raggruppata
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) è un firmatario Android che mantiene le chiavi private Nostr separate dalle applicazioni che richiedono firme. La sua schermata multi-richiesta ridisegnata fornisce controlli Approva e Nega per ogni richiesta e ogni gruppo, sostituendo il precedente flusso di selezione e conferma. Le richieste negate inviate tramite l'interfaccia bunker mediata da relay di Amber ricevono ora risposte di errore corrette, così il client richiedente può distinguere un rifiuto da un firmatario bloccato.
+
+Il [codice sorgente taggato di Amber](https://github.com/greenart7c3/Amber/tree/v6.4.0) aggiunge anche etichette localizzate e leggibili per altri 113 kind di evento in ogni locale distribuito. Le aggiunte includono eventi di gruppo Concord, segnalibri di repository Git [NIP-51](/it/topics/nip-51/) (liste e insiemi curati) ed eventi di presenza in stanza [NIP-53](/it/topics/nip-53/) (attività live), dando agli utenti più contesto su dati non familiari prima di approvare una firma. Una guardia concurrent-map corregge anche un crash di sottoscrizione ai relay che poteva produrre un `NegativeArraySizeException`.
+
+### Safebox Acorn separa un componente di recupero portatile dall'app web
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) è un componente Python autonomo e un'interfaccia a riga di comando per proteggere chiavi, fondi e record controllati dall'utente tramite stato supportato da Nostr. L'estrazione di Acorn dalla più ampia applicazione web Safebox consente a un altro progetto Python di installare il runtime e usare i suoi helper per chiavi, profili Nostr, relay, record, Cashu, Lightning e crittografia senza adottare l'interfaccia web. Le attuali primitive di protezione dei record possono generare una nuova chiave a 256 bit, derivarne una da entropia fornita separatamente e codificare la chiave esatta come frase di recupero di 24 parole con checksum.
+
+La [guida al recupero e alla continuità](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) del progetto presenta Acorn come componente di protocollo sostituibile all'interno di una Safebox domestica o comunitaria. Il design mantiene lo stato cifrato disponibile tramite un relay locale e repliche indipendenti, così il recupero non dipende da un singolo dispositivo, applicazione, relay, mint o fornitore di servizi. La documentazione chiarisce con attenzione il limite attuale: la cifratura dei record protetti è ancora in fase di progettazione, quindi le applicazioni non dovrebbero far dipendere i record dalla nuova chiave di protezione finché quel profilo non sarà implementato e sottoposto a revisione.
+
+
+## Rilasci taggati
+
+### Mostro Core 0.14.2 cambia l'envelope della chat cifrata
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) è la libreria Rust di tipi condivisi e funzioni peer-to-peer usata dal daemon di scambio Mostro e dai suoi client. La [versione 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) sostituisce i messaggi di chat gift-wrap con envelope di kind 14 che usano chiavi separate di crittografia della conversazione e di firma derivate dal shared secret dei peer. Il nuovo reader valida autore, firma, destinatario, timestamp e dimensione del contenuto, mentre gli helper gift-wrap legacy restano disponibili così i client possono leggere entrambi i formati durante la migrazione.
+
+### Mostro 0.18.1 avvia un percorso escrow Cashu e rafforza il daemon
+
+[Mostro](https://github.com/MostroP2P/mostro) è un daemon di scambio Lightning peer-to-peer che coordina gli ordini tramite Nostr. La [versione 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) getta le basi per un backend escrow Cashu, inclusi configurazione, helper del database, integrazione con mint, wiring all'avvio e la prima azione di lock. Può anche usare prezzi annunciati da un nodo fidato su Nostr e pubblica requisiti di proof-of-work per il primo contatto nel suo evento info sostituibile. La release aggiorna la dipendenza Nostr per una correzione denial-of-service NIP-44, rimuove le chiavi private dai log di restore-session, rifiuta messaggi di cooperative-cancel non autorizzati, rafforza i fetch LNURL contro server-side request forgery e hang, valida le invoice di payout e ripristina le sottoscrizioni alle hold invoice dopo un riavvio.
+
+### LaWallet NWC 2.3.0 aggiunge notifiche Nostr e ricevute zap
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) è una piattaforma Lightning Address open-source che collega i wallet tramite [Nostr Wallet Connect](/it/topics/nip-47/) (NIP-47). La [versione 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) permette a ogni wallet di inviare notifiche di ricezione e inoltro come eventi Nostr configurabili, inclusi un tag destinatario `p`, relay selezionati, contenuto templato e crittografia opzionale [NIP-44](/it/topics/nip-44/) (crittografia versionata); i tentativi riusano lo stesso ID evento firmato. Accetta anche zap request e pubblica ricevute firmate [NIP-57](/it/topics/nip-57/) (zap) di kind 9735 dopo il regolamento, mentre una nuova vista delle capability dell'indirizzo mostra se l'indirizzo risolto supporta NIP-05, NIP-57 e i protocolli Lightning Address correlati.
+
+### nostr-double-ratchet TypeScript 0.0.166 lega inviti pubblici alle chiavi di sessione
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) fornisce primitive TypeScript e Rust per messaggistica diretta e di gruppo cifrata end-to-end su relay Nostr. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) richiede che una risposta a un invito dimostri la proprietà della sua chiave di sessione, impedendo a un invito pubblico riutilizzabile di legare un'identità Nostr alla sessione di un'altra parte. La release rifiuta anche campi rumor malformati e rafforza la validazione del payload; le sessioni esistenti continuano a funzionare, ma un invitante aggiornato rifiuta risposte senza prova da invitati più vecchi.
+
+### cln-nip47 0.2.0 espande e isola le richieste NWC
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) è un plugin Core Lightning che espone un nodo ai wallet tramite [Nostr Wallet Connect](/it/topics/nip-47/) (NIP-47). La [versione 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) aggiunge metodi NWC per creare, annullare e regolare hold invoice più una notifica `hold_invoice_accepted`, e pubblica l'insieme di metodi che il nodo connesso supporta effettivamente. Le risposte transaction-list si fermano ora a 500 voci e circa 128 kB, gli eventi di richiesta vengono deduplicati per ID evento, e la notifica fallita di un client non impedisce più la consegna agli altri client. La release rimuove anche i due metodi multi-payment che non fanno più parte della specifica NWC.
+
+### ClipRelay 0.1.3 ripristina connessioni a relay e firmatario dopo periodi di inattività
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) sincronizza gli appunti di un utente tra dispositivi tramite relay Nostr, cifrando il contenuto verso la stessa identità con [NIP-44](/it/topics/nip-44/) (crittografia versionata). Le release [desktop](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) e [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 corrispondenti aggiungono una casella di testo per inviare testo digitato direttamente agli appunti di un altro dispositivo. Testano anche la liveness con round trip reali sui relay dopo periodi di inattività, escalando da risottoscrizione a sostituzione del socket e a un pool di connessioni ricostruito, mentre le chiamate al firmatario [NIP-46](/it/topics/nip-46/) (firma remota mediata da relay) bloccate ora scadono e si ricostruiscono automaticamente.
+
+### NoorNote 1.3.2 sposta la scoperta degli articoli nel grafo sociale
+
+[NoorNote](https://github.com/77elements/noornote) è un client Nostr per post social, messaggi cifrati, articoli in formato lungo e altri kind di evento su web, desktop e Android. La [versione 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) sostituisce il feed globale piatto degli articoli con una scoperta tratta da contatti di primo, secondo e terzo grado, offrendo ai lettori una timeline di articoli radicata nel grafo dei follow. Collassa anche raffiche di messaggi diretti riprodotti da mittenti sconosciuti in un'unica notifica continua invece di produrre una pila di toast man mano che arriva la cronologia dei relay.
+
+
+### Bray 2.4.0 aggiunge un dialetto compatto di firma remota
+
+[Bray](https://github.com/forgesworn/bray) è un server MCP Nostr che offre ad agenti software e persone strumenti per accesso ai relay, identità, pubblicazione e firma remota. La [versione 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) accetta una richiesta di firma il cui evento è un oggetto oltre alla forma stringificata usata da [NIP-46](/it/topics/nip-46/) (firma remota mediata da relay), e aggiunge `sign_event_compact`, che restituisce solo ID evento, firma, chiave pubblica e timestamp. Quel formato più piccolo di richiesta e risposta riduce l'uso di memoria per firmatari hardware vincolati, mentre il flusso standard `sign_event` resta invariato e entrambi i dialetti producono una firma sull'ID dell'evento ricevuto.
+
+
+## Appena scoperti
+
+### Pact porta legami tra agenti con consenso reciproco su Nostr
+
+[Pact](https://github.com/bobodread876/pact), scoperto questa settimana, è uno strato relazionale in fase iniziale per agenti software costruito su MATE.md e su una bozza di trasporto NIP-BD. I suoi legami firmati con consenso reciproco sono detenuti dalle chiavi degli agenti stessi e possono essere pubblicati su Nostr, mentre i legami privati usano il gift wrapping [NIP-59](/it/topics/nip-59/) (metadati nascosti). Il monorepo include un server MCP, SDK TypeScript, client da riga di comando, daemon self-hostable e interfaccia web. La sua attività più recente nel repository precede la finestra settimanale di questo numero, quindi questa è una nota di scoperta e non l'affermazione di una nuova release.
+
+
+## Modifiche non rilasciate
+
+### nostrord mantiene sincronizzato il muting di gruppo tra dispositivi
+
+[nostrord](https://github.com/nostrord/nostrord) è un client multipiattaforma per comunità gestite da relay. La [PR #250](https://github.com/nostrord/nostrord/pull/250) memorizza le scelte di mute per gruppo di ogni account in un evento [NIP-78](/it/topics/nip-78/) (dati specifici dell'applicazione) di kind `30078` auto-cifrato, così un'impostazione fatta su un dispositivo può seguire l'utente su un altro senza rivelare la lista dei gruppi al relay. Il record sostituibile usa l'ordinamento per evento più recente, ascolta le modifiche in tempo reale e ripristina l'interfaccia quando la firma o la pubblicazione falliscono invece di lasciare lo stato locale fuori sync. I gruppi mutati smettono anche di contribuire ai totali non letti visibili mantenendo la posizione non letta per la visita successiva.
+
+### Amethyst completa il ciclo di vita degli inviti Concord
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) è un client Nostr Android il cui supporto alle comunità cifrate implementa il protocollo Concord. La [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) permette ai link di invito di sopravvivere a un refounding della comunità riemettendo i bundle alle stesse coordinate indirizzabili, mentre un controllo di ban impedisce a un membro rimosso di usare quel percorso di recupero. Implementa anche la lista inviti cifrata CORD-05 sia sull'app sia sul client da riga di comando `amy`, aggiunge tombstone di revoca per link, e richiede conferma del relay prima di eliminare l'unica chiave di firma memorizzata che può ritirare un link. Lo stesso lavoro dà a `amy` i percorsi di consegna della control key, refounding, rekeying e recupero dei membri stranded necessari per seguire le epoche comunitarie successive.
+
+### Buzz porta l'aspetto di ogni comunità tra desktop e mobile
+
+[Buzz](https://github.com/block/buzz) è uno workspace comunitario basato su Nostr con client desktop e mobile. Le PR desktop [PR #3653](https://github.com/block/buzz/pull/3653) e mobile [PR #3767](https://github.com/block/buzz/pull/3767) unite memorizzano tema, accento e scelta della modalità di sistema di ogni comunità come record NIP-78 cifrato sul relay di quella comunità. Entrambi i client condividono lo stesso payload versionato e mantengono cache locali scoped per identità, così cambiare comunità o account non può applicare l'aspetto sbagliato mentre il relay non è disponibile. Ordinamento di sostituzione, scritture protette e risottoscrizione dopo una connessione chiusa permettono ai due client di riconvergere dopo la riconnessione.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) è seguito prima del cutoff del numero con un passaggio di performance e affidabilità. Rimuove regressioni introdotte dopo 0.5.9, accelera il caricamento dei canali, limita la retention iniziale della timeline, coalescesce la persistenza dello stato di lettura, preserva timeline di canale fresche e impedisce al worker di ingest dei relay di crashare sulle reazioni agli eventi di progetto. Aggiunge anche l'invio di un messaggio di thread a un canale e restringe la ricerca desktop allo scope previsto.
+
+
+## Aggiornamenti NIP e lavoro di specifica del protocollo
+
+### NIP
+
+La [PR NIPs #2435](https://github.com/nostr-protocol/nips/pull/2435) è un emendamento aperto a NIP-34, che standardizza la collaborazione su repository git tramite eventi Nostr. Aggiunge un tag `b` opzionale a un evento pull-request così l'autore può nominare un branch di destinazione diverso dal default del repository. La proposta corrisponde al supporto già implementato in ngit e GitWorkshop, ma non è entrata nella specifica.
+
+La [PR NIPs #2434](https://github.com/nostr-protocol/nips/pull/2434) è una proposta aperta per chiavi di identità post-quantum. Deriva chiavi post-quantum di crittografia e firma accanto alla chiave secp256k1 esistente da un seed di derivazione chiavi NIP-06, poi lega le chiavi pubbliche all'identità Nostr con un'attestazione di kind `10203`. La bozza limita la sua pretesa alla protezione della riservatezza dei messaggi precedenti se secp256k1 venisse compromesso in seguito; non sostituisce le firme degli eventi odierne.
+
+La [PR NIPs #2431](https://github.com/nostr-protocol/nips/pull/2431) è un emendamento aperto a NIP-07 per firmatari browser. Un client potrebbe allegare la chiave pubblica che si aspetta alle richieste di firma o crittografia, richiedendo al firmatario di usare quell'account o rifiutare la chiamata. Ciò impedirebbe a una pagina di continuare silenziosamente sotto un'identità diversa dopo che l'utente cambia account nel firmatario.
+
+La [PR NIPs #1813](https://github.com/nostr-protocol/nips/pull/1813) resta una proposta open double-ratchet dopo lavoro sostanziale nella finestra. Specifica conversazioni cifrate forward-secret le cui chiavi avanzano con i messaggi, con un'implementazione già disponibile nella libreria nostr-double-ratchet e in Iris. Resta una bozza, non un NIP unito.
+
+La [PR NIPs #2433](https://github.com/nostr-protocol/nips/pull/2433) si è aperta e chiusa senza merge nella finestra. Proponeva di chiarire gli errori relay NIP-42 così `auth-required` significherebbe che un'altra autenticazione potrebbe cambiare il risultato, mentre `restricted` significherebbe che non potrebbe. La distinzione riguardava connessioni autenticate per una chiave ma ancora prive di autorizzazione per un'altra; lo stato chiuso significa che la formulazione non è entrata nella specifica.
+
+La [PR NIPs #2378](https://github.com/nostr-protocol/nips/pull/2378), trattata in precedenza mentre era ancora proposta, si è ora chiusa senza merge. I suoi eventi proposti di agent passport, discovery, task, marketplace, invoice e connection restano quindi fuori dall'insieme dei NIP.
+
+Il [commit NIPs 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) ha unito una correzione solo documentale a NIP-29. Aggiunge un tag `previous` all'esempio di metadati del gruppo, mostrando come un evento di sostituzione possa identificare l'evento che sostituisce. Questo chiarisce un esempio e non introduce una nuova funzionalità di protocollo.
+
+### Concord e CORD
+
+La [PR CORD #18](https://github.com/concord-protocol/concord/pull/18) frammenterebbe le Community List cifrate su eventi di kind `33302`, rimuoverebbe il limite di 50 appartenenze e poterebbe le voci ritirate per restare entro i limiti dei relay. Altre due proposte aperte aggiungono [locator di menzione privati](https://github.com/concord-protocol/concord/pull/16) e un [segnale di pausa](https://github.com/concord-protocol/concord/pull/17) che sospende la chat senza scartare i messaggi.
+
+La [PR CORD-02 #15](https://github.com/concord-protocol/concord/pull/15) si è unita il 6 agosto e restringe le scritture al piano di controllo di una comunità. Proprietari e staff detengono un nuovo secret di firma `control_root`, mentre tutti i membri conservano la chiave pubblica derivata e la read key necessarie per verificare e decifrare lo stato di moderazione. La write key è una barriera anti-spam, non un sostituto delle firme interne dell'attore e dei controlli del roster che stabiliscono l'autorità.
+
+La [PR CORD #12](https://github.com/concord-protocol/concord/pull/12), trattata in precedenza come bozza aperta, si è ora chiusa senza merge. La sua porzione di piano di controllo è stata superata dall'emendamento CORD-02 più ristretto unito sopra, mentre canali restricted-write e gli altri materiali di bozza non sono entrati nella specifica.
+
+## Approfondimento NIP
+
+### Richieste di cancellazione degli eventi (NIP-09)
+
+[NIP-09](/it/topics/nip-09/) (richieste di cancellazione eventi), definito dalla [specifica principale](https://github.com/nostr-protocol/nips/blob/master/09.md), offre a un autore di evento un modo firmato di chiedere a relay e client di smettere di servire uno o più eventi di quell'autore. Non cancella ogni copia. Trasporta l'intenzione dell'autore attraverso la stessa rete di relay che ha distribuito l'evento originale.
+
+La richiesta è un evento firmato ordinario di kind `5`. I suoi tag contengono uno o più riferimenti `e` a ID evento specifici o riferimenti `a` a coordinate di eventi indirizzabili, e le [regole dei tag NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) dicono che dovrebbe includere un tag `k` per ogni kind di evento referenziato. Il `content` opzionale può spiegare il motivo. Per un riferimento `a`, un relay dovrebbe rimuovere ogni versione a quella coordinata il cui timestamp non è successivo al `created_at` della richiesta, impedendo a una vecchia richiesta di cancellazione di sopprimere una sostituzione successiva.
+
+[L'autore è il confine di sicurezza](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Un relay dovrebbe smettere di pubblicare un evento referenziato solo quando la sua `pubkey` corrisponde alla `pubkey` della richiesta di cancellazione, e un client deve eseguire quel controllo prima di nascondere un evento. Un relay potrebbe non possedere l'evento referenziato e quindi non essere in grado di validare la relazione quando accetta la richiesta, così i client non possono trattare l'accettazione del relay come prova che la cancellazione fosse autorizzata. La specifica chiede anche ai relay di conservare la richiesta di kind `5` perché un altro client potrebbe già detenere l'evento originale e incontrare la richiesta in seguito.
+
+Ecco un [evento firmato di kind `5`](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+La cancellazione resta una politica cooperativa, non la revoca di un oggetto firmato. Un relay, una cache, uno screenshot o un client offline possono preservare i byte originali, e cancellare la richiesta di kind `5` stessa non la annulla. I client possono nascondere l'obiettivo, contrassegnarlo come disconosciuto o mostrare il motivo della richiesta, ma dovrebbero dire agli utenti che una cancellazione universale non può essere garantita. Questo differisce da [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md), dove un tag `expiration` chiede ai relay di smettere di memorizzare un evento dopo un tempo scelto al momento della pubblicazione. NIP-09 gestisce una decisione successiva dell'autore e può puntare a eventi già distribuiti.
+
+Le implementazioni attuali applicano quella politica a livelli diversi. La [PR Divine #6623](https://github.com/divinevideo/divine-mobile/pull/6623) rimuove i video cancellati dall'event store del client, la [PR strfry #251](https://github.com/hoytech/strfry/pull/251) estende le richieste di cancellazione valide ai destinatari gift-wrap, e [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) dichiara supporto NIP-09 nel suo client. Il [client di gruppo di nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) offre un altro percorso di implementazione attuale.
+
+### Segnalazioni (NIP-56)
+
+[NIP-56](/it/topics/nip-56/) (eventi di segnalazione), definito dalla [specifica principale](https://github.com/nostr-protocol/nips/blob/master/56.md), standardizza una segnalazione firmata su un account, un evento o un blob referenziato. Separa il segnale di segnalazione dalla decisione di moderazione, permettendo a ogni client o relay di scegliere quali reporter fidare e quale risposta si adatti alla propria politica.
+
+Una segnalazione usa kind `1984` e deve identificare l'account segnalato in un tag `p`. Segnalare una nota richiede anche un tag `e` per l'ID evento. Il terzo valore del tag porta una delle categorie specificate: `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation` o `other`. Una segnalazione su un blob può usare il suo hash in un tag `x`, un tag `e` per l'evento che ha referenziato il blob, e un tag `server` opzionale per una posizione. I tag opzionali `L` e `l` da [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) possono aggiungere un'etichetta con namespace quando l'elenco fisso di categorie non è abbastanza preciso.
+
+[L'evento prova solo che una chiave ha fatto un'accusa](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). Il contenuto segnalato non diventa falso, illegale o rimovibile solo perché esiste un kind `1984` valido, e un relay aperto non può contare in sicurezza segnalazioni anonime come voti. La specifica sconsiglia la moderazione automatica del relay perché le segnalazioni sono facili da manipolare, permettendo però agli amministratori di relay di agire su segnalazioni da moderatori che già fidano. Un client può invece pesare le segnalazioni attraverso il grafo sociale dell'utente, per esempio sfocando contenuti dopo che diversi contatti fidati segnalano lo stesso account.
+
+Ecco un [evento firmato di kind `1984`](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 e NIP-09 risolvono problemi diversi](https://github.com/nostr-protocol/nips/tree/master). Una segnalazione di kind `1984` può prendere di mira l'account o l'evento di qualcun altro, ma non conferisce alcuna autorità di cancellazione. Una richiesta di kind `5` esprime l'intenzione dell'autore originale ed è valida solo contro gli eventi di quell'autore. Nessuna garantisce la rimozione: NIP-56 delega deliberatamente l'azione alla politica di moderazione locale, mentre NIP-09 dipende da relay e client che onorano una richiesta autenticata.
+
+Le implementazioni espongono quelle scelte in prodotti diversi. La [PR Divine #6591](https://github.com/divinevideo/divine-mobile/pull/6591) corregge la consegna delle segnalazioni in un client di video brevi, la [PR Conduit #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) legge le segnalazioni come contesto limitato per i partecipanti al marketplace, e il [modulo NIP-56 di nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) pubblica e processa eventi di segnalazione. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) elenca anche il supporto NIP-56 attuale.
+
+
+---
+
+Invia un DM NIP-17 per condividere un progetto o una notizia tramite il [progetto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/ja/newsletters/2026-08-12-newsletter.md
+++ b/content/ja/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "ポスト量子アイデンティティツール、より強固な暗号化メッセージングと署名、ポータブルなコミュニティ設定、NIPとConcordにまたがるプロトコル作業。"
+---
+
+[Nostr Compass](https://nostrcompass.org)へようこそ。Nostrのウィークリーガイドです。
+
+**今週:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension)は、既存のNostrアイデンティティに加えてポスト量子鍵とオプトインの保護メッセージを追加します。[Divine](https://github.com/divinevideo/divine-mobile)はアカウント分離、プライベートメッセージの検証、公開確認を強化し、[MDK](https://github.com/marmot-protocol/mdk)は暗号化グループの収束とリカバリを強化します。[Amber](https://github.com/greenart7c3/Amber)はグループ化された署名決定を明示的にします。リリースではウォレット接続、暗号化チャット、ソーシャルディスカバリ、デバイス同期、リモート署名が改善され、プロトコル作業はアイデンティティと暗号化コミュニティをカバーします。ディープダイブでは認証済み削除リクエストと分散型通報を解説します。
+
+## トップストーリー
+
+### nostr-wot-extension 0.4.0はNostrアイデンティティにポスト量子鍵を追加
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0)は、Nostrアイデンティティの管理と署名のためのブラウザ拡張です。24語seedから作成されたアカウントは、既存のNostr鍵に加えてML-KEM-1024暗号化鍵とML-DSA-87署名鍵を導出できるようになりました。ワンクリックのフローで、Nostr pubkeyを両方のポスト量子公開鍵に結び付け、ML-DSA所有証明を含むkind `10203`の証明を公開します。12語ニーモニック、生の`nsec`、リモートsigner、読み取り専用鍵からインポートされたアカウントは導出フローを使用できず、拡張機能はアカウントビューでその制限を説明します。
+
+このリリースでは、オプトインのポスト量子ダイレクトメッセージも追加されます。ML-KEM共有秘密を既存の[NIP-44暗号化メッセージ会話鍵](https://github.com/nostr-protocol/nips/blob/master/44.md)とHKDFで組み合わせ、relay配信には通常の[NIP-59](/ja/topics/nip-59/)（gift wrap）メタデータ非表示レイヤーを維持します。受信者がオプトインした後、暗号化は黙ってフォールバックせず、復号は適切なパスを自動的に選択します。これは新しいメッセージパスを、現行のNostr秘密鍵が後から復元される攻撃から保護しますが、secp256k1イベント署名を置き換えるものではありません。リリースは、その大規模な移行をrelayとclientとの将来の調整に委ねることを明示しています。
+
+### Divine Mobile 1.0.19はアカウント、プライベートメッセージ、公開を強化
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19)は、Nostr経由で動画を公開・取得するモバイルショート動画clientです。アカウントスイッチャーは各サインイン済みアイデンティティをアカウントスコープのコンテナで構成するようになり、公開の修正により動画が誤ったアカウントで送信されるのを防ぎます。relay公開パスは明示的な成功セマンティクス付きの`OK`応答を待つようになり、relay `CLOSED`フレームは保留中のクエリを宙ぶらりにせず、自身のクエリを終了できます。
+
+[プライベートメッセージ処理](https://github.com/divinevideo/divine-mobile/pull/6368)は、未認証のrumorフィールドと未署名sealを拒否し、4つの欠落メッセージケースを復元し、完全にフォローされた参加者からのグループ会話を受信箱にルーティングします。このリリースでは、アドレサブル動画イベントのtagをリスト更新時に保持し、観測された削除リクエストを消費して削除された動画をローカル状態から消します。これらの変更は先週取り上げたrelayごとのクエリタイムアウト作業に続くものですが、焦点を取得の分離からアイデンティティ境界、メッセージ検証、公開確認へ移します。
+
+### MDK 0.9.11はMarmotグループの収束とリカバリを強化
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11)は、Nostr上で運ばれる暗号化グループメッセージングプロトコルMarmot向けのRust開発キットです。このリリースはグループ状態マシンを中心に、より大きな収束・リカバリシステムを構築します。古い収束パスは現在のグループtipで再開し、インバウンドcapability投影は原子的にコミットし、延期メッセージは再起動をまたいで有界な寿命を受け取り、コミットアドレス指定チェックポイントはアイデンティティ自身のコミットフォークのリカバリに役立ちます。非安定送信はキューに入れてリカバリでき、epoch-stallパスはバックフィルへエスカレートし、送信済みメッセージは収束作業を生き延びます。
+
+[ストレージとホスト統合](https://github.com/marmot-protocol/mdk/pull/1201)も並行して強化されます。MDKは剪定されたSQLite投影を安全に削除し、インポートされた秘密鍵、[NIP-49](/ja/topics/nip-49/)（暗号化秘密鍵）エクスポート中間体、OpenMLSシリアライゼーションバッファをゼロ化し、デバッグ出力からグループ画像鍵を編集します。アカウントインポートは中断後に再開でき、iOSとAndroidのプライベートストレージパスが修復され、ホストはサスペンド前にストレージを明示的に閉じられます。新しい軽量rosterとローカルメンバーシップ投影はアプリケーションが読み取る量を減らし、Hermesコネクタは複数のエージェント生成画像を1つのMarmotアルバムとして配信できます。
+
+### Nostria 4.1.67は暗号化コミュニティ管理を拡張
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67)は、Nostr向けのウェブおよびデスクトップソーシャルclientです。4.1.53で導入された実験的な[NIP-29](/ja/topics/nip-29/)（relay管理グループ）とConcord暗号化コミュニティを基盤に、コミュニティ解散、アイコンとバナー管理、圧縮プレビュー付き暗号化写真アップロード、フルリアクションピッカー、ユーザーがノートや記事を読みながらコミュニティを開いたままにするデュアルペインレイアウトを追加します。このリリースでは、スレッドメッセージングと公開・グループ・プライベートチャットを統合したハブも追加されます。
+
+### Amber 6.4.0はグループ化された署名決定をすべて明示的にする
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0)は、Nostr秘密鍵を署名を要求するアプリケーションから分離して保持するAndroid signerです。再設計されたマルチリクエスト画面は、各リクエストと各グループにApproveとDenyコントロールを提供し、以前の選択・確認フローを置き換えます。Amberのrelay仲介bunkerインターフェース経由で拒否されたリクエストは、適切なエラー応答を受け取るようになり、要求側clientは拒否と停滞したsignerを区別できます。
+
+[Amberのタグ付きソース](https://github.com/greenart7c3/Amber/tree/v6.4.0)は、出荷済みすべてのロケールで113種類のイベントkindに対するローカライズされた人間可読ラベルも追加します。追加にはConcordグループイベント、[NIP-51](/ja/topics/nip-51/)（リスト）Gitリポジトリブックマーク、[NIP-53](/ja/topics/nip-53/)（ライブアクティビティ）ルームプレゼンスイベントが含まれ、ユーザーは署名を承認する前に馴染みのないデータについてより多くの文脈を得られます。concurrent-mapガードは、`NegativeArraySizeException`を引き起こしうるrelayサブスクリプションクラッシュも修正します。
+
+### Safebox Acornはポータブルなリカバリコンポーネントをウェブアプリから分離
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn)は、Nostrバックエンド状態でユーザー管理鍵、資金、レコードを保護するためのスタンドアロンPythonコンポーネントおよびコマンドラインインターフェースです。Acornをより広いSafeboxウェブアプリケーションから抽出することで、別のPythonプロジェクトがランタイムをインストールし、ウェブインターフェースを引き受けずに鍵、Nostrプロフィール、relay、レコード、Cashu、Lightning、暗号ヘルパーを使用できます。現在のレコード保護プリミティブは、新鮮な256ビット鍵を生成し、別途供給されたエントロピーから1つを導出し、正確な鍵をチェックサム付き24語リカバリフレーズとしてエンコードできます。
+
+プロジェクトの[リカバリと継続性ガイド](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/)は、Acornを家庭またはコミュニティSafebox内の交換可能なプロトコルコンポーネントとして位置づけます。設計は暗号化状態をローカルrelayと独立レプリカ経由で利用可能に保ち、リカバリが1台の機器、アプリケーション、relay、mint、サービスプロバイダーに依存しないようにします。ドキュメントは現在の境界について慎重です。保護レコードの暗号化は設計中のままであり、そのプロファイルが実装・レビューされるまで、アプリケーションは新しいレコード保護鍵にレコードを依存させるべきではありません。
+
+
+## タグ付きリリース
+
+### Mostro Core 0.14.2は暗号化チャットエンベロープを変更
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core)は、Mostro取引デーモンとそのclientが使用する共有型およびピアツーピア関数のRustライブラリです。[バージョン0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2)は、gift wrapされたチャットメッセージを、ピアの共有秘密から導出した別々の会話暗号化鍵と署名鍵を使用するkind 14エンベロープに置き換えます。新しいリーダーは著者、署名、受信者、タイムスタンプ、コンテンツサイズを検証し、レガシーgift wrapヘルパーは移行中に両形式を読めるよう残ります。
+
+### Mostro 0.18.1はCashu escrowパスを開始しデーモンを強化
+
+[Mostro](https://github.com/MostroP2P/mostro)は、Nostr経由で注文を調整するピアツーピアLightning取引デーモンです。[バージョン0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1)は、Cashu escrowバックエンドの基盤を築き、設定、データベースヘルパー、mint統合、起動配線、最初のロックアクションを含みます。信頼できるノードがNostr経由で発表する価格も使用でき、置換可能infoイベントで初回接触のproof-of-work要件を告知します。このリリースは[NIP-44](/ja/topics/nip-44/)（暗号化メッセージ）DoS修正のためNostr依存を更新し、リストアセッションログから秘密鍵を削除し、未承認の協調キャンセルメッセージを拒否し、LNURL取得をSSRFとハングから保護し、支払いinvoiceを検証し、再起動後にhold invoiceサブスクリプションを復元します。
+
+### LaWallet NWC 2.3.0はNostr通知とzapレシートを追加
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc)は、[Nostr Wallet Connect](/ja/topics/nip-47/)（NWC）経由でウォレットを接続するオープンソースLightning Addressプラットフォームです。[バージョン2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0)は、各ウォレットが受信・転送通知を設定可能なNostrイベントとして送信できるようにし、受信者`p` tag、選択relay、テンプレート化コンテンツ、オプションの[NIP-44](/ja/topics/nip-44/)（暗号化メッセージ）暗号化を含みます。再試行は同じ署名済みイベントIDを再利用します。またzapリクエストを受け入れ、決済後に署名済み[NIP-57](/ja/topics/nip-57/)（zap）kind 9735レシートを公開し、新しいアドレスcapabilityビューは解決されたアドレスが[NIP-05](/ja/topics/nip-05/)（検証可能アイデンティティ）、NIP-57、関連Lightning Addressプロトコルをサポートするかを表示します。
+
+### nostr-double-ratchet TypeScript 0.0.166は公開inviteをセッション鍵に結び付ける
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet)は、Nostr relay上のエンドツーエンド暗号化ダイレクトおよびグループメッセージングのTypeScriptおよびRustプリミティブを提供します。[TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166)は、invite応答がセッション鍵の所有を証明することを要求し、再利用可能な公開inviteが1つのNostrアイデンティティを別当事者のセッションに結び付けるのを防ぎます。このリリースは不正なrumorフィールドも拒否し、ペイロード検証を強化します。既存セッションは引き続き動作しますが、更新されたinviterは古いinviteeからの証明なし応答を拒否します。
+
+### cln-nip47 0.2.0はNWCリクエストを拡張・分離
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47)は、[Nostr Wallet Connect](/ja/topics/nip-47/)（NWC）経由でノードをウォレットに公開するCore Lightningプラグインです。[バージョン0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0)は、hold invoiceの作成・キャンセル・決済用NWCメソッドと`hold_invoice_accepted`通知を追加し、接続ノードが実際にサポートするメソッドセットを告知します。トランザクションリスト応答は500エントリと約128 kBで停止し、リクエストイベントはイベントIDで重複排除され、1 clientの失敗通知が他clientへの配信を妨げなくなります。このリリースは、NWC仕様の一部ではなくなった2つのマルチペイメントメソッドも削除します。
+
+### ClipRelay 0.1.3はアイドル期間後にrelayとsigner接続を復元
+
+[ClipRelay](https://github.com/tajava2006/cliprelay)は、Nostr relay経由でユーザーのクリップボードをデバイス間で同期し、[NIP-44](/ja/topics/nip-44/)（暗号化メッセージ）で同一アイデンティティ向けにコンテンツを暗号化します。対応する[デスクトップ](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3)および[Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3リリースは、入力テキストを別デバイスのクリップボードへ直接送るテキストボックスを追加します。アイドル期間後は実relay往復で生存性をテストし、再サブスクリプションからソケット交換、再構築された接続プールへエスカレートし、停滞した[NIP-46](/ja/topics/nip-46/)（リモート署名）signer呼び出しはタイムアウトして自動再構築します。
+
+### NoorNote 1.3.2は記事ディスカバリをソーシャルグラフへ移す
+
+[NoorNote](https://github.com/77elements/noornote)は、ウェブ、デスクトップ、Android向けのソーシャル投稿、暗号化メッセージ、長文記事、その他イベントkindに対応するNostr clientです。[バージョン1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2)は、平坦なグローバル記事フィードを1次・2次・3次接触からのディスカバリに置き換え、読者にフォローグラフに根ざした記事タイムラインを提供します。また、未知の送信者からの再生ダイレクトメッセージのバーストを、relay履歴到着時にtoastの山ではなく1つのローリング通知にまとめます。
+
+### Bray 2.4.0はコンパクトなリモート署名ダイアレクトを追加
+
+[Bray](https://github.com/forgesworn/bray)は、ソフトウェアエージェントと人間にrelayアクセス、アイデンティティ、公開、リモート署名のツールを提供するNostr MCPサーバーです。[バージョン2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0)は、[NIP-46](/ja/topics/nip-46/)（リモート署名）が使用する文字列化形式に加え、イベントがオブジェクトである署名リクエストも受け入れ、`sign_event_compact`を追加してイベントID、署名、pubkey、タイムスタンプのみを返します。その小さなリクエスト・応答形式は制約のあるハードウェアsignerのメモリ使用量を削減し、標準の`sign_event`フローは変更されず、両ダイアレクトは受信イベントのID上に署名を生成します。
+
+
+## 新たに発見
+
+### Pactは相互同意のエージェントbondをNostrにもたらす
+
+[Pact](https://github.com/bobodread876/pact)は今週新たに発見され、MATE.mdとドラフトNIP-BDトランスポート上に構築されたソフトウェアエージェント向けの初期段階の関係レイヤーです。署名済みで相互同意のbondはエージェント自身の鍵が保持し、Nostr経由で公開でき、プライベートbondは[NIP-59](/ja/topics/nip-59/)（gift wrap）を使用します。モノレポにはMCPサーバー、TypeScript SDK、コマンドラインclient、自己ホスト可能デーモン、ウェブインターフェースが含まれます。最新のリポジトリアクティビティは今号の週次ウィンドウより前のものであるため、これは新リリースの主張ではなく発見メモです。
+
+
+## 開発中
+
+### nostrordはグループミュートをデバイス間で同期
+
+[nostrord](https://github.com/nostrord/nostrord)は、relay管理コミュニティ向けのクロスプラットフォームclientです。[PR #250](https://github.com/nostrord/nostrord/pull/250)は、各アカウントのグループごとのミュート選択を自己暗号化[NIP-78](/ja/topics/nip-78/)（アプリ固有データ）kind `30078`イベントに保存し、1台のデバイスで行った設定がrelayにグループリストを明かさずに別デバイスへ追随できるようにします。置換可能レコードは最新イベント順序を使用し、ライブ変更をリッスンし、署名または公開失敗時にインターフェースをロールバックしてローカル状態の不整合を残しません。ミュートされたグループは可視未読合計への寄与を止めつつ、次回訪問のための未読位置は保持します。
+
+### AmethystはConcordのinviteライフサイクルを完成
+
+[Amethyst](https://github.com/vitorpamplona/amethyst)は、Concordプロトコルを実装する暗号化コミュニティサポートを備えたAndroid Nostr clientです。[PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888)は、inviteリンクがコミュニティrefoundingを生き延び、同じアドレサブル座標でbundleを再発行できるようにし、banチェックは削除されたメンバーがそのリカバリパスを使用するのを防ぎます。また暗号化CORD-05 inviteリストをアプリと`amy`コマンドラインclientの両方で実装し、リンクごとの失効tombstoneを追加し、リンクを退役できる唯一の保存署名鍵を削除する前にrelay確認を要求します。同じ作業で`amy`に、後続コミュニティepochを追従するために必要なcontrol鍵配信、refounding、rekeying、孤立メンバーリカバリパスを与えます。
+
+### Buzzは各コミュニティの外観をデスクトップとモバイル間で運ぶ
+
+[Buzz](https://github.com/block/buzz)は、デスクトップとモバイルclientを備えたNostrベースのコミュニティワークスペースです。マージ済みデスクトップ[PR #3653](https://github.com/block/buzz/pull/3653)とモバイル[PR #3767](https://github.com/block/buzz/pull/3767)は、各コミュニティのテーマ、アクセント、システムモード選択を、そのコミュニティrelay上の暗号化NIP-78レコードとして保存します。両clientは同じバージョン付きペイロードを共有し、アイデンティティスコープのローカルキャッシュを保持するため、コミュニティやアカウントを切り替えてもrelayが利用不能な間に誤った外観が適用されません。置換順序、ガード付き書き込み、closed接続後の再サブスクリプションにより、再接続後に2 clientが再収束します。
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10)は号の締切前に、パフォーマンスと信頼性のパスが続きました。0.5.9以降に導入された退行を除去し、チャンネル読み込みを加速し、初期タイムライン保持を有界化し、既読状態の永続化を統合し、新鮮なチャンネルタイムラインを保持し、プロジェクトイベントへのリアクションでrelay取り込みワーカーがクラッシュするのを止めます。また、スレッドメッセージをチャンネルへ送信する機能を追加し、デスクトップ検索を意図したスコープに絞ります。
+
+
+## プロトコルと仕様作業
+
+### NIPs
+
+[NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435)は、[NIP-34](/ja/topics/nip-34/)（git-over-Nostr）をNostrイベント経由のgitリポジトリ協業を標準化するオープン修正案です。pull-requestイベントにオプションの`b` tagを追加し、著者がリポジトリのデフォルト以外のターゲットブランチを指定できるようにします。この提案はngitとGitWorkshopですでに実装されているサポートに一致しますが、仕様にはまだ入っていません。
+
+[NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434)は、ポスト量子アイデンティティ鍵のオープン提案です。[NIP-06](/ja/topics/nip-06/)（鍵導出）ニーモニック鍵導出seedから既存secp256k1鍵に加えてポスト量子暗号化・署名鍵を導出し、公開鍵をkind `10203`証明でNostrアイデンティティに結び付けます。ドラフトは、secp256k1が後から破られた場合に以前のメッセージの機密性を保護するという主張に限定し、今日のイベント署名を置き換えません。
+
+[NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431)は、ブラウザsigner向け[NIP-07](/ja/topics/nip-07/)（ブラウザ署名）のオープン修正案です。clientは署名または暗号化リクエストに期待するpubkeyを添付でき、signerはそのアカウントを使用するか呼び出しを拒否する必要があります。これにより、ユーザーがsignerでアカウントを切り替えた後、ページが黙って別アイデンティティのまま続くのを防げます。
+
+[NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813)は、ウィンドウ中の実質的作業後もオープンのdouble-ratchet提案のままです。メッセージとともに鍵が進む前方秘匿暗号化会話を指定し、nostr-double-ratchetライブラリとIrisに実装が既にあります。まだドラフトであり、マージされたNIPではありません。
+
+[NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433)はウィンドウ中にオープンしてマージなしでクローズしました。[NIP-42](/ja/topics/nip-42/)（relay認証）relayエラーを明確化する提案で、`auth-required`は別の認証が結果を変えうることを意味し、`restricted`は変えられないことを意味します。この区別は1つの鍵では認証済みだが別の鍵の認可が欠けている接続に対処します。クローズ状態は文言が仕様に入らなかったことを意味します。
+
+[NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378)は、まだ提案中に以前取り上げられましたが、マージなしでクローズしました。提案されていたエージェントpassport、ディスカバリ、タスク、マーケットプレイス、invoice、接続イベントはNIP集合の外に残ります。
+
+[NIPs commit 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab)は[NIP-29](/ja/topics/nip-29/)（relay管理グループ）へのドキュメントのみの修正をマージしました。グループメタデータ例に`previous` tagを追加し、置換イベントが置き換えるイベントを特定する方法を示します。これは例を明確化するものであり、新しいプロトコル機能は導入しません。
+
+### Concord and CORDs
+
+[CORD PR #18](https://github.com/concord-protocol/concord/pull/18)は、暗号化Community Listをkind `33302`イベントにシャードし、50メンバーシップ上限を撤廃し、退役エントリを剪定してrelay制限内に収めます。他2つのオープン提案は[プライベートメンションlocator](https://github.com/concord-protocol/concord/pull/16)と、メッセージを破棄せずにチャットを一時停止する[一時停止シグナル](https://github.com/concord-protocol/concord/pull/17)を追加します。
+
+[CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15)は8月6日にマージされ、コミュニティcontrol planeへの書き込みを制限します。オーナーとスタッフは新しい`control_root`署名秘密を保持し、全メンバーはモデレーション状態を検証・復号するために必要な導出pubkeyとread鍵を保持します。write鍵はスパム障壁であり、権限を確立する内部actor署名とrosterチェックの代替ではありません。
+
+[CORD PR #12](https://github.com/concord-protocol/concord/pull/12)は、オープンドラフトとして以前取り上げられましたが、マージなしでクローズしました。control plane部分は上記の狭いマージ済みCORD-02修正に置き換えられ、制限付きwriteチャンネルとその他のドラフト資料は仕様に入りませんでした。
+
+## NIPディープダイブ
+
+### イベント削除リクエスト（NIP-09）
+
+[NIP-09](/ja/topics/nip-09/)（イベント削除）は、[一次仕様](https://github.com/nostr-protocol/nips/blob/master/09.md)で定義され、イベント著者にrelayとclientへその著者の1つ以上のイベントの配信停止を求める署名付き方法を与えます。すべてのコピーを消去するものではありません。元イベントを配布したのと同じrelayネットワークを通じて著者の意図を運びます。
+
+リクエストは通常の署名済みkind `5`イベントです。tagには特定イベントIDへの1つ以上の`e`参照、またはアドレサブルイベント座標への`a`参照が含まれ、[NIP-09 tagルール](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request)は参照イベントkindごとに`k` tagを含めるべきと述べます。オプションの`content`で理由を説明できます。`a`参照では、relayはその座標のうちタイムスタンプがリクエストの`created_at`以下のすべてのバージョンを削除すべきであり、古い削除リクエストが後の置換を抑制するのを防ぎます。
+
+[著者性がセキュリティ境界](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior)です。relayは参照イベントの`pubkey`が削除リクエストの`pubkey`と一致するときのみ、その配信を止めるべきであり、clientはイベントを隠す前にそのチェックを行う必要があります。relayは参照イベントを保持していない場合があり、リクエスト受け入れ時に関係を検証できないことがあるため、clientはrelay受け入れを削除が承認された証明と見なせません。仕様はまた、別clientが元イベントを既に保持し後からリクエストに遭遇する可能性があるため、relayにkind `5`リクエストを保持するよう求めます。
+
+以下は[署名済みkind `5`イベント](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943)です。
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+削除は署名済みオブジェクトの失効ではなく、協調的ポリシーです。relay、キャッシュ、スクリーンショット、オフラインclientは元のバイト列を保持でき、kind `5`リクエスト自体を削除してもそれを取り消しません。clientは対象を隠したり、放棄済みとしてマークしたり、リクエスト理由を表示したりできますが、普遍的削除は保証できないことをユーザーに伝えるべきです。これは、イベント公開時に選択した時刻以降relayにイベント保存を止めるよう求める`expiration` tagを持つ[NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)（期限付きイベント）とは異なります。NIP-09は後の著者決定を扱い、既に配布されたイベントを指せます。
+
+現在の実装はそのポリシーを異なるレイヤーで適用します。[Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623)は削除された動画をclientのイベントストアから除去し、[strfry PR #251](https://github.com/hoytech/strfry/pull/251)は有効な削除リクエストをgift wrap受信者へ拡張し、[Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md)はclientでNIP-09サポートを宣言します。[nostrordのグループclient](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt)は別の現在の実装パスを提供します。
+
+### 通報（NIP-56）
+
+[NIP-56](/ja/topics/nip-56/)（通報イベント）は、[一次仕様](https://github.com/nostr-protocol/nips/blob/master/56.md)で定義され、アカウント、イベント、または参照blobについての署名済み通報を標準化します。通報シグナルをモデレーション決定から分離し、各clientまたはrelayが信頼する通報者と方針に合う対応を選べます。
+
+通報はkind `1984`を使用し、通報対象アカウントを`p` tagで特定する必要があります。ノートの通報にはイベントIDの`e` tagも必要です。tagの3番目の値は、指定カテゴリの1つを担います: `nudity`、`malware`、`profanity`、`illegal`、`spam`、`impersonation`、`other`。blobについての通報は、hashを`x` tagに、blobを参照したイベントを`e` tagに、場所をオプションの`server` tagに使えます。[NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md)（ラベリング）のオプション`L`および`l` tagは、固定カテゴリリストが十分に精密でないときに名前空間付きラベルを追加できます。
+
+[イベントが証明するのは1つの鍵が申し立てを行ったことのみ](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting)です。通報されたコンテンツは、有効なkind `1984`が存在したからといって虚偽、違法、削除可能になるわけではなく、オープンrelayは匿名通報を票として安全に数えられません。仕様は通報のゲーム化が容易なため自動relayモデレーションに反対しつつ、relay管理者が既に信頼するモデレーターの通報に基づいて行動することを許容します。clientは代わりに、例えば信頼する連絡先が同じアカウントを複数フラグした後にコンテンツをぼかすなど、ユーザーのソーシャルグラフを通じて通報に重みを付けられます。
+
+以下は[署名済みkind `1984`イベント](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2)です。
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56とNIP-09は異なる問題を解く](https://github.com/nostr-protocol/nips/tree/master)ものです。kind `1984`通報は他人のアカウントやイベントを対象にできますが、削除権限を与えません。kind `5`リクエストは元著者の意図を表し、その著者自身のイベントに対してのみ有効です。どちらも削除を保証しません。NIP-56は意図的にローカルモデレーションポリシーへ委譲し、NIP-09はrelayとclientが認証済みリクエストを尊重することに依存します。
+
+実装はそれらの選択を異なる製品で露出します。[Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591)はショート動画clientの通報配信を修正し、[Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250)はマーケットプレイス参加者向けの有界コンテキストとして通報を読み、[nostrordのNIP-56モジュール](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt)は通報イベントを公開・処理します。[Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support)も現在のNIP-56サポートを列挙します。
+
+
+---
+
+[NIP-17](/ja/topics/nip-17/)（gift-wrappedプライベートDM）でプロジェクトやニュース項目を共有し、[Nostr Compassプロジェクト](https://github.com/andotherstuff/nostr-compass)へ送ってください。

--- a/content/ko/newsletters/2026-08-12-newsletter.md
+++ b/content/ko/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "양자 이후 대비 신원 도구, 강화된 암호화 메시징과 서명, 휴대용 커뮤니티 설정, NIP와 Concord 전반의 프로토콜 작업"
+---
+
+[Nostr Compass](https://nostrcompass.org)에 다시 오신 것을 환영합니다. Nostr 주간 가이드입니다.
+
+**이번 주:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension)은 기존 Nostr 신원 옆에 post-quantum 키와 옵트인 보호 메시지를 추가합니다. [Divine](https://github.com/divinevideo/divine-mobile)은 계정 격리, 다이렉트 메시지 검증, 게시 확인을 강화하고, [MDK](https://github.com/marmot-protocol/mdk)는 암호화 그룹 수렴과 복구를 강화하며, [Amber](https://github.com/greenart7c3/Amber)는 그룹화된 서명 결정을 명시적으로 만듭니다. 릴리스는 지갑 연결, 암호화 채팅, 소셜 발견, 기기 동기화, 원격 서명을 개선하고, 프로토콜 작업은 신원과 암호화 커뮤니티를 다룹니다. 심층 분석에서는 인증된 삭제 요청과 분산 신고를 설명합니다.
+
+## 주요 소식
+
+### nostr-wot-extension 0.4.0은 Nostr 신원 옆에 post-quantum 키를 추가
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0)은 Nostr 신원을 관리하고 서명하는 브라우저 확장입니다. 24단어 시드에서 생성된 계정은 이제 기존 Nostr 키와 함께 ML-KEM-1024 암호화 및 ML-DSA-87 서명 키를 도출할 수 있습니다. 원클릭 흐름은 Nostr 공개 키를 두 post-quantum 공개 키에 바인딩하고 ML-DSA 소유 증명을 포함하는 kind `10203` 증명을 게시합니다. 12단어 니모닉, bare `nsec`, 원격 서명자, 또는 읽기 전용 키에서 가져온 계정은 도출 흐름을 사용할 수 없으며, 확장은 계정 보기에서 그 제한을 설명합니다.
+
+릴리스는 또한 옵트인 post-quantum 다이렉트 메시지를 추가합니다. ML-KEM 공유 비밀을 HKDF를 통해 기존 [NIP-44 암호화 메시지 대화 키](https://github.com/nostr-protocol/nips/blob/master/44.md)와 결합한 다음, 릴레이 전달을 위해 일반적인 [NIP-59](/ko/topics/nip-59/)(gift wrap) 메타데이터 숨김 gift-wrap 레이어를 유지합니다. 수신자가 옵트인한 후 암호화는 조용히 폴백하지 않으며, 복호화는 적절한 경로를 자동으로 선택합니다. 이는 새 메시지 경로를 현재 Nostr 개인 키의 나중 복구로부터 보호하지만, secp256k1 이벤트 서명을 대체하지는 않습니다. 릴리스는 그 더 큰 마이그레이션을 릴레이와 클라이언트와의 향후 조정에 맡긴다고 명시합니다.
+
+### Divine Mobile 1.0.19는 계정, 다이렉트 메시지, 게시를 강화
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19)는 Nostr를 통해 비디오를 게시하고 검색하는 모바일 숏폼 비디오 클라이언트입니다. 계정 전환기는 이제 각 로그인 신원을 계정 범위 컨테이너 주변에 구축하고, 게시 수정은 비디오가 잘못된 계정으로 전송되는 것을 방지합니다. 릴레이 게시 경로는 이제 명시적 성공 의미가 있는 `OK` 응답을 기다리며, 릴레이 `CLOSED` 프레임은 요청을 걸어두는 대신 자체 보류 쿼리를 종료할 수 있습니다.
+
+[다이렉트 메시지 처리](https://github.com/divinevideo/divine-mobile/pull/6368)는 인증되지 않은 rumor 필드와 서명되지 않은 seal을 거부하고, 네 가지 누락 메시지 케이스를 복원하며, 완전히 팔로우한 참가자의 그룹 대화를 받은편지함으로 라우팅합니다. 릴리스는 또한 목록이 업데이트될 때 어드레서블 비디오 이벤트의 태그를 보존하고, 관찰된 삭제 요청을 소비하여 제거된 비디오가 로컬 상태에서 사라지게 합니다. 이러한 변경은 지난주 다룬 릴레이별 쿼리 타임아웃 작업을 따르지만, 초점을 검색 격리에서 신원 경계, 메시지 검증, 게시 확인으로 옮깁니다.
+
+### MDK 0.9.11은 Marmot 그룹 수렴과 복구를 강화
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11)은 Nostr를 통해 전달되는 암호화 그룹 메시징 프로토콜 Marmot을 위한 Rust 개발 키트입니다. 릴리스는 그룹 상태 머신 주변에 더 큰 수렴 및 복구 시스템을 구축합니다. 오래된 수렴 패스는 현재 그룹 팁에서 다시 열리고, 인바운드 capability projection은 원자적으로 커밋되며, 지연된 메시지는 재시작 전반에 걸쳐 제한된 수명을 받고, 커밋 주소 지정 체크포인트는 신원의 자체 커밋 포크를 복구하는 데 도움이 됩니다. 비안정 전송은 대기열에 넣고 복구할 수 있으며, epoch-stall 경로는 backfill로 에스컬레이션하고 전송된 메시지는 수렴 작업을 견딥니다.
+
+[스토리지 및 호스트 통합](https://github.com/marmot-protocol/mdk/pull/1201)은 병렬 강화 패스를 받습니다. MDK는 가지치기된 SQLite projection을 안전하게 삭제하고, 가져온 개인 키, [NIP-49](/ko/topics/nip-49/)(암호화된 개인 키 형식) 암호화 키 내보내기 중간 결과, OpenMLS 직렬화 버퍼를 영점화하며, 디버그 출력에서 그룹 이미지 키를 편집합니다. 계정 가져오기는 중단 후 재개할 수 있고, iOS 및 Android 개인 스토리지 경로가 수정되며, 호스트는 일시 중지 전에 스토리지를 명시적으로 닫을 수 있습니다. 새로운 경량 roster 및 로컬 멤버십 projection은 애플리케이션이 읽어야 하는 것을 줄이고, Hermes 커넥터는 여러 에이전트 생성 이미지를 하나의 Marmot 앨범으로 전달할 수 있습니다.
+
+### Nostria 4.1.67은 암호화 커뮤니티 관리를 확장
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67)은 Nostr를 위한 웹 및 데스크톱 소셜 클라이언트입니다. 실험적 [NIP-29](/ko/topics/nip-29/)(릴레이 관리 그룹) 릴레이 관리 그룹과 4.1.53에서 도입된 Concord 암호화 커뮤니티를 기반으로, 커뮤니티 해산, 아이콘 및 배너 관리, 압축 미리보기가 있는 암호화 사진 업로드, 전체 리액션 선택기, 사용자가 노트나 기사를 읽는 동안 커뮤니티를 열어 두는 듀얼-pane 레이아웃을 추가합니다. 릴리스는 또한 스레드 메시징과 공개, 그룹, 비공개 채팅을 위한 통합 허브를 추가합니다.
+
+### Amber 6.4.0은 모든 그룹화된 서명 결정을 명시적으로 만듦
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0)은 Nostr 개인 키를 서명을 요청하는 애플리케이션과 분리해 두는 Android 서명자입니다. 재설계된 다중 요청 화면은 각 요청과 각 그룹에 Approve 및 Deny 컨트롤을 제공하여 이전 선택 및 확인 흐름을 대체합니다. Amber의 릴레이 매개 bunker 인터페이스를 통해 전송된 거부된 요청은 이제 적절한 오류 응답을 받으므로, 요청 클라이언트는 정체된 서명자와의 거부를 구별할 수 있습니다.
+
+[Amber의 태그된 소스](https://github.com/greenart7c3/Amber/tree/v6.4.0)는 또한 출시된 모든 로케일에서 113개 이상의 이벤트 kind에 대해 현지화된 사람이 읽을 수 있는 레이블을 추가합니다. 추가 항목에는 Concord 그룹 이벤트, [NIP-51](/ko/topics/nip-51/)(Git 리포지토리 북마크) Git 리포지토리 북마크, [NIP-53](/ko/topics/nip-53/)(룸 프레즌스) 룸 프레즌스 이벤트가 포함되어, 사용자가 서명을 승인하기 전에 낯선 데이터에 대한 더 많은 맥락을 제공합니다. concurrent-map 가드는 또한 `NegativeArraySizeException`을 발생시킬 수 있는 릴레이 구독 충돌을 수정합니다.
+
+### Safebox Acorn은 휴대용 복구 컴포넌트를 웹 앱에서 분리
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn)은 Nostr 기반 상태로 사용자 제어 키, 자금, 레코드를 보호하는 독립 Python 컴포넌트 및 명령줄 인터페이스입니다. Acorn을 더 넓은 Safebox 웹 애플리케이션에서 분리하면 다른 Python 프로젝트가 웹 인터페이스를 맡지 않고도 런타임과 키, Nostr 프로필, 릴레이, 레코드, Cashu, Lightning, 암호화 helper를 설치하여 사용할 수 있습니다. 현재 record-protection 원시 기능은 새로운 256비트 키를 생성하고, 별도로 제공된 엔트로피에서 하나를 도출하며, 정확한 키를 checksummed 24단어 복구 구문으로 인코딩할 수 있습니다.
+
+프로젝트의 [복구 및 연속성 가이드](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/)는 Acorn을 가정 또는 커뮤니티 Safebox 내부의 교체 가능한 프로토콜 컴포넌트로 프레이밍합니다. 설계는 로컬 릴레이와 독립 복제본을 통해 암호화된 상태를 사용 가능하게 유지하여 복구가 하나의 appliance, 애플리케이션, 릴레이, mint, 또는 서비스 제공자에 의존하지 않도록 합니다. 문서는 현재 경계에 대해 신중합니다. protected-record 암호화는 아직 설계 중이므로, 해당 프로필이 구현되고 검토될 때까지 애플리케이션은 레코드가 새 record-protection 키에 의존하지 않도록 해야 합니다.
+
+
+## 태그 릴리스
+
+### Mostro Core 0.14.2는 암호화 채팅 봉투를 변경
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core)는 Mostro 교환 데몬과 클라이언트가 사용하는 공유 타입 및 피어 투 피어 함수의 Rust 라이브러리입니다. [버전 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2)는 gift-wrap 채팅 메시지를 피어 공유 비밀에서 도출된 별도 대화 암호화 및 서명 키를 사용하는 kind 14 봉투로 대체합니다. 새 리더는 작성자, 서명, 수신자, 타임스탬프, 콘텐츠 크기를 검증하며, 레거시 gift-wrap helper는 마이그레이션 중 클라이언트가 두 형식을 모두 읽을 수 있도록 유지됩니다.
+
+### Mostro 0.18.1은 Cashu escrow 경로를 시작하고 데몬을 강화
+
+[Mostro](https://github.com/MostroP2P/mostro)는 Nostr를 통해 주문을 조정하는 피어 투 피어 Lightning 교환 데몬입니다. [버전 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1)은 Cashu escrow 백엔드를 위한 기반을 마련하며, 구성, 데이터베이스 helper, mint 통합, 시작 배선, 첫 lock 액션을 포함합니다. 또한 Nostr를 통해 신뢰할 수 있는 노드가 발표한 가격을 사용할 수 있고, 교체 가능한 info 이벤트에서 첫 연락에 대한 proof-of-work 요구 사항을 광고합니다. 릴리스는 NIP-44 denial-of-service 수정을 위해 Nostr 의존성을 업데이트하고, 복원 세션 로그에서 개인 키를 제거하며, 승인되지 않은 cooperative-cancel 메시지를 거부하고, LNURL 가져오기를 server-side request forgery 및 hang에 대해 강화하고, payout 인보이스를 검증하며, 재시작 후 hold-invoice 구독을 복원합니다.
+
+### LaWallet NWC 2.3.0은 Nostr 알림과 zap 영수증을 추가
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc)는 [Nostr Wallet Connect](/ko/topics/nip-47/)를 통해 지갑을 연결하는 오픈소스 Lightning Address 플랫폼입니다. [버전 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0)은 각 지갑이 수신 및 전달 알림을 구성 가능한 Nostr 이벤트로 보낼 수 있게 하며, 수신자 `p` 태그, 선택된 릴레이, 템플릿 콘텐츠, 선택적 [NIP-44](/ko/topics/nip-44/) 암호화를 포함합니다. 재시도는 동일한 서명된 이벤트 ID를 재사용합니다. 또한 zap 요청을 수락하고 정산 후 서명된 [NIP-57](/ko/topics/nip-57/) kind 9735 영수증을 게시하며, 새 주소 capability 보기는 해결된 주소가 NIP-05, NIP-57, 관련 Lightning Address 프로토콜을 지원하는지 표시합니다.
+
+### nostr-double-ratchet TypeScript 0.0.166은 공개 초대를 세션 키에 바인딩
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet)은 Nostr 릴레이를 통한 end-to-end 암호화 다이렉트 및 그룹 메시징을 위한 TypeScript 및 Rust 원시 기능을 제공합니다. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166)은 초대 응답이 세션 키의 소유권을 증명하도록 요구하여, 재사용 가능한 공개 초대가 하나의 Nostr 신원을 다른 당사자의 세션에 바인딩하는 것을 방지합니다. 릴리스는 또한 잘못된 형식의 rumor 필드를 거부하고 페이로드 검증을 강화합니다. 기존 세션은 계속 작동하지만, 업데이트된 초대자는 오래된 초대 대상의 증명 없는 응답을 거부합니다.
+
+### cln-nip47 0.2.0은 NWC 요청을 확장하고 격리
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47)은 [Nostr Wallet Connect](/ko/topics/nip-47/)를 통해 지갑에 노드를 노출하는 Core Lightning 플러그인입니다. [버전 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0)은 hold 인보이스를 생성, 취소, 정산하는 NWC 메서드와 `hold_invoice_accepted` 알림을 추가하고, 연결된 노드가 실제로 지원하는 메서드 집합을 광고합니다. 트랜잭션 목록 응답은 이제 500개 항목과 약 128 kB에서 중단되며, 요청 이벤트는 이벤트 ID로 중복 제거되고, 한 클라이언트의 실패한 알림이 더 이상 다른 클라이언트에 대한 전달을 막지 않습니다. 릴리스는 또한 NWC 사양에 더 이상 포함되지 않는 두 multi-payment 메서드를 제거합니다.
+
+### ClipRelay 0.1.3은 유휴 기간 후 릴레이 및 서명자 연결을 복원
+
+[ClipRelay](https://github.com/tajava2006/cliprelay)는 [NIP-44](/ko/topics/nip-44/)로 동일한 신원에 콘텐츠를 암호화하여 Nostr 릴레이를 통해 사용자 클립보드를 기기 간에 동기화합니다. 해당 [데스크톱](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) 및 [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 릴리스는 입력한 텍스트를 다른 기기의 클립보드로 직접 보낼 수 있는 텍스트 상자를 추가합니다. 또한 유휴 기간 후 실제 릴레이 왕복으로 활성 상태를 테스트하며, 재구독에서 소켓 교체 및 재구축된 연결 풀로 에스컬레이션하고, 정체된 [NIP-46](/ko/topics/nip-46/)(릴레이 매개 원격 서명) 서명자 호출은 이제 타임아웃되고 자동으로 재구축됩니다.
+
+### NoorNote 1.3.2는 기사 발견을 소셜 그래프로 이동
+
+[NoorNote](https://github.com/77elements/noornote)는 웹, 데스크톱, Android에서 소셜 게시물, 암호화 메시지, 장문 기사, 기타 이벤트 kind를 다루는 Nostr 클라이언트입니다. [버전 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2)는 평면적인 전역 기사 피드를 1차, 2차, 3차 연락처에서 가져온 발견으로 대체하여, 독자에게 팔로우 그래프에 뿌리를 둔 기사 타임라인을 제공합니다. 또한 알 수 없는 발신자의 재생된 다이렉트 메시지 버스트를 릴레이 기록이 도착할 때 토스트 스택을 만드는 대신 하나의 롤링 알림으로 축소합니다.
+
+### Bray 2.4.0은 컴팩트 원격 서명 방언을 추가
+
+[Bray](https://github.com/forgesworn/bray)는 소프트웨어 에이전트와 사람에게 릴레이 접근, 신원, 게시, 원격 서명 도구를 제공하는 Nostr MCP 서버입니다. [버전 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0)은 [NIP-46](/ko/topics/nip-46/)에서 사용하는 문자열 형식뿐 아니라 이벤트가 객체인 서명 요청도 수락하고, 이벤트 ID, 서명, 공개 키, 타임스탬프만 반환하는 `sign_event_compact`를 추가합니다. 더 작은 요청 및 응답 형식은 제약된 하드웨어 서명자의 메모리 사용량을 줄이며, 표준 `sign_event` 흐름은 변경되지 않고 두 방언 모두 수신된 이벤트 ID에 대한 서명을 생성합니다.
+
+
+## 새로 발견됨
+
+### Pact는 상호 동의 에이전트 bond를 Nostr에 가져옴
+
+[Pact](https://github.com/bobodread876/pact)는 이번 주 새로 발견되었으며, MATE.md와 초안 NIP-BD 전송을 기반으로 한 소프트웨어 에이전트를 위한 초기 단계 관계 레이어입니다. 서명되고 상호 동의된 bond는 에이전트 자체 키가 보유하며 Nostr를 통해 게시할 수 있고, 비공개 bond는 [NIP-59](/ko/topics/nip-59/) gift wrapping을 사용합니다. 모노레포에는 MCP 서버, TypeScript SDK, 명령줄 클라이언트, 자체 호스팅 가능한 데몬, 웹 인터페이스가 포함됩니다. 최신 리포지토리 활동은 이번 호의 주간 창보다 이전이므로, 이는 새 릴리스 주장이 아닌 발견 메모입니다.
+
+
+## 개발 중
+
+### nostrord는 그룹 음소거를 기기 간에 동기화
+
+[nostrord](https://github.com/nostrord/nostrord)는 릴레이 관리 커뮤니티를 위한 크로스 플랫폼 클라이언트입니다. [PR #250](https://github.com/nostrord/nostrord/pull/250)은 각 계정의 그룹별 음소거 선택을 자체 암호화된 [NIP-78](/ko/topics/nip-78/)(애플리케이션별 데이터) kind `30078` 이벤트에 저장하여, 한 기기에서 만든 설정이 릴레이에 그룹 목록을 공개하지 않고 다른 기기로 사용자를 따라갈 수 있게 합니다. 교체 가능한 레코드는 최신 이벤트 순서를 사용하고, 실시간 변경을 수신하며, 서명 또는 게시가 실패할 때 인터페이스를 롤백하여 로컬 상태가 동기화되지 않은 채로 남지 않습니다. 음소거된 그룹은 다음 방문을 위한 읽지 않은 위치를 유지하면서 가시적인 읽지 않은 합계에 기여하지 않습니다.
+
+### Amethyst는 Concord 초대 수명 주기를 완성
+
+[Amethyst](https://github.com/vitorpamplona/amethyst)는 Concord 프로토콜을 구현하는 암호화 커뮤니티 지원 Android Nostr 클라이언트입니다. [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888)은 커뮤니티 refounding 후에도 초대 링크가 같은 어드레서블 좌표에서 bundle을 재발행하여 살아남게 하며, ban 검사는 제거된 멤버가 그 복구 경로를 사용하는 것을 방지합니다. 또한 앱과 `amy` 명령줄 클라이언트 모두에서 암호화된 CORD-05 초대 목록을 구현하고, 링크별 폐기 tombstone을 추가하며, 링크를 폐기할 수 있는 유일하게 저장된 서명 키를 삭제하기 전에 릴레이 확인을 요구합니다. 같은 작업은 `amy`에 이후 커뮤니티 epoch를 따르는 데 필요한 control-key 전달, refounding, rekeying, stranded-member 복구 경로를 제공합니다.
+
+### Buzz는 각 커뮤니티의 외관을 데스크톱과 모바일에 걸쳐 전달
+
+[Buzz](https://github.com/block/buzz)는 데스크톱 및 모바일 클라이언트를 갖춘 Nostr 기반 커뮤니티 워크스페이스입니다. 병합된 데스크톱 [PR #3653](https://github.com/block/buzz/pull/3653)과 모바일 [PR #3767](https://github.com/block/buzz/pull/3767)은 각 커뮤니티의 테마, accent, system-mode 선택을 해당 커뮤니티 릴레이의 암호화된 NIP-78 레코드로 저장합니다. 두 클라이언트는 동일한 버전 지정 페이로드를 공유하고 신원 범위 로컬 캐시를 유지하므로, 커뮤니티나 계정을 변경할 때 릴레이를 사용할 수 없는 동안 잘못된 외관이 적용되지 않습니다. 교체 순서, 보호된 쓰기, 연결 종료 후 재구독은 두 클라이언트가 재연결 후 다시 수렴할 수 있게 합니다.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10)은 호 마감 전에 성능 및 안정성 패스로 이어졌습니다. 0.5.9 이후 도입된 회귀를 제거하고, 채널 로딩을 가속하며, 초기 타임라인 보존을 제한하고, 읽음 상태 지속을 병합하고, 새로운 채널 타임라인을 보존하며, 프로젝트 이벤트에 대한 리액션에서 릴레이 ingest worker가 충돌하는 것을 중단합니다. 또한 스레드 메시지를 채널로 보내는 기능을 추가하고 데스크톱 검색을 의도한 범위로 좁힙니다.
+
+
+## NIP 업데이트 및 프로토콜 사양 작업
+
+### NIPs
+
+[NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435)는 Nostr 이벤트를 통해 Git 리포지토리 협업을 표준화하는 [NIP-34](/ko/topics/nip-34/)(Git over Nostr)에 대한 공개 수정입니다. pull-request 이벤트에 선택적 `b` 태그를 추가하여 작성자가 리포지토리 기본값이 아닌 대상 브랜치를 지정할 수 있게 합니다. 제안은 ngit과 GitWorkshop에 이미 구현된 지원과 일치하지만, 아직 사양에 들어가지 않았습니다.
+
+[NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434)는 post-quantum 신원 키에 대한 공개 제안입니다. [NIP-06](/ko/topics/nip-06/)(니모닉 키 파생) 니모닉 키 파생 시드에서 기존 secp256k1 키 옆에 post-quantum 암호화 및 서명 키를 도출한 다음, kind `10203` 증명으로 공개 키를 Nostr 신원에 바인딩합니다. 초안은 secp256k1이 나중에 깨질 경우 더 이른 메시지의 기밀성을 보호한다는 주장으로 범위를 제한합니다. 오늘의 이벤트 서명을 대체하지는 않습니다.
+
+[NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431)은 브라우저 서명자를 위한 공개 [NIP-07](/ko/topics/nip-07/)(브라우저 확장 서명) 수정입니다. 클라이언트가 서명 또는 암호화 요청에 기대하는 공개 키를 첨부하여, 서명자가 해당 계정을 사용하거나 호출을 거부하도록 요구할 수 있습니다. 이는 사용자가 서명자에서 계정을 전환한 후 페이지가 다른 신원으로 조용히 계속되는 것을 방지합니다.
+
+[NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813)은 창 동안 실질적인 작업 후에도 공개 double-ratchet 제안으로 남아 있습니다. 메시지와 함께 키가 진행되는 forward-secret 암호화 대화를 지정하며, nostr-double-ratchet 라이브러리와 Iris에서 이미 구현을 사용할 수 있습니다. 아직 병합된 NIP가 아닌 초안입니다.
+
+[NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433)은 창 동안 열렸다가 병합 없이 닫혔습니다. [NIP-42](/ko/topics/nip-42/)(릴레이 인증) 릴레이 오류를 명확히 하여 `auth-required`는 다른 인증이 결과를 변경할 수 있음을, `restricted`는 변경할 수 없음을 의미하도록 제안했습니다. 이 구분은 한 키로 인증되었지만 다른 키에 대한 권한이 여전히 없는 연결을 다룹니다. 닫힌 상태는 문구가 사양에 들어가지 않았음을 의미합니다.
+
+이전에 아직 제안된 상태로 다룬 [NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378)은 이제 병합 없이 닫혔습니다. 제안된 agent passport, discovery, task, marketplace, invoice, connection 이벤트는 따라서 NIP 집합 밖에 남아 있습니다.
+
+[NIPs 커밋 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab)는 [NIP-29](/ko/topics/nip-29/)에 대한 문서 전용 수정을 병합했습니다. 그룹 메타데이터 예시에 `previous` 태그를 추가하여, 교체 이벤트가 대체하는 이벤트를 식별하는 방법을 보여줍니다. 이는 예시를 명확히 할 뿐 새 프로토콜 기능을 도입하지 않습니다.
+
+### Concord and CORDs
+
+[CORD PR #18](https://github.com/concord-protocol/concord/pull/18)은 암호화 Community List를 kind `33302` 이벤트에 샤딩하고, 50 멤버십 제한을 제거하며, 릴레이 제한 내에 머물도록 은퇴한 항목을 가지치기합니다. 다른 두 공개 제안은 [비공개 멘션 locator](https://github.com/concord-protocol/concord/pull/16)와 메시지를 폐기하지 않고 채팅을 일시 중단하는 [pause signal](https://github.com/concord-protocol/concord/pull/17)을 추가합니다.
+
+[CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15)는 8월 6일에 병합되어 커뮤니티 control plane에 대한 쓰기를 제한합니다. 소유자와 staff는 새 `control_root` 서명 비밀을 보유하고, 모든 멤버는 중재 상태를 검증하고 복호화하는 데 필요한 도출된 공개 키와 read key를 유지합니다. write key는 스팸 장벽이며, 권한을 확립하는 내부 actor 서명과 roster 검사를 대체하지 않습니다.
+
+이전에 공개 초안으로 다룬 [CORD PR #12](https://github.com/concord-protocol/concord/pull/12)는 이제 병합 없이 닫혔습니다. control-plane 부분은 위의 더 좁은 병합된 CORD-02 수정으로 대체되었고, restricted-write 채널과 다른 초안 자료는 사양에 들어가지 않았습니다.
+
+## NIP 심층 분석
+
+### 이벤트 삭제 요청(NIP-09)
+
+[기본 사양](https://github.com/nostr-protocol/nips/blob/master/09.md)에서 정의된 [NIP-09](/ko/topics/nip-09/)(이벤트 삭제 요청)은 이벤트 작성자에게 해당 작성자의 이벤트 하나 이상의 제공을 중단하도록 릴레이와 클라이언트에 요청하는 서명된 방법을 제공합니다. 모든 사본을 지우지는 않습니다. 원래 이벤트를 배포한 것과 같은 릴레이 네트워크를 통해 작성자의 의도를 전달합니다.
+
+요청은 일반적인 서명된 kind `5` 이벤트입니다. 태그에는 특정 이벤트 ID에 대한 하나 이상의 `e` 참조 또는 어드레서블 이벤트 좌표에 대한 `a` 참조가 포함되며, [NIP-09 태그 규칙](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request)에 따르면 참조된 각 이벤트 kind에 대해 `k` 태그를 포함해야 합니다. 선택적 `content`는 이유를 설명할 수 있습니다. `a` 참조의 경우, 릴레이는 해당 좌표에서 타임스탬프가 요청의 `created_at`보다 늦지 않은 모든 버전을 제거해야 하며, 이는 오래된 삭제 요청이 이후 교체를 억제하는 것을 방지합니다.
+
+[작성자 권한이 보안 경계](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior)입니다. 릴레이는 참조된 이벤트의 `pubkey`가 삭제 요청의 `pubkey`와 일치할 때만 해당 이벤트 게시를 중단해야 하며, 클라이언트는 이벤트를 숨기기 전에 그 검사를 수행해야 합니다. 릴레이는 참조된 이벤트를 보유하지 않을 수 있어 요청을 수락할 때 관계를 검증하지 못할 수 있으므로, 클라이언트는 릴레이 수락을 삭제가 승인되었다는 증거로 취급할 수 없습니다. 사양은 또한 다른 클라이언트가 이미 원본 이벤트를 보유하고 나중에 요청을 만날 수 있으므로 릴레이가 kind `5` 요청을 보존하도록 요청합니다.
+
+다음은 [서명된 kind `5` 이벤트](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943)입니다.
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+삭제는 서명된 객체의 취소가 아닌 협력적 정책으로 남아 있습니다. 릴레이, 캐시, 스크린샷, 또는 오프라인 클라이언트는 원본 바이트를 보존할 수 있으며, kind `5` 요청 자체를 삭제해도 취소되지 않습니다. 클라이언트는 대상을 숨기거나, 소유권을 포기한 것으로 표시하거나, 요청 이유를 표시할 수 있지만, 보편적 삭제가 보장될 수 없음을 사용자에게 알려야 합니다. 이는 이벤트가 게시될 때 선택한 시간 이후 릴레이가 이벤트 저장을 중단하도록 요청하는 `expiration` 태그가 있는 [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)과 다릅니다. NIP-09는 이후 작성자 결정을 다루며 이미 배포된 이벤트를 가리킬 수 있습니다.
+
+현재 구현은 서로 다른 레이어에서 그 정책을 적용합니다. [Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623)은 삭제된 비디오를 클라이언트 이벤트 저장소에서 제거하고, [strfry PR #251](https://github.com/hoytech/strfry/pull/251)은 유효한 삭제 요청을 gift-wrap 수신자까지 확장하며, [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md)는 클라이언트에서 NIP-09 지원을 선언합니다. [nostrord의 그룹 클라이언트](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt)는 또 다른 현재 구현 경로를 제공합니다.
+
+### 신고(NIP-56)
+
+[기본 사양](https://github.com/nostr-protocol/nips/blob/master/56.md)에서 정의된 [NIP-56](/ko/topics/nip-56/)(신고 이벤트)은 계정, 이벤트, 또는 참조된 blob에 대한 서명된 신고를 표준화합니다. 신고 신호를 중재 결정과 분리하여, 각 클라이언트나 릴레이가 신뢰하는 신고자와 해당 정책에 맞는 응답을 선택할 수 있게 합니다.
+
+신고는 kind `1984`를 사용하며 `p` 태그로 신고된 계정을 식별해야 합니다. 노트를 신고하려면 이벤트 ID에 대한 `e` 태그도 필요합니다. 태그의 세 번째 값은 지정된 카테고리 중 하나를 담습니다. `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation`, `other`. blob에 대한 신고는 해시를 `x` 태그에, blob을 참조한 이벤트를 `e` 태그에, 위치를 `server` 태그에 사용할 수 있습니다. 고정 카테고리 목록이 충분히 정확하지 않을 때 [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md)의 선택적 `L` 및 `l` 태그로 namespaced 레이블을 추가할 수 있습니다.
+
+[이벤트는 하나의 키가 주장을 했다는 것만 증명](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting)합니다. 신고된 콘텐츠는 유효한 kind `1984`가 존재한다고 해서 거짓, 불법, 또는 제거 가능해지지 않으며, 개방형 릴레이는 익명 신고를 투표로 안전하게 집계할 수 없습니다. 사양은 신고를 조작하기 쉬우므로 자동 릴레이 중재에 반대하면서, 이미 신뢰하는 중재자의 신고에 대해 릴레이 관리자가 조치할 수 있도록 허용합니다. 클라이언트는 대신 사용자의 소셜 그래프를 통해 신고에 가중치를 줄 수 있습니다. 예를 들어, 신뢰하는 여러 연락처가 같은 계정을 플래그한 후 콘텐츠를 흐리게 처리합니다.
+
+다음은 [서명된 kind `1984` 이벤트](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2)입니다.
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56과 NIP-09는 서로 다른 문제를 해결](https://github.com/nostr-protocol/nips/tree/master)합니다. kind `1984` 신고는 다른 사람의 계정이나 이벤트를 대상으로 할 수 있지만, 삭제 권한을 부여하지 않습니다. kind `5` 요청은 원본 작성자의 의도를 표현하며 해당 작성자 자신의 이벤트에 대해서만 유효합니다. 둘 다 제거를 보장하지 않습니다. NIP-56은 의도적으로 조치를 로컬 중재 정책에 위임하고, NIP-09는 릴레이와 클라이언트가 인증된 요청을 존중하는 데 의존합니다.
+
+구현은 서로 다른 제품에서 그 선택을 노출합니다. [Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591)은 숏폼 비디오 클라이언트에서 신고 전달을 수정하고, [Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250)은 marketplace 참가자를 위한 제한된 맥락으로 신고를 읽으며, [nostrord의 NIP-56 모듈](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt)은 신고 이벤트를 게시하고 처리합니다. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support)도 현재 NIP-56 지원을 나열합니다.
+
+
+---
+
+[Nostr Compass 프로젝트](https://github.com/andotherstuff/nostr-compass)를 통해 프로젝트나 뉴스를 공유하려면 NIP-17 DM을 보내주세요.

--- a/content/nl/newsletters/2026-08-12-newsletter.md
+++ b/content/nl/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Post-quantum-identiteitstools, sterkere versleutelde berichten en ondertekening, draagbare community-instellingen en protocolwerk over NIPs en Concord."
+---
+
+Welkom terug bij [Nostr Compass](https://nostrcompass.org), je wekelijkse gids voor Nostr.
+
+**Deze week:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) voegt post-quantum-sleutels en optioneel beschermde berichten toe naast bestaande Nostr-identiteiten. [Divine](https://github.com/divinevideo/divine-mobile) verscherpt accountisolatie, validatie van privéberichten en publicatiebevestiging; [MDK](https://github.com/marmot-protocol/mdk) versterkt convergentie en herstel van versleutelde groepen; en [Amber](https://github.com/greenart7c3/Amber) maakt gegroepeerde ondertekeningsbeslissingen expliciet. Releases verbeteren walletverbindingen, versleutelde chat, sociale ontdekking, apparaatsynchronisatie en remote signing, terwijl protocolwerk identiteit en versleutelde communities behandelt. De deep dives leggen geauthenticeerde verwijderingsverzoeken en gedecentraliseerde meldingen uit.
+
+## Topverhalen
+
+### nostr-wot-extension 0.4.0 voegt post-quantum-sleutels toe naast een Nostr-identiteit
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) is een browserextensie voor het beheren van Nostr-identiteiten en ondertekenen. Accounts die uit een 24-woords seed zijn aangemaakt, kunnen nu ML-KEM-1024-versleutelings- en ML-DSA-87-ondertekeningssleutels afleiden naast hun bestaande Nostr-sleutel. Een flow met één klik publiceert een kind `10203`-attestatie die de Nostr-public key bindt aan beide post-quantum-public keys en een ML-DSA-bezitsbewijs bevat. Accounts geïmporteerd uit een 12-woords mnemonic, een kale `nsec`, een remote signer of een alleen-lezen sleutel kunnen de afleidingsflow niet gebruiken, en de extensie legt die beperking uit in de accountweergave.
+
+De release voegt ook optionele post-quantum directe berichten toe. Het combineert het ML-KEM-gedeelde geheim met de bestaande [NIP-44 encrypted-message conversation key](https://github.com/nostr-protocol/nips/blob/master/44.md) via HKDF en behoudt de normale NIP-59 metadata-hiding gift-wrap-lagen voor relaylevering. Versleuteling valt nooit stil terug nadat een ontvanger zich heeft aangemeld, terwijl ontsleuteling automatisch het passende pad kiest. Dit beschermt het nieuwe berichtenpad tegen later herstel van een huidige Nostr-private key, maar vervangt geen secp256k1-eventsignaturen; de release laat die grotere migratie expliciet over aan toekomstige coördinatie met relays en clients.
+
+### Divine Mobile 1.0.19 verscherpt accounts, privéberichten en publiceren
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) is een mobiele kortvideo-client die video's publiceert en ophaalt via Nostr. De accountwisselaar bouwt elke ingelogde identiteit nu rond een accountgebonden container, en een publicatiefix voorkomt dat een video onder het verkeerde account wordt verstuurd. Relaypublicatiepaden wachten nu op een `OK`-antwoord met expliciete successemantiek, terwijl een relay-`CLOSED`-frame zijn eigen lopende query kan beëindigen in plaats van het verzoek te laten hangen.
+
+[Privéberichtenafhandeling](https://github.com/divinevideo/divine-mobile/pull/6368) wijst niet-geauthenticeerde rumor-velden en ongetekende seals af, herstelt vier gevallen van ontbrekende berichten en stuurt groepsgesprekken van volledig gevolgde deelnemers naar de inbox. De release behoudt ook de tags op adresseerbare video-events wanneer lijsten worden bijgewerkt en verwerkt waargenomen verwijderingsverzoeken zodat verwijderde video's uit de lokale staat verdwijnen. Die wijzigingen volgen op het per-relay query-timeoutwerk van vorige week, maar verschuiven de focus van ophaalisolatie naar identiteitsgrenzen, berichtvalidatie en publicatiebevestiging.
+
+### MDK 0.9.11 verhardt Marmot-groepsconvergentie en -herstel
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) is een Rust-ontwikkelkit voor Marmot, een versleuteld groepsberichtenprotocol over Nostr. De release bouwt een groter convergentie- en herstelsysteem rond de groepsstate machine: verouderde convergentiepasses heropenen op de huidige groepstip, inkomende capability-projecties worden atomisch gecommit, uitgestelde berichten krijgen begrensde levensduur over herstarts heen, en commit-adressed checkpoints helpen de eigen commit-forks van een identiteit te herstellen. Niet-stabiele sends kunnen in de wachtrij worden gezet en hersteld, terwijl een epoch-stall-pad escaleert naar backfill en verzonden berichten convergentiewerk overleven.
+
+[Opslag- en hostintegraties](https://github.com/marmot-protocol/mdk/pull/1201) krijgen een parallelle verhardingsronde. MDK verwijdert veilig geprunede SQLite-projecties, wist geïmporteerde private keys, NIP-49 encrypted-key export-intermediairs en OpenMLS-serialisatiebuffers, en redacteert groepsafbeeldingssleutels uit debug-output. Accountimport kan hervat worden na onderbreking, iOS- en Android-paden voor privéopslag zijn gerepareerd, en hosts kunnen opslag expliciet sluiten vóór suspensie. Nieuwe lichtgewicht roster- en lokale-lidmaatschapsprojecties verminderen wat applicaties moeten lezen, terwijl de Hermes-connector meerdere door agents gegenereerde afbeeldingen als één Marmot-album kan afleveren.
+
+### Nostria 4.1.67 breidt versleutelde-communitybeheer uit
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) is een web- en desktop-social client voor Nostr. De release bouwt voort op de experimentele NIP-29 relay-beheerde groepen en Concord-versleutelde communities uit 4.1.53, met community-ontbinding, icoon- en bannerbeheer, versleutelde fotouploads met gecomprimeerde previews, een volledige reactiepicker en een dual-pane-layout die een community openhoudt terwijl de gebruiker notities of artikelen leest. De release voegt ook threaded messaging en een gecombineerde hub voor publieke, groeps- en privéchats toe.
+
+### Amber 6.4.0 maakt elke gegroepeerde ondertekeningsbeslissing expliciet
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) is een Android-signer die Nostr-private keys scheidt van de applicaties die handtekeningen aanvragen. Het herontworpen multi-requestscherm biedt Approve- en Deny-controls voor elk verzoek en elke groep, ter vervanging van de vorige selectie-en-bevestigingsflow. Afgewezen verzoeken via Amber's relay-bemiddelde bunkerinterface ontvangen nu correcte foutresponses, zodat de aanvragende client afwijzing kan onderscheiden van een vastgelopen signer.
+
+[Amber's getagde bron](https://github.com/greenart7c3/Amber/tree/v6.4.0) voegt ook gelokaliseerde, menselijk leesbare labels toe voor 113 extra event kinds in elke uitgeleverde locale. De toevoegingen omvatten Concord-groepsevents, NIP-51 Git-repositorybookmarks en NIP-53 room-presence-events, waardoor gebruikers meer context krijgen over onbekende data voordat ze een handtekening goedkeuren. Een concurrent-map-guard lost ook een relay-subscriptiecrash op die een `NegativeArraySizeException` kon opleveren.
+
+### Safebox Acorn scheidt een draagbare herstelcomponent af van de webapp
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) is een standalone Python-component en command-line interface voor het beveiligen van door de gebruiker beheerde sleutels, fondsen en records met Nostr-ondersteunde staat. Acorn uit de bredere Safebox-webapplicatie halen laat een ander Python-project de runtime installeren en de sleutel-, Nostr-profiel-, relay-, record-, Cashu-, Lightning- en cryptografische helpers gebruiken zonder de webinterface mee te nemen. De huidige recordbeschermingsprimitieven kunnen een nieuwe 256-bit sleutel genereren, er één afleiden uit apart aangeleverde entropie, en de exacte sleutel coderen als een gecontroleerde 24-woords herstelzin.
+
+De [recovery and continuity guide](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) van het project positioneert Acorn als het vervangbare protocolcomponent binnen een huishouden- of community-Safebox. Het ontwerp houdt versleutelde staat beschikbaar via een lokale relay en onafhankelijke replica's, zodat herstel niet afhangt van één apparaat, applicatie, relay, mint of dienstverlener. De documentatie is voorzichtig over de huidige grens: versleuteling van beschermde records is nog in ontwerp, dus applicaties mogen records niet afhankelijk maken van de nieuwe recordbeschermingssleutel totdat dat profiel is geïmplementeerd en beoordeeld.
+
+
+## Getagde releases
+
+### Mostro Core 0.14.2 wijzigt de versleutelde chat-envelope
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) is de Rust-bibliotheek met gedeelde types en peer-to-peer-functies voor de Mostro-exchange-daemon en zijn clients. [Versie 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) vervangt gift-wrapped chatberichten door kind 14-envelopes die aparte conversation-encryption- en signing keys afleiden uit het gedeelde geheim van de peers. De nieuwe reader valideert auteur, handtekening, ontvanger, timestamp en contentgrootte, terwijl legacy gift-wrap-helpers beschikbaar blijven zodat clients beide formaten kunnen lezen tijdens migratie.
+
+### Mostro 0.18.1 start een Cashu-escrowpad en verhardt de daemon
+
+[Mostro](https://github.com/MostroP2P/mostro) is een peer-to-peer Lightning-exchange-daemon die orders coördineert via Nostr. [Versie 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) legt de basis voor een Cashu-escrow-backend, inclusief configuratie, databasehelpers, mint-integratie, startup-verdraad en de eerste lock-actie. Het kan ook prijzen gebruiken die een vertrouwde node via Nostr aankondigt, en adverteert proof-of-work-vereisten voor eerste contact in zijn replaceable info-event. De release werkt de Nostr-afhankelijkheid bij voor een NIP-44 denial-of-service-fix, verwijdert private keys uit restore-sessionlogs, wijst niet-geautoriseerde cooperative-cancel-berichten af, verhardt LNURL-fetches tegen server-side request forgery en hangs, valideert payout-invoices en herstelt hold-invoice-subscripties na een herstart.
+
+### LaWallet NWC 2.3.0 voegt Nostr-meldingen en zap-receipts toe
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) is een open-source Lightning Address-platform dat wallets verbindt via [Nostr Wallet Connect](/nl/topics/nip-47/). [Versie 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) laat elke wallet ontvangen en doorgestuurde meldingen sturen als configureerbare Nostr-events, inclusief een ontvanger-`p`-tag, geselecteerde relays, gesjabloonde content en optionele [NIP-44](/nl/topics/nip-44/)-versleuteling; retries hergebruiken dezelfde getekende event-ID. Het accepteert ook zap-verzoeken en publiceert getekende [NIP-57](/nl/topics/nip-57/) kind 9735-receipts na settlement, terwijl een nieuwe address-capability-weergave laat zien of het opgeloste adres NIP-05, NIP-57 en gerelateerde Lightning Address-protocollen ondersteunt.
+
+### nostr-double-ratchet TypeScript 0.0.166 bindt publieke invites aan session keys
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) levert TypeScript- en Rust-primitieven voor end-to-end versleutelde directe en groepsberichten over Nostr-relays. [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) vereist dat een invite-response het bezit van zijn session key bewijst, zodat een herbruikbare publieke invite geen Nostr-identiteit kan binden aan de session van een andere partij. De release wijst ook malformed rumor-velden af en verscherpt payloadvalidatie; bestaande sessions blijven werken, maar een bijgewerkte inviter wijst proofless responses van oudere invitees af.
+
+### cln-nip47 0.2.0 breidt NWC-verzoeken uit en isoleert ze
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) is een Core Lightning-plugin die een node blootstelt aan wallets via [Nostr Wallet Connect](/nl/topics/nip-47/). [Versie 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) voegt NWC-methodes toe om hold invoices aan te maken, te annuleren en te settlen plus een `hold_invoice_accepted`-notificatie, en adverteert de methodeset die de verbonden node daadwerkelijk ondersteunt. Transaction-list-responses stoppen nu bij 500 entries en ongeveer 128 kB, request-events worden gededupliceerd op event-ID, en de mislukte notificatie van één client blokkeert levering aan andere clients niet meer. De release verwijdert ook de twee multi-payment-methodes die niet langer deel uitmaken van de NWC-specificatie.
+
+### ClipRelay 0.1.3 herstelt relay- en signer-verbindingen na idle-periodes
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) synchroniseert het klembord van een gebruiker tussen apparaten via Nostr-relays en versleutelt de content voor dezelfde identiteit met [NIP-44](/nl/topics/nip-44/). De bijpassende [desktop-](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) en [Android-](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3)releases 0.1.3 voegen een tekstvak toe om getypte tekst rechtstreeks naar het klembord van een ander apparaat te sturen. Ze testen ook liveness met echte relay-roundtrips na idle-periodes, escalerend van resubscriptie naar socket-vervanging en een herbouwde connection pool, terwijl vastgelopen [NIP-46](/nl/topics/nip-46/)-signer-aanroepen nu time-outen en automatisch herbouwen.
+
+### NoorNote 1.3.2 verplaatst artikelontdekking naar de social graph
+
+[NoorNote](https://github.com/77elements/noornote) is een Nostr-client voor social posts, versleutelde berichten, long-form-artikelen en andere event types op web, desktop en Android. [Versie 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) vervangt de platte globale artikelfeed door ontdekking uit eerste-, tweede- en derdegraadscontacten, waardoor lezers een aan de follow graph gewortelde artikeltimeline krijgen. Het vouwt ook bursts van gereplayde directe berichten van onbekende afzenders samen tot één rollende notificatie in plaats van een stapel toasts terwijl relayhistorie binnenkomt.
+
+### Bray 2.4.0 voegt een compact remote-signing-dialect toe
+
+[Bray](https://github.com/forgesworn/bray) is een Nostr MCP-server die software-agents en mensen tools geeft voor relaytoegang, identiteit, publiceren en remote signing. [Versie 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) accepteert een signing request waarvan het event een object is naast de stringified vorm die [NIP-46](/nl/topics/nip-46/) gebruikt, en voegt `sign_event_compact` toe, dat alleen event-ID, handtekening, public key en timestamp teruggeeft. Dat kleinere request- en responseformaat vermindert geheugengebruik voor constrained hardware signers, terwijl de standaard `sign_event`-flow ongewijzigd blijft en beide dialecten een handtekening over de ID van het ontvangen event produceren.
+
+
+## Nieuw ontdekt
+
+### Pact brengt wederzijds toegestemde agent bonds naar Nostr
+
+[Pact](https://github.com/bobodread876/pact), deze week nieuw ontdekt, is een vroeg stadium relationshiplaag voor software-agents gebouwd op MATE.md en een draft NIP-BD-transport. Zijn getekende, wederzijds toegestemde bonds worden vastgehouden door de eigen sleutels van de agents en kunnen via Nostr worden gepubliceerd, terwijl private bonds [NIP-59](/nl/topics/nip-59/) gift wrapping gebruiken. De monorepo omvat een MCP-server, TypeScript SDK, command-line client, zelf te hosten daemon en webinterface. De laatste repositoryactiviteit valt vóór het wekelijkse venster van deze editie, dus dit is een ontdekkingsnotitie en geen claim op een nieuwe release.
+
+
+## In ontwikkeling
+
+### nostrord houdt groepsdempen gesynchroniseerd tussen apparaten
+
+[nostrord](https://github.com/nostrord/nostrord) is een cross-platform client voor relay-beheerde communities. [PR #250](https://github.com/nostrord/nostrord/pull/250) slaat de per-groep dempkeuzes van elk account op in een zelfversleuteld [NIP-78](/nl/topics/nip-78/) (application-specific data) kind `30078`-event, zodat een instelling op één apparaat de gebruiker naar een ander kan volgen zonder de groepslijst aan de relay prijs te geven. Het replaceable record gebruikt newest-event ordering, luistert naar live wijzigingen en rolt de interface terug wanneer ondertekenen of publiceren mislukt in plaats van lokale staat desynchroon te laten. Gedempte groepen dragen niet meer bij aan zichtbare ongelezen totalen maar behouden hun ongelezen positie voor het volgende bezoek.
+
+### Amethyst voltooit Concords invite lifecycle
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) is een Android Nostr-client waarvan de versleutelde-community-ondersteuning het Concord-protocol implementeert. [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) laat invitelinks een community-refounding overleven door hun bundles opnieuw uit te geven op dezelfde adresseerbare coördinaten, terwijl een ban-check voorkomt dat een verwijderd lid dat herstelpad gebruikt. Het implementeert ook de versleutelde CORD-05-invitelijst in zowel de app als de `amy` command-line client, voegt per-link revocation tombstones toe en vereist relaybevestiging vóór het verwijderen van de enige opgeslagen signing key die een link kan pensioneren. Hetzelfde werk geeft `amy` de control-key delivery-, refounding-, rekeying- en stranded-member recovery-paden die nodig zijn om latere community-epochs te volgen.
+
+### Buzz draagt het uiterlijk van elke community mee over desktop en mobiel
+
+[Buzz](https://github.com/block/buzz) is een Nostr-gebaseerde community-workspace met desktop- en mobiele clients. Gemergde desktop-[PR #3653](https://github.com/block/buzz/pull/3653) en mobiele [PR #3767](https://github.com/block/buzz/pull/3767) slaan het theme, accent en system-mode-keuze van elke community op als versleuteld NIP-78-record op de relay van die community. Beide clients delen dezelfde versioned payload en houden identiteitsscoped lokale caches bij, zodat wisselen van community of account het verkeerde uiterlijk niet kan toepassen terwijl de relay niet beschikbaar is. Replacement ordering, guarded writes en resubscriptie na een gesloten verbinding laten beide clients opnieuw convergeren na reconnect.
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) volgde vóór de issue-cutoff met een performance- en betrouwbaarheidsronde. Het verwijdert regressies na 0.5.9, versnelt het laden van kanalen, begrenst initiële timeline-retentie, coalesceert read-state persistence, behoudt verse kanaaltimelines en voorkomt dat de relay ingest worker crasht op reacties op projectevents. Het voegt ook het sturen van een threadbericht naar een kanaal toe en beperkt desktopzoeken tot de bedoelde scope.
+
+
+## Protocol- en specificatiewerk
+
+### NIPs
+
+[NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435) is een open amendement op NIP-34, dat git-repositorysamenwerking via Nostr-events standaardiseert. Het voegt een optionele `b`-tag toe aan een pull-request-event zodat de auteur een target branch anders dan de default van de repository kan noemen. Het voorstel komt overeen met ondersteuning die al is geïmplementeerd in ngit en GitWorkshop, maar is nog niet in de specificatie opgenomen.
+
+[NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434) is een open voorstel voor post-quantum-identiteitssleutels. Het leidt post-quantum-versleutelings- en signing keys af naast de bestaande secp256k1-sleutel uit een NIP-06 mnemonic key-derivation seed en bindt de public keys aan de Nostr-identiteit met een kind `10203`-attestatie. Het draft beperkt zijn claim tot het beschermen van de vertrouwelijkheid van eerdere berichten als secp256k1 later wordt gebroken; het vervangt de huidige eventsignaturen niet.
+
+[NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431) is een open NIP-07-amendement voor browser signers. Een client zou de public key die hij verwacht kunnen meegeven bij signing- of encryption requests, waardoor de signer dat account moet gebruiken of de call moet afwijzen. Dat zou voorkomen dat een pagina stil doorgaat onder een andere identiteit nadat de gebruiker van account wisselt in de signer.
+
+[NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813) blijft een open double-ratchet-voorstel na substantieel werk in het venster. Het specificeert forward-secret versleutelde gesprekken waarvan de sleutels met berichten doorgaan, met een implementatie die al beschikbaar is in de nostr-double-ratchet-bibliotheek en Iris. Het is nog steeds een draft, geen gemergde NIP.
+
+[NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433) opende en sloot zonder merge in het venster. Het stelde voor NIP-42 relay errors te verduidelijken zodat `auth-required` zou betekenen dat verdere authenticatie het resultaat kan wijzigen, terwijl `restricted` zou betekenen dat dit niet kan. Het onderscheid richtte zich op verbindingen geauthenticeerd voor één sleutel maar nog zonder autorisatie voor een andere; de closed status betekent dat de formulering niet in de specificatie is opgenomen.
+
+[NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378), eerder behandeld terwijl het nog voorgesteld was, is nu gesloten zonder merge. De voorgestelde agent passports, discovery-, task-, marketplace-, invoice- en connection-events blijven daarmee buiten de NIP-set.
+
+[NIPs commit 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) merge een uitsluitend documentaire correctie op NIP-29. Het voegt een `previous`-tag toe aan het groepsmetadatavoorbeeld, waarmee wordt getoond hoe een replacement event het event kan identificeren dat het vervangt. Dit verduidelijkt een voorbeeld en introduceert geen nieuw protocolfeature.
+
+### Concord en CORDs
+
+[CORD PR #18](https://github.com/concord-protocol/concord/pull/18) zou versleutelde Community Lists sharden over kind `33302`-events, de limiet van 50 lidmaatschappen verwijderen en gepensioneerde entries prunen om binnen relaylimieten te blijven. Twee andere open voorstellen voegen [private mention locators](https://github.com/concord-protocol/concord/pull/16) en een [pause signal](https://github.com/concord-protocol/concord/pull/17) toe dat chat pauzeert zonder berichten weg te gooien.
+
+[CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15) merge op 6 augustus en beperkt writes tot het control plane van een community. Owners en staff houden een nieuw `control_root` signing secret, terwijl alle leden de afgeleide public key en read key behouden die nodig zijn om moderatiestaat te verifiëren en te ontsleutelen. De write key is een spambarrière, geen vervanging voor de inner actor signatures en roster checks die autoriteit vestigen.
+
+[CORD PR #12](https://github.com/concord-protocol/concord/pull/12), eerder behandeld als open draft, is nu gesloten zonder merge. Het control-plane-gedeelte werd vervangen door het smallere gemergde CORD-02-amendement hierboven, terwijl restricted-write channels en het overige draftmateriaal niet in de specificatie zijn opgenomen.
+
+## NIP Deep Dive
+
+### Event Deletion Requests (NIP-09)
+
+[NIP-09](/nl/topics/nip-09/), gedefinieerd door de [primaire specificatie](https://github.com/nostr-protocol/nips/blob/master/09.md), geeft een eventauteur een getekende manier om relays en clients te vragen één of meer events van die auteur niet meer te serveren. Het wist niet elke kopie. Het draagt de intentie van de auteur door hetzelfde relaynetwerk dat het oorspronkelijke event verspreidde.
+
+Het verzoek is een gewoon getekend kind `5`-event. De tags bevatten één of meer `e`-referenties naar specifieke event-ID's of `a`-referenties naar adresseerbare-eventcoördinaten, en de [NIP-09 tag rules](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) zeggen dat het een `k`-tag moet bevatten voor elk gerefereerd event kind. De optionele `content` kan de reden uitleggen. Voor een `a`-referentie moet een relay elke versie op die coördinaat verwijderen waarvan de timestamp niet later is dan de `created_at` van het verzoek, wat voorkomt dat een oud verwijderingsverzoek een latere replacement onderdrukt.
+
+[Auteurschap is de beveiligingsgrens](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Een relay moet een gerefereerd event stoppen met publiceren alleen wanneer zijn `pubkey` overeenkomt met de `pubkey` van het verwijderingsverzoek, en een client moet die check uitvoeren vóór het verbergen van een event. Een relay bezit het gerefereerde event mogelijk niet en kan daardoor de relatie niet valideren bij acceptatie van het verzoek, dus clients kunnen relayacceptatie niet behandelen als bewijs dat de verwijdering geautoriseerd was. De specificatie vraagt relays ook het kind `5`-verzoek te bewaren omdat een andere client het oorspronkelijke event al kan hebben en het verzoek later tegenkomt.
+
+Hier is een [getekend kind `5`-event](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+Verwijdering blijft een coöperatief beleid, geen intrekking van een getekend object. Een relay, cache, screenshot of offline client kan de oorspronkelijke bytes bewaren, en het verwijderen van het kind `5`-verzoek zelf maakt het niet ongedaan. Clients kunnen het doel verbergen, als disowned markeren of de reden van het verzoek tonen, maar moeten gebruikers vertellen dat universele verwijdering niet gegarandeerd kan worden. Dit verschilt van [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md), waar een `expiration`-tag relays vraagt een event niet meer op te slaan na een tijd die bij publicatie is gekozen. NIP-09 behandelt een latere auteursbeslissing en kan naar al verspreide events wijzen.
+
+Huidige implementaties passen dat beleid op verschillende lagen toe. [Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623) verwijdert verwijderde video's uit de event store van de client, [strfry PR #251](https://github.com/hoytech/strfry/pull/251) breidt geldige verwijderingsverzoeken uit naar gift-wrap-ontvangers, en [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) declareert NIP-09-ondersteuning in zijn client. [nostrord's group client](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) levert nog een huidig implementatiepad.
+
+### Reporting (NIP-56)
+
+[NIP-56](/nl/topics/nip-56/), gedefinieerd door de [primaire specificatie](https://github.com/nostr-protocol/nips/blob/master/56.md), standaardiseert een getekende melding over een account, event of gerefereerde blob. Het scheidt het meldingssignaal van de moderatiebeslissing, zodat elke client of relay kan kiezen welke reporters hij vertrouwt en welke respons bij zijn beleid past.
+
+Een melding gebruikt kind `1984` en moet het gemelde account identificeren in een `p`-tag. Het melden van een note vereist ook een `e`-tag voor de event-ID. De derde waarde van de tag draagt één van de gespecificeerde categorieën: `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation` of `other`. Een melding over een blob kan zijn hash gebruiken in een `x`-tag, een `e`-tag voor het event dat naar de blob verwees, en optioneel een `server`-tag voor een locatie. Optionele `L`- en `l`-tags uit [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) kunnen een namespaced label toevoegen wanneer de vaste categorielijst niet precies genoeg is.
+
+[Het event bewijst alleen dat één sleutel een beschuldiging heeft gedaan](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). De gemelde content wordt niet onwaar, illegaal of verwijderbaar alleen omdat een geldig kind `1984` bestaat, en een open relay kan anonieme meldingen niet veilig als stemmen tellen. De specificatie adviseert tegen automatische relaymoderatie omdat meldingen gemakkelijk te manipuleren zijn, maar staat relaybeheerders toe te handelen op meldingen van moderators die ze al vertrouwen. Een client kan meldingen in plaats daarvan wegen via de social graph van een gebruiker, bijvoorbeeld door content te vervagen nadat meerdere vertrouwde contacten hetzelfde account hebben gemarkeerd.
+
+Hier is een [getekend kind `1984`-event](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 en NIP-09 lossen verschillende problemen op](https://github.com/nostr-protocol/nips/tree/master). Een kind `1984`-melding kan het account of event van iemand anders targeten, maar verleent geen verwijderingsautoriteit. Een kind `5`-verzoek drukt de intentie van de oorspronkelijke auteur uit en is alleen geldig tegen de eigen events van die auteur. Geen van beide garandeert verwijdering: NIP-56 delegeert actie bewust aan lokaal moderatiebeleid, terwijl NIP-09 afhangt van relays en clients die een geauthenticeerd verzoek honoreren.
+
+Implementaties leggen die keuzes bloot in verschillende producten. [Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591) corrigeert meldingslevering in een kortvideo-client, [Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) leest meldingen als begrensde context voor marketplace-deelnemers, en [nostrord's NIP-56 module](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) publiceert en verwerkt meldingsevents. [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) vermeldt ook huidige NIP-56-ondersteuning.
+
+
+---
+
+Stuur een NIP-17 DM om een project of nieuwsitem te delen via het [Nostr Compass-project](https://github.com/andotherstuff/nostr-compass).

--- a/content/pt/newsletters/2026-08-12-newsletter.md
+++ b/content/pt/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "Ferramentas de identidade pós-quântica, mensagens criptografadas e assinatura mais robustas, configurações portáteis de comunidade e trabalho de protocolo em NIPs e Concord."
+---
+
+Bem-vindos de volta ao [Nostr Compass](https://nostrcompass.org), seu guia semanal de Nostr.
+
+**Esta semana:** o [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) adiciona chaves pós-quânticas e mensagens protegidas opt-in ao lado de identidades Nostr existentes. O [Divine](https://github.com/divinevideo/divine-mobile) reforça o isolamento de contas, a validação de mensagens privadas e a confirmação de publicação; o [MDK](https://github.com/marmot-protocol/mdk) fortalece a convergência e a recuperação de grupos criptografados; e o [Amber](https://github.com/greenart7c3/Amber) torna explícitas as decisões de assinatura em grupo. Os lançamentos melhoram conexões de carteira, chat criptografado, descoberta social, sincronização entre dispositivos e assinatura remota, enquanto o trabalho de protocolo abrange identidade e comunidades criptografadas. Os mergulhos profundos explicam solicitações autenticadas de exclusão e denúncias descentralizadas.
+
+## Histórias Principais
+
+### nostr-wot-extension 0.4.0 adiciona chaves pós-quânticas ao lado de uma identidade Nostr
+
+O [nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) é uma extensão de navegador para gerenciar identidades Nostr e assinar. Contas criadas a partir de uma seed de 24 palavras agora podem derivar chaves de criptografia ML-KEM-1024 e de assinatura ML-DSA-87 ao lado da chave Nostr existente. Um fluxo de um clique publica uma atestação kind `10203` que vincula a chave pública Nostr às duas chaves públicas pós-quânticas e inclui uma prova de posse ML-DSA. Contas importadas de um mnemônico de 12 palavras, `nsec` nu, signatário remoto ou chave somente leitura não podem usar o fluxo de derivação, e a extensão explica essa limitação na visualização da conta.
+
+O lançamento também adiciona mensagens diretas pós-quânticas opt-in. Ele combina o segredo compartilhado ML-KEM com a [chave de conversa de mensagens criptografadas do NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) existente por meio de HKDF e mantém as camadas normais de gift-wrap do NIP-59 que ocultam metadados para entrega via relay. A criptografia nunca recua silenciosamente depois que o destinatário opta por entrar, enquanto a descriptografia seleciona automaticamente o caminho apropriado. Isso protege o novo caminho de mensagens contra a recuperação posterior de uma chave privada Nostr atual, mas não substitui assinaturas de eventos secp256k1; o lançamento deixa explicitamente essa migração maior para coordenação futura com relays e clientes.
+
+### Divine Mobile 1.0.19 reforça contas, mensagens privadas e publicação
+
+O [Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) é um cliente móvel de vídeos curtos que publica e recupera vídeos por meio do Nostr. Seu seletor de contas agora constrói cada identidade conectada em torno de um contêiner com escopo de conta, e uma correção de publicação impede que um vídeo seja enviado pela conta errada. Os caminhos de publicação em relays agora aguardam uma resposta `OK` com semântica explícita de sucesso, enquanto um frame `CLOSED` do relay pode encerrar sua própria consulta pendente em vez de deixar a requisição pendurada.
+
+O [tratamento de mensagens privadas](https://github.com/divinevideo/divine-mobile/pull/6368) rejeita campos rumor não autenticados e seals não assinados, restaura quatro casos de mensagens ausentes e encaminha conversas em grupo de participantes totalmente seguidos para a caixa de entrada. O lançamento também preserva as tags em eventos de vídeo endereçáveis quando listas são atualizadas e consome solicitações de exclusão observadas para que vídeos removidos desapareçam do estado local. Essas mudanças seguem o trabalho de tempo limite de consulta por relay coberto na semana passada, mas deslocam o foco do isolamento de recuperação para limites de identidade, validação de mensagens e confirmação de publicação.
+
+### MDK 0.9.11 endurece a convergência e a recuperação de grupos Marmot
+
+O [MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) é um kit de desenvolvimento Rust para Marmot, um protocolo de mensagens em grupo criptografadas transportado sobre Nostr. O lançamento constrói um sistema maior de convergência e recuperação em torno da máquina de estados do grupo: passes de convergência obsoletos reabrem na ponta atual do grupo, projeções de capacidade de entrada são confirmadas atomicamente, mensagens adiadas recebem tempos de vida limitados entre reinicializações, e checkpoints endereçados por commit ajudam a recuperar os próprios forks de commit de uma identidade. Envios não estáveis podem ser enfileirados e recuperados, enquanto um caminho de estagnação de epoch escala para backfill e mensagens enviadas sobrevivem ao trabalho de convergência.
+
+[Integrações de armazenamento e host](https://github.com/marmot-protocol/mdk/pull/1201) recebem um endurecimento paralelo. O MDK exclui com segurança projeções SQLite podadas, zera chaves privadas importadas, intermediários de exportação de chave criptografada NIP-49 e buffers de serialização OpenMLS, e redige chaves de imagem de grupo da saída de debug. A importação de conta pode ser retomada após interrupção, caminhos de armazenamento privado em iOS e Android são reparados, e hosts podem fechar explicitamente o armazenamento antes da suspensão. Novas projeções leves de roster e associação local reduzem o que os aplicativos precisam ler, enquanto o conector Hermes pode entregar várias imagens geradas por agentes como um álbum Marmot.
+
+### Nostria 4.1.67 expande a administração de comunidades criptografadas
+
+O [Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) é um cliente social web e desktop para Nostr. Ele se baseia nos grupos gerenciados por relays experimentais NIP-29 e nas comunidades criptografadas Concord introduzidas na 4.1.53, adicionando dissolução de comunidade, administração de ícone e banner, uploads de fotos criptografadas com prévias comprimidas, um seletor completo de reações e um layout de dois painéis que mantém uma comunidade aberta enquanto o usuário lê notas ou artigos. O lançamento também adiciona mensagens encadeadas e um hub combinado para chats públicos, de grupo e privados.
+
+### Amber 6.4.0 torna explícita cada decisão de assinatura em grupo
+
+O [Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) é um signatário Android que mantém chaves privadas Nostr separadas dos aplicativos que solicitam assinaturas. Sua tela redesenhada de múltiplas requisições oferece controles Aprovar e Negar para cada requisição e cada grupo, substituindo o fluxo anterior de seleção e confirmação. Requisições negadas enviadas pela interface bunker mediada por relay do Amber agora recebem respostas de erro adequadas, para que o cliente solicitante possa distinguir rejeição de um signatário parado.
+
+A [fonte marcada do Amber](https://github.com/greenart7c3/Amber/tree/v6.4.0) também adiciona rótulos localizados e legíveis por humanos para mais 113 kinds de evento em todos os locales publicados. As adições incluem eventos de grupo Concord, favoritos de repositório Git NIP-51 e eventos de presença em sala NIP-53, dando aos usuários mais contexto sobre dados desconhecidos antes de aprovar uma assinatura. Um guarda de mapa concorrente também corrige uma falha de inscrição em relay que podia produzir um `NegativeArraySizeException`.
+
+### Safebox Acorn separa um componente portátil de recuperação do aplicativo web
+
+O [Safebox Acorn](https://github.com/trbouma/safebox-acorn) é um componente Python autônomo e interface de linha de comando para salvaguardar chaves, fundos e registros controlados pelo usuário com estado respaldado por Nostr. Extrair o Acorn do aplicativo web Safebox mais amplo permite que outro projeto Python instale o runtime e use seus helpers de chave, perfil Nostr, relay, registro, Cashu, Lightning e criptográficos sem assumir a interface web. Suas primitivas atuais de proteção de registros podem gerar uma chave fresca de 256 bits, derivar uma a partir de entropia fornecida separadamente e codificar a chave exata como uma frase de recuperação de 24 palavras com checksum.
+
+O [guia de recuperação e continuidade](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) do projeto enquadra o Acorn como o componente de protocolo substituível dentro de um Safebox doméstico ou comunitário. O design mantém estado criptografado disponível por meio de um relay local e réplicas independentes, de modo que a recuperação não dependa de um único aparelho, aplicativo, relay, mint ou provedor de serviço. A documentação é cuidadosa quanto ao limite atual: a criptografia de registros protegidos permanece em design, portanto aplicativos não devem fazer registros dependerem da nova chave de proteção de registros até que esse perfil tenha sido implementado e revisado.
+
+
+## Lançamentos com tag
+
+### Mostro Core 0.14.2 altera o envelope de chat criptografado
+
+O [Mostro Core](https://github.com/MostroP2P/mostro-core) é a biblioteca Rust de tipos compartilhados e funções peer-to-peer usada pelo daemon de exchange Mostro e seus clientes. A [versão 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) substitui mensagens de chat gift-wrapped por envelopes kind 14 que usam chaves separadas de criptografia de conversa e de assinatura derivadas do segredo compartilhado dos pares. O novo leitor valida o autor, a assinatura, o destinatário, o timestamp e o tamanho do conteúdo, enquanto helpers legados de gift-wrap permanecem disponíveis para que clientes possam ler ambos os formatos durante a migração.
+
+### Mostro 0.18.1 inicia um caminho de escrow Cashu e endurece o daemon
+
+O [Mostro](https://github.com/MostroP2P/mostro) é um daemon de exchange Lightning peer-to-peer que coordena ordens por meio do Nostr. A [versão 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) lança a base para um backend de escrow Cashu, incluindo configuração, helpers de banco de dados, integração com mint, wiring de inicialização e a primeira ação de lock. Ele também pode usar preços anunciados por um nó confiável sobre Nostr e anuncia requisitos de proof-of-work para primeiro contato em seu evento de info substituível. O lançamento atualiza sua dependência Nostr para uma correção de negação de serviço do NIP-44, remove chaves privadas de logs de sessão de restauração, rejeita mensagens de cancelamento cooperativo não autorizadas, endurece buscas LNURL contra server-side request forgery e travamentos, valida faturas de payout e restaura inscrições de hold invoice após reinicialização.
+
+### LaWallet NWC 2.3.0 adiciona notificações Nostr e recibos de zap
+
+O [LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) é uma plataforma Lightning Address de código aberto que conecta carteiras por meio do [Nostr Wallet Connect](/pt/topics/nip-47/). A [versão 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) permite que cada carteira envie notificações de recebimento e encaminhamento como eventos Nostr configuráveis, incluindo uma tag `p` de destinatário, relays selecionados, conteúdo templado e criptografia opcional [NIP-44](/pt/topics/nip-44/) (payloads criptografados); novas tentativas reutilizam o mesmo ID de evento assinado. Ele também aceita zap requests e publica recibos kind 9735 assinados do [NIP-57](/pt/topics/nip-57/) (zaps) após liquidação, enquanto uma nova visualização de capacidade de endereço mostra se o endereço resolvido suporta NIP-05, NIP-57 e protocolos Lightning Address relacionados.
+
+### nostr-double-ratchet TypeScript 0.0.166 vincula convites públicos a chaves de sessão
+
+O [nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) fornece primitivas TypeScript e Rust para mensagens diretas e em grupo criptografadas de ponta a ponta sobre relays Nostr. O [TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) exige que uma resposta a convite prove posse de sua chave de sessão, impedindo que um convite público reutilizável vincule uma identidade Nostr à sessão de outra parte. O lançamento também rejeita campos rumor malformados e reforça a validação de payload; sessões existentes continuam funcionando, mas um convidador atualizado rejeita respostas sem prova de convidados mais antigos.
+
+### cln-nip47 0.2.0 expande e isola requisições NWC
+
+O [cln-nip47](https://github.com/daywalker90/cln-nip47) é um plugin Core Lightning que expõe um nó a carteiras por meio do [Nostr Wallet Connect](/pt/topics/nip-47/). A [versão 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) adiciona métodos NWC para criar, cancelar e liquidar hold invoices, além de uma notificação `hold_invoice_accepted`, e anuncia o conjunto de métodos que o nó conectado realmente suporta. Respostas de lista de transações agora param em 500 entradas e cerca de 128 kB, eventos de requisição são deduplicados por ID de evento, e a falha de notificação de um cliente não impede mais a entrega a outros clientes. O lançamento também remove os dois métodos de multipagamento que não fazem mais parte da especificação NWC.
+
+### ClipRelay 0.1.3 restaura conexões de relay e signatário após períodos ociosos
+
+O [ClipRelay](https://github.com/tajava2006/cliprelay) sincroniza a área de transferência de um usuário entre dispositivos por meio de relays Nostr, criptografando o conteúdo para a mesma identidade com [NIP-44](/pt/topics/nip-44/) (payloads criptografados). Os lançamentos [desktop](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) e [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 adicionam uma caixa de texto para enviar texto digitado diretamente para a área de transferência de outro dispositivo. Eles também testam vivacidade com round trips reais de relay após períodos ociosos, escalando de reinscrição a substituição de socket e um pool de conexões reconstruído, enquanto chamadas de signatário [NIP-46](/pt/topics/nip-46/) (assinatura remota) paradas agora expiram e reconstruem automaticamente.
+
+### NoorNote 1.3.2 move a descoberta de artigos para o grafo social
+
+O [NoorNote](https://github.com/77elements/noornote) é um cliente Nostr para publicações sociais, mensagens criptografadas, artigos longos e outros tipos de evento em web, desktop e Android. A [versão 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) substitui seu feed global plano de artigos por descoberta extraída de contatos de primeiro, segundo e terceiro grau, dando aos leitores uma linha do tempo de artigos enraizada em seu grafo de seguidos. Ele também colapsa rajadas de mensagens diretas repetidas de remetentes desconhecidos em uma única notificação contínua em vez de produzir uma pilha de toasts conforme o histórico do relay chega.
+
+### Bray 2.4.0 adiciona um dialeto compacto de assinatura remota
+
+O [Bray](https://github.com/forgesworn/bray) é um servidor Nostr MCP que oferece a agentes de software e pessoas ferramentas para acesso a relays, identidade, publicação e assinatura remota. A [versão 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) aceita uma requisição de assinatura cujo evento é um objeto, além da forma stringificada usada pelo [NIP-46](/pt/topics/nip-46/), e adiciona `sign_event_compact`, que retorna apenas o ID do evento, a assinatura, a chave pública e o timestamp. Esse formato menor de requisição e resposta reduz o uso de memória para signatários de hardware restritos, enquanto o fluxo padrão `sign_event` permanece inalterado e ambos os dialetos produzem uma assinatura sobre o ID do evento recebido.
+
+
+## Recém-descobertos
+
+### Pact traz vínculos de agentes mutuamente consentidos ao Nostr
+
+O [Pact](https://github.com/bobodread876/pact), recém-descoberto esta semana, é uma camada de relacionamento em estágio inicial para agentes de software construída sobre MATE.md e um transporte draft NIP-BD. Seus vínculos assinados e mutuamente consentidos são mantidos pelas próprias chaves dos agentes e podem ser publicados sobre Nostr, enquanto vínculos privados usam gift wrapping do [NIP-59](/pt/topics/nip-59/) (metadados ocultos). O monorepo inclui um servidor MCP, SDK TypeScript, cliente de linha de comando, daemon auto-hospedável e interface web. Sua atividade mais recente no repositório é anterior à janela semanal desta edição, portanto esta é uma nota de descoberta e não uma alegação de novo lançamento.
+
+
+## Em desenvolvimento
+
+### nostrord mantém silenciamento de grupo sincronizado entre dispositivos
+
+O [nostrord](https://github.com/nostrord/nostrord) é um cliente multiplataforma para comunidades gerenciadas por relays. O [PR #250](https://github.com/nostrord/nostrord/pull/250) armazena as escolhas de silenciamento por grupo de cada conta em um evento kind `30078` auto-criptografado do [NIP-78](/pt/topics/nip-78/) (dados específicos de aplicativo), de modo que uma configuração feita em um dispositivo possa seguir o usuário para outro sem revelar a lista de grupos ao relay. O registro substituível usa ordenação por evento mais recente, escuta mudanças ao vivo e reverte a interface quando assinatura ou publicação falha, em vez de deixar o estado local dessincronizado. Grupos silenciados também deixam de contribuir com totais visíveis de não lidos, mantendo sua posição de não lidos para a próxima visita.
+
+### Amethyst completa o ciclo de vida de convites do Concord
+
+O [Amethyst](https://github.com/vitorpamplona/amethyst) é um cliente Nostr Android cujo suporte a comunidades criptografadas implementa o protocolo Concord. O [PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) permite que links de convite sobrevivam a um refounding de comunidade reemitindo seus bundles nas mesmas coordenadas endereçáveis, enquanto uma verificação de ban impede que um membro removido use esse caminho de recuperação. Ele também implementa a lista de convites criptografada CORD-05 tanto no aplicativo quanto no cliente de linha de comando `amy`, adiciona tombstones de revogação por link, e exige confirmação do relay antes de excluir a única chave de assinatura armazenada que pode aposentar um link. O mesmo trabalho dá ao `amy` os caminhos de entrega de control key, refounding, rekeying e recuperação de membros isolados necessários para seguir epochs posteriores da comunidade.
+
+### Buzz transporta a aparência de cada comunidade entre desktop e mobile
+
+O [Buzz](https://github.com/block/buzz) é um workspace comunitário baseado em Nostr com clientes desktop e mobile. Os PRs mergeados de desktop [PR #3653](https://github.com/block/buzz/pull/3653) e mobile [PR #3767](https://github.com/block/buzz/pull/3767) armazenam o tema, o destaque e a escolha de modo do sistema de cada comunidade como um registro NIP-78 criptografado no relay dessa comunidade. Ambos os clientes compartilham o mesmo payload versionado e mantêm caches locais com escopo de identidade, de modo que mudar de comunidade ou conta não possa aplicar a aparência errada enquanto o relay está indisponível. Ordenação de substituição, escritas protegidas e reinscrição após conexão fechada permitem que os dois clientes converjam novamente após reconectar.
+
+O [Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) veio antes do corte desta edição com uma passagem de desempenho e confiabilidade. Ele remove regressões introduzidas após a 0.5.9, acelera o carregamento de canais, limita a retenção inicial da linha do tempo, coalesce a persistência de estado de leitura, preserva linhas do tempo frescas de canal e impede que o worker de ingestão de relay falhe em reações a eventos de projeto. Ele também adiciona o envio de uma mensagem de thread para um canal e restringe a busca desktop ao escopo pretendido.
+
+
+## Trabalho em protocolos e especificações
+
+### NIPs
+
+O [NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435) é uma emenda aberta ao NIP-34, que padroniza colaboração em repositórios git por meio de eventos Nostr. Ele adiciona uma tag `b` opcional a um evento de pull request para que o autor possa nomear um branch de destino diferente do padrão do repositório. A proposta corresponde ao suporte já implementado no ngit e no GitWorkshop, mas ainda não entrou na especificação.
+
+O [NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434) é uma proposta aberta para chaves de identidade pós-quânticas. Ela deriva chaves pós-quânticas de criptografia e assinatura ao lado da chave secp256k1 existente a partir de uma seed de derivação de chaves mnemônica NIP-06 e, em seguida, vincula as chaves públicas à identidade Nostr com uma atestação kind `10203`. O rascunho limita sua reivindicação a proteger a confidencialidade de mensagens anteriores se o secp256k1 for quebrado posteriormente; ele não substitui as assinaturas de eventos atuais.
+
+O [NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431) é uma emenda aberta ao NIP-07 para signatários de navegador. Um cliente poderia anexar a chave pública que espera a requisições de assinatura ou criptografia, exigindo que o signatário use essa conta ou rejeite a chamada. Isso impediria que uma página continuasse silenciosamente sob uma identidade diferente depois que o usuário troca de conta no signatário.
+
+O [NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813) permanece uma proposta aberta de double-ratchet após trabalho substancial durante a janela. Ela especifica conversas criptografadas com forward secrecy cujas chaves avançam com as mensagens, com uma implementação já disponível na biblioteca nostr-double-ratchet e no Iris. Ainda é um rascunho, não um NIP mergeado.
+
+O [NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433) abriu e fechou sem merge durante a janela. Ele propôs esclarecer erros de relay do NIP-42 para que `auth-required` significasse que outra autenticação poderia alterar o resultado, enquanto `restricted` significaria que não poderia. A distinção tratava de conexões autenticadas para uma chave, mas ainda sem autorização para outra; o status fechado significa que a redação não entrou na especificação.
+
+O [NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378), coberto anteriormente enquanto ainda proposto, agora fechou sem merge. Seus eventos propostos de passaportes de agente, descoberta, tarefa, marketplace, fatura e conexão permanecem, portanto, fora do conjunto de NIPs.
+
+O [NIPs commit 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) mergeou uma correção apenas documental ao NIP-29. Ele adiciona uma tag `previous` ao exemplo de metadados de grupo, mostrando como um evento de substituição pode identificar o evento que substitui. Isso esclarece um exemplo e não introduz um novo recurso de protocolo.
+
+### Concord e CORDs
+
+O [CORD PR #18](https://github.com/concord-protocol/concord/pull/18) fragmentaria Community Lists criptografadas entre eventos kind `33302`, removeria o limite de 50 associações e podaria entradas aposentadas para permanecer dentro dos limites de relay. Duas outras propostas abertas adicionam [localizadores de menção privada](https://github.com/concord-protocol/concord/pull/16) e um [sinal de pausa](https://github.com/concord-protocol/concord/pull/17) que suspende o chat sem descartar mensagens.
+
+O [CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15) mergeou em 6 de agosto e restringe escritas ao plano de controle de uma comunidade. Proprietários e equipe detêm um novo segredo de assinatura `control_root`, enquanto todos os membros retêm a chave pública derivada e a read key necessárias para verificar e descriptografar o estado de moderação. A write key é uma barreira contra spam, não um substituto para as assinaturas internas de ator e verificações de roster que estabelecem autoridade.
+
+O [CORD PR #12](https://github.com/concord-protocol/concord/pull/12), coberto anteriormente como rascunho aberto, agora fechou sem merge. Sua porção de plano de controle foi substituída pela emenda CORD-02 mais estreita mergeada acima, enquanto canais de escrita restrita e o restante do material de rascunho não entraram na especificação.
+
+## Mergulho Profundo em NIPs
+
+### Solicitações de Exclusão de Eventos (NIP-09)
+
+O [NIP-09](/pt/topics/nip-09/) (solicitações de exclusão de eventos), definido pela [especificação primária](https://github.com/nostr-protocol/nips/blob/master/09.md), dá a um autor de evento uma forma assinada de pedir a relays e clientes que parem de servir um ou mais eventos desse autor. Ele não apaga todas as cópias. Ele transporta a intenção do autor pela mesma rede de relays que distribuiu o evento original.
+
+A requisição é um evento kind `5` assinado comum. Suas tags contêm uma ou mais referências `e` a IDs de evento específicos ou referências `a` a coordenadas de eventos endereçáveis, e as [regras de tag do NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) dizem que deve incluir uma tag `k` para cada kind de evento referenciado. O `content` opcional pode explicar o motivo. Para uma referência `a`, um relay deve remover toda versão naquela coordenada cujo timestamp não seja posterior ao `created_at` da requisição, o que impede que uma requisição de exclusão antiga suprima uma substituição posterior.
+
+[A autoria é a fronteira de segurança](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior). Um relay deve parar de publicar um evento referenciado apenas quando seu `pubkey` corresponder ao `pubkey` da requisição de exclusão, e um cliente deve executar essa verificação antes de ocultar um evento. Um relay pode não possuir o evento referenciado e, portanto, pode ser incapaz de validar o relacionamento ao aceitar a requisição, de modo que clientes não podem tratar a aceitação do relay como prova de que a exclusão foi autorizada. A especificação também pede que relays retenham a requisição kind `5`, porque outro cliente pode já possuir o evento original e encontrar a requisição depois.
+
+Aqui está um [evento kind `5` assinado](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+A exclusão permanece uma política cooperativa, não revogação de um objeto assinado. Um relay, cache, screenshot ou cliente offline pode preservar os bytes originais, e excluir a própria requisição kind `5` não a desfaz. Clientes podem ocultar o alvo, marcá-lo como desautorizado ou exibir o motivo da requisição, mas devem dizer aos usuários que a exclusão universal não pode ser garantida. Isso difere do [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md), onde uma tag `expiration` pede a relays que parem de armazenar um evento após um horário escolhido quando o evento é publicado. O NIP-09 trata de uma decisão posterior do autor e pode apontar para eventos já distribuídos.
+
+Implementações atuais aplicam essa política em camadas diferentes. O [Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623) remove vídeos excluídos do armazenamento de eventos do cliente, o [strfry PR #251](https://github.com/hoytech/strfry/pull/251) estende requisições válidas de exclusão a destinatários gift-wrap, e o [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) declara suporte ao NIP-09 em seu cliente. O [cliente de grupo do nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) oferece outro caminho de implementação atual.
+
+### Denúncias (NIP-56)
+
+O [NIP-56](/pt/topics/nip-56/) (eventos de denúncia), definido pela [especificação primária](https://github.com/nostr-protocol/nips/blob/master/56.md), padroniza uma denúncia assinada sobre uma conta, evento ou blob referenciado. Ele separa o sinal de denúncia da decisão de moderação, permitindo que cada cliente ou relay escolha quais denunciantes confia e qual resposta se encaixa em sua política.
+
+Uma denúncia usa kind `1984` e deve identificar a conta denunciada em uma tag `p`. Denunciar uma nota também exige uma tag `e` para o ID do evento. O terceiro valor da tag carrega uma das categorias especificadas: `nudity`, `malware`, `profanity`, `illegal`, `spam`, `impersonation` ou `other`. Uma denúncia sobre um blob pode usar seu hash em uma tag `x`, uma tag `e` para o evento que referenciou o blob, e uma tag `server` opcional para um local. Tags `L` e `l` opcionais do [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) (rotulagem) podem adicionar um rótulo com namespace quando a lista fixa de categorias não é precisa o suficiente.
+
+[O evento prova apenas que uma chave fez uma alegação](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting). O conteúdo denunciado não se torna falso, ilegal ou removível apenas porque existe um kind `1984` válido, e um relay aberto não pode contar com segurança denúncias anônimas como votos. A especificação desaconselha moderação automática de relay porque denúncias são fáceis de manipular, enquanto permite que administradores de relay ajam sobre denúncias de moderadores em quem já confiam. Um cliente pode, em vez disso, ponderar denúncias pelo grafo social de um usuário, por exemplo borrando conteúdo depois que vários contatos confiáveis sinalizam a mesma conta.
+
+Aqui está um [evento kind `1984` assinado](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 e NIP-09 resolvem problemas diferentes](https://github.com/nostr-protocol/nips/tree/master). Uma denúncia kind `1984` pode mirar a conta ou evento de outra pessoa, mas não confere autoridade de exclusão. Uma requisição kind `5` expressa a intenção do autor original e é válida apenas contra os próprios eventos desse autor. Nenhuma garante remoção: o NIP-56 delega deliberadamente a ação à política local de moderação, enquanto o NIP-09 depende de relays e clientes honrarem uma requisição autenticada.
+
+Implementações expõem essas escolhas em produtos diferentes. O [Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591) corrige a entrega de denúncias em um cliente de vídeo curto, o [Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) lê denúncias como contexto limitado para participantes de marketplace, e o [módulo NIP-56 do nostrord](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) publica e processa eventos de denúncia. O [Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) também lista suporte atual ao NIP-56.
+
+
+---
+
+Envie uma DM NIP-17 para compartilhar um projeto ou notícia por meio do [projeto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/zh/newsletters/2026-08-12-newsletter.md
+++ b/content/zh/newsletters/2026-08-12-newsletter.md
@@ -1,0 +1,202 @@
+---
+title: "Nostr Compass #35"
+date: 2026-08-12
+publishDate: 2026-08-12
+translationOf: /en/newsletters/2026-08-12-newsletter.md
+translationDate: 2026-08-12
+draft: false
+type: newsletters
+description: "后量子身份工具、更强的加密消息与签名、可移植的社区设置,以及横跨 NIPs 与 Concord 的协议工作。"
+---
+
+欢迎回到 [Nostr Compass](https://nostrcompass.org),您的 Nostr 每周指南。
+
+**本周:** [nostr-wot-extension](https://github.com/nostr-wot/nostr-wot-extension) 在现有 Nostr 身份旁添加后量子密钥和可选的保护消息。[Divine](https://github.com/divinevideo/divine-mobile) 收紧账户隔离、私信验证和发布确认;[MDK](https://github.com/marmot-protocol/mdk) 加强加密群组收敛与恢复;[Amber](https://github.com/greenart7c3/Amber) 使分组签名决策变得明确。版本发布改进了钱包连接、加密聊天、社交发现、设备同步和远程签名,协议工作涵盖身份与加密社区。深度解析将解释经身份验证的删除请求和去中心化举报。
+
+## 头条新闻
+
+### nostr-wot-extension 0.4.0 在 Nostr 身份旁添加后量子密钥
+
+[nostr-wot-extension 0.4.0](https://github.com/nostr-wot/nostr-wot-extension/releases/tag/v0.4.0) 是一款用于管理 Nostr 身份和签名的浏览器扩展。从 24 词 seed 创建的账户现在可以在现有 Nostr 密钥旁派生 ML-KEM-1024 加密密钥和 ML-DSA-87 签名密钥。一键流程发布 kind `10203` 证明,将 Nostr 公钥绑定到两个后量子公钥,并包含 ML-DSA 占有证明。从 12 词助记词、裸 `nsec`、远程签名器或只读密钥导入的账户无法使用该派生流程,扩展会在账户视图中说明这一限制。
+
+该版本还添加了可选的后量子私信。它通过 HKDF 将 ML-KEM 共享密钥与现有的 [NIP-44 encrypted-message conversation key](https://github.com/nostr-protocol/nips/blob/master/44.md) 结合,并保留正常的 NIP-59 元数据隐藏 gift-wrap 层用于中继投递。收件人选择加入后,加密绝不会静默回退,而解密会自动选择适当路径。这可以保护新消息路径免受日后恢复当前 Nostr 私钥的影响,但不会替换 secp256k1 事件签名;该版本明确将更大规模的迁移留给未来与中继和客户端的协调。
+
+### Divine Mobile 1.0.19 收紧账户、私信和发布
+
+[Divine Mobile 1.0.19](https://github.com/divinevideo/divine-mobile/releases/tag/1.0.19) 是一款通过 Nostr 发布和检索视频的移动短视频客户端。其账户切换器现在围绕账户作用域容器构建每个已登录身份,发布修复可防止视频在错误账户下发送。中继发布路径现在等待带有明确成功语义的 `OK` 响应,而中继 `CLOSED` 帧可以终止其自身的待处理查询,而不是让请求挂起。
+
+[私信处理](https://github.com/divinevideo/divine-mobile/pull/6368) 拒绝未认证的 rumor 字段和未签名的 seal,恢复四种缺失消息情况,并将完全关注参与者的群组对话路由到收件箱。该版本在更新列表时还会保留可寻址视频事件的标签,并消费观察到的删除请求,使已移除视频从本地状态中消失。这些更改延续了上周涵盖的按中继查询超时工作,但将焦点从检索隔离转向身份边界、消息验证和发布确认。
+
+### MDK 0.9.11 强化 Marmot 群组收敛与恢复
+
+[MDK 0.9.11](https://github.com/marmot-protocol/mdk/releases/tag/v0.9.11) 是 Marmot 的 Rust 开发工具包,Marmot 是一种通过 Nostr 承载的加密群组消息协议。该版本围绕群组状态机构建更大的收敛与恢复系统:过时的收敛轮次在当前群组 tip 处重新打开,入站 capability 投影原子提交,延迟消息在重启间获得有界生命周期,commit 寻址检查点帮助恢复身份自身的 commit 分叉。非稳定发送可以排队并恢复,而 epoch-stall 路径会升级到 backfill,已发送消息在收敛工作中得以保留。
+
+[存储与宿主集成](https://github.com/marmot-protocol/mdk/pull/1201) 获得并行强化。MDK 安全删除已修剪的 SQLite 投影,清零导入的私钥、NIP-49 encrypted-key 导出中间体和 OpenMLS 序列化缓冲区,并从调试输出中编辑群组图像密钥。账户导入可在中断后恢复,iOS 和 Android 私有存储路径已修复,宿主可在挂起前显式关闭存储。新的轻量级 roster 和本地成员投影减少了应用必须读取的内容,而 Hermes 连接器可以将多个 agent 生成的图像作为一张 Marmot 相册投递。
+
+### Nostria 4.1.67 扩展加密社区管理
+
+[Nostria 4.1.67](https://github.com/nostria-app/nostria/releases/tag/v4.1.67) 是一款用于 Nostr 的 Web 和桌面社交客户端。它在 4.1.53 引入的实验性 NIP-29 中继管理群组和 Concord 加密社区基础上,增加了社区解散、图标和横幅管理、带压缩预览的加密照片上传、完整反应选择器,以及双窗格布局——在用户阅读笔记或文章时保持社区打开。该版本还添加了线程消息以及公开、群组和私聊的组合中心。
+
+### Amber 6.4.0 使每个分组签名决策都明确
+
+[Amber 6.4.0](https://github.com/greenart7c3/Amber/releases/tag/v6.4.0) 是一款 Android 签名器,将 Nostr 私钥与请求签名的应用分离。重新设计的多请求屏幕为每个请求和每个分组提供 Approve 和 Deny 控件,取代先前的选择并确认流程。通过 Amber 中继介导 bunker 接口发送的被拒绝请求现在会收到正确的错误响应,因此请求客户端可以区分拒绝与签名器停滞。
+
+[Amber 的 tagged source](https://github.com/greenart7c3/Amber/tree/v6.4.0) 还在每个已发布语言环境中为另外 113 种 event kind 添加本地化、人类可读标签。新增内容包括 Concord 群组事件、NIP-51 Git 仓库书签和 NIP-53 room-presence 事件,在用户批准签名前为不熟悉的数据提供更多上下文。并发 map 守卫还修复了可能导致 `NegativeArraySizeException` 的中继订阅崩溃。
+
+### Safebox Acorn 将可移植恢复组件与 Web 应用分离
+
+[Safebox Acorn](https://github.com/trbouma/safebox-acorn) 是一个独立的 Python 组件和命令行界面,用于通过 Nostr 支持的状态保护用户控制的密钥、资金和记录。将 Acorn 从更广泛的 Safebox Web 应用中抽出,让另一个 Python 项目可以安装运行时并使用其密钥、Nostr 个人资料、中继、记录、Cashu、Lightning 和加密辅助工具,而无需承担 Web 界面。其当前的记录保护原语可以生成新的 256 位密钥,从单独提供的熵派生一个,并将精确密钥编码为带校验的 24 词恢复短语。
+
+项目的 [recovery and continuity guide](https://trbouma.github.io/safebox-acorn/recovery-and-continuity/) 将 Acorn 定位为家庭或社区 Safebox 内可替换的协议组件。该设计通过本地中继和独立副本保持加密状态可用,因此恢复不依赖单一设备、应用、中继、mint 或服务提供商。文档对当前边界保持谨慎:受保护记录加密仍在设计中,因此在实现并审查该配置文件之前,应用不应让记录依赖新的记录保护密钥。
+
+
+## 打标签的发布
+
+### Mostro Core 0.14.2 更改加密聊天信封
+
+[Mostro Core](https://github.com/MostroP2P/mostro-core) 是 Mostro 交换守护进程及其客户端使用的共享类型和点对点函数的 Rust 库。[版本 0.14.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.2) 用 kind 14 信封替换 gift-wrapped 聊天消息,该信封从对等方共享密钥派生独立的 conversation-encryption 和 signing keys。新读取器验证作者、签名、收件人、时间戳和内容大小,而 legacy gift-wrap 辅助工具仍可用,以便客户端在迁移期间读取两种格式。
+
+### Mostro 0.18.1 启动 Cashu 托管路径并强化守护进程
+
+[Mostro](https://github.com/MostroP2P/mostro) 是通过 Nostr 协调订单的点对点 Lightning 交换守护进程。[版本 0.18.1](https://github.com/MostroP2P/mostro/releases/tag/v0.18.1) 为 Cashu 托管后端奠定基础,包括配置、数据库辅助工具、mint 集成、启动接线和首个 lock 操作。它还可以使用受信任节点通过 Nostr 公布的价格,并在其可替换 info 事件中宣传首次联系的 proof-of-work 要求。该版本更新 Nostr 依赖以修复 NIP-44 拒绝服务问题,从 restore-session 日志中移除私钥,拒绝未授权的合作取消消息,强化 LNURL 获取以防范服务端请求伪造和挂起,验证 payout invoice,并在重启后恢复 hold-invoice 订阅。
+
+### LaWallet NWC 2.3.0 添加 Nostr 通知和 zap 收据
+
+[LaWallet NWC](https://github.com/lawalletio/lawallet-nwc) 是一个开源 Lightning Address 平台,通过 [Nostr Wallet Connect](/zh/topics/nip-47/) 连接钱包。[版本 2.3.0](https://github.com/lawalletio/lawallet-nwc/releases/tag/v2.3.0) 允许每个钱包将收到和转发的通知作为可配置的 Nostr 事件发送,包括收件人 `p` 标签、选定中继、模板化内容和可选 [NIP-44](/zh/topics/nip-44/) 加密;重试复用同一已签名 event ID。它还接受 zap 请求并在结算后发布已签名的 [NIP-57](/zh/topics/nip-57/) kind 9735 收据,而新的地址能力视图显示解析后的地址是否支持 NIP-05、NIP-57 及相关 Lightning Address 协议。
+
+### nostr-double-ratchet TypeScript 0.0.166 将公开邀请绑定到 session keys
+
+[nostr-double-ratchet](https://github.com/irislib/nostr-double-ratchet) 提供通过 Nostr 中继进行端到端加密直接和群组消息的 TypeScript 和 Rust 原语。[TypeScript 0.0.166](https://github.com/irislib/nostr-double-ratchet/releases/tag/nostr-double-ratchet-ts-v0.0.166) 要求邀请响应证明其 session key 的所有权,防止可复用的公开邀请将一种 Nostr 身份绑定到另一方的 session。该版本还拒绝格式错误的 rumor 字段并收紧 payload 验证;现有 session 继续工作,但更新后的邀请方会拒绝来自旧受邀者的无证明响应。
+
+### cln-nip47 0.2.0 扩展并隔离 NWC 请求
+
+[cln-nip47](https://github.com/daywalker90/cln-nip47) 是一个 Core Lightning 插件,通过 [Nostr Wallet Connect](/zh/topics/nip-47/) 向钱包暴露节点。[版本 0.2.0](https://github.com/daywalker90/cln-nip47/releases/tag/v0.2.0) 添加 NWC 方法以创建、取消和结算 hold invoice,以及 `hold_invoice_accepted` 通知,并宣传连接节点实际支持的方法集。交易列表响应现在在 500 条和约 128 kB 处停止,request 事件按 event ID 去重,一个客户端的失败通知不再阻止向其他客户端投递。该版本还移除不再属于 NWC 规范的两个 multi-payment 方法。
+
+### ClipRelay 0.1.3 在空闲期后恢复中继和签名器连接
+
+[ClipRelay](https://github.com/tajava2006/cliprelay) 通过 Nostr 中继在设备间同步用户剪贴板,并使用 [NIP-44](/zh/topics/nip-44/) 将内容加密给同一身份。配套的 [desktop](https://github.com/tajava2006/cliprelay/releases/tag/desktop/v0.1.3) 和 [Android](https://github.com/tajava2006/cliprelay/releases/tag/android/v0.1.3) 0.1.3 版本添加文本框,可将输入文本直接发送到另一设备的剪贴板。它们还在空闲期后通过真实中继往返测试活性,从重新订阅升级到 socket 替换和重建连接池,而停滞的 [NIP-46](/zh/topics/nip-46/) 签名器调用现在会超时并自动重建。
+
+### NoorNote 1.3.2 将文章发现移入社交图谱
+
+[NoorNote](https://github.com/77elements/noornote) 是一款用于社交帖子、加密消息、长文和其他 event types 的 Nostr 客户端,覆盖 Web、桌面和 Android。[版本 1.3.2](https://github.com/77elements/noornote/releases/tag/v1.3.2) 用来自一、二、三度联系人的发现替换其扁平全局文章 feed,为读者提供根植于关注图谱的文章时间线。它还将来自未知发送者的重放私信突发合并为一条滚动通知,而不是在中继历史到达时产生一堆 toast。
+
+### Bray 2.4.0 添加紧凑远程签名方言
+
+[Bray](https://github.com/forgesworn/bray) 是一个 Nostr MCP 服务器,为软件 agent 和用户提供中继访问、身份、发布和远程签名工具。[版本 2.4.0](https://github.com/forgesworn/bray/releases/tag/v2.4.0) 接受 event 为对象的签名请求,以及 [NIP-46](/zh/topics/nip-46/) 使用的字符串化形式,并添加 `sign_event_compact`,仅返回 event ID、签名、公钥和时间戳。更小的请求和响应格式降低受限硬件签名器的内存使用,而标准 `sign_event` 流程保持不变,两种方言都会对收到事件的 ID 生成签名。
+
+
+## 新发现
+
+### Pact 将相互同意的 agent bonds 引入 Nostr
+
+[Pact](https://github.com/bobodread876/pact) 是本周新发现的项目,是基于 MATE.md 和 draft NIP-BD 传输的早期关系层,面向软件 agent。其已签名、相互同意的 bonds 由 agent 自身密钥持有,可通过 Nostr 发布,而 private bonds 使用 [NIP-59](/zh/topics/nip-59/) gift wrapping。monorepo 包含 MCP 服务器、TypeScript SDK、命令行客户端、可自托管守护进程和 Web 界面。其最新仓库活动早于本期周刊窗口,因此这是发现说明,而非新发布的声明。
+
+
+## 开发中
+
+### nostrord 在设备间同步群组静音
+
+[nostrord](https://github.com/nostrord/nostrord) 是一款面向中继管理社区的跨平台客户端。[PR #250](https://github.com/nostrord/nostrord/pull/250) 将每个账户的按群组静音选择存储在自加密 [NIP-78](/zh/topics/nip-78/) (application-specific data) kind `30078` 事件中,因此在一台设备上的设置可以跟随用户到另一台,而无需向中继暴露群组列表。可替换记录使用 newest-event ordering,监听实时变更,并在签名或发布失败时回滚界面,而不是让本地状态不同步。已静音群组不再计入可见未读总数,但保留未读位置供下次访问。
+
+### Amethyst 完成 Concord 邀请生命周期
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) 是一款 Android Nostr 客户端,其加密社区支持实现了 Concord 协议。[PR #3888](https://github.com/vitorpamplona/amethyst/pull/3888) 让邀请链接在社区 refounding 后仍能存活,在同一可寻址坐标重新签发 bundle,而 ban 检查防止被移除成员使用该恢复路径。它还在 app 和 `amy` 命令行客户端上实现加密 CORD-05 邀请列表,添加按链接 revocation tombstones,并在删除唯一存储的可使链接退役的 signing key 之前要求中继确认。同一工作为 `amy` 提供 control-key delivery、refounding、rekeying 和 stranded-member recovery 路径,以跟随后续社区 epoch。
+
+### Buzz 在桌面和移动端携带各社区外观
+
+[Buzz](https://github.com/block/buzz) 是一个基于 Nostr 的社区工作区,拥有桌面和移动客户端。已合并的桌面 [PR #3653](https://github.com/block/buzz/pull/3653) 和移动 [PR #3767](https://github.com/block/buzz/pull/3767) 将每个社区的主题、强调色和 system-mode 选择存储为该社区中继上的加密 NIP-78 记录。两个客户端共享相同 versioned payload 并保持身份作用域本地缓存,因此在 relay 不可用时切换社区或账户不会应用错误外观。replacement ordering、guarded writes 和连接关闭后的重新订阅让两个客户端在重连后再次收敛。
+
+[Buzz Desktop 0.5.10](https://github.com/block/buzz/releases/tag/desktop-v0.5.10) 在 issue cutoff 前跟进,进行性能与可靠性改进。它移除 0.5.9 之后引入的回归,加速频道加载,限制初始时间线保留,合并 read-state persistence,保留新鲜频道时间线,并防止 relay ingest worker 因对 project events 的反应而崩溃。它还添加将线程消息发送到频道,并将桌面搜索限定在预期范围。
+
+
+## 协议与规范工作
+
+### NIPs
+
+[NIPs PR #2435](https://github.com/nostr-protocol/nips/pull/2435) 是对 NIP-34 的开放修订,NIP-34 通过 Nostr 事件标准化 git 仓库协作。它为 pull-request 事件添加可选 `b` 标签,使作者可以指定仓库 default 以外的 target branch。该提案与 ngit 和 GitWorkshop 中已实现的支持一致,但尚未进入规范。
+
+[NIPs PR #2434](https://github.com/nostr-protocol/nips/pull/2434) 是关于后量子身份密钥的开放提案。它从 NIP-06 mnemonic key-derivation seed 在现有 secp256k1 密钥旁派生后量子加密和签名密钥,然后用 kind `10203` 证明将公钥绑定到 Nostr 身份。草案将其主张限制为保护 secp256k1 日后被破解时早期消息的机密性;它不会替换当前的事件签名。
+
+[NIPs PR #2431](https://github.com/nostr-protocol/nips/pull/2431) 是针对浏览器签名器的开放 NIP-07 修订。客户端可以在签名或加密请求中附加其期望的公钥,要求签名器使用该账户或拒绝调用。这将防止用户在签名器中切换账户后,页面仍在另一身份下静默继续。
+
+[NIPs PR #1813](https://github.com/nostr-protocol/nips/pull/1813) 在窗口期内经过实质性工作后,仍是开放 double-ratchet 提案。它规范了 forward-secret 加密对话,其密钥随消息推进,实现已在 nostr-double-ratchet 库和 Iris 中可用。它仍是草案,而非已合并 NIP。
+
+[NIPs PR #2433](https://github.com/nostr-protocol/nips/pull/2433) 在窗口期内打开并在未合并的情况下关闭。它提议澄清 NIP-42 中继错误,使 `auth-required` 表示进一步认证可能改变结果,而 `restricted` 表示不能。该区分针对已为一种密钥认证但仍缺少另一种授权的连接;closed 状态意味着措辞未进入规范。
+
+[NIPs PR #2378](https://github.com/nostr-protocol/nips/pull/2378) 此前在仍为提案时被报道,现已关闭且未合并。其提议的 agent passports、discovery、task、marketplace、invoice 和 connection events 因此仍不在 NIP 集合中。
+
+[NIPs commit 656cecc](https://github.com/nostr-protocol/nips/commit/656cecc7c0a815b6a2b218d3b5d6f078b3f4dbab) 合并了对 NIP-29 的纯文档修正。它为群组 metadata 示例添加 `previous` 标签,展示 replacement event 如何标识其取代的事件。这澄清示例,不引入新协议功能。
+
+### Concord 和 CORDs
+
+[CORD PR #18](https://github.com/concord-protocol/concord/pull/18) 将把加密 Community Lists 分片到 kind `33302` 事件,移除 50 成员上限,并修剪已退役条目以符合中继限制。另外两个开放提案添加 [private mention locators](https://github.com/concord-protocol/concord/pull/16) 和 [pause signal](https://github.com/concord-protocol/concord/pull/17),在不丢弃消息的情况下暂停聊天。
+
+[CORD-02 PR #15](https://github.com/concord-protocol/concord/pull/15) 于 8 月 6 日合并,并将写入限制在社区 control plane。owners 和 staff 持有新的 `control_root` signing secret,而所有成员保留验证和解密 moderation state 所需的派生公钥和 read key。write key 是垃圾信息屏障,不是建立 authority 的内部 actor signatures 和 roster checks 的替代。
+
+[CORD PR #12](https://github.com/concord-protocol/concord/pull/12) 此前作为开放 draft 被报道,现已关闭且未合并。其 control-plane 部分被上文更窄的已合并 CORD-02 修订取代,而 restricted-write channels 和其他 draft 材料未进入规范。
+
+## NIP 深度解析
+
+### Event Deletion Requests (NIP-09)
+
+[NIP-09](/zh/topics/nip-09/),由 [primary specification](https://github.com/nostr-protocol/nips/blob/master/09.md) 定义,为事件作者提供一种签名方式,请求中继和客户端停止提供该作者的一个或多个事件。它不会擦除每一份副本。它通过分发原始事件的同一中继网络传递作者意图。
+
+请求是普通已签名的 kind `5` 事件。其 tags 包含一个或多个指向特定 event ID 的 `e` 引用,或指向可寻址 event 坐标的 `a` 引用,[NIP-09 tag rules](https://github.com/nostr-protocol/nips/blob/master/09.md#event-deletion-request) 要求为每个被引用 event kind 包含 `k` 标签。可选 `content` 可说明原因。对于 `a` 引用,中继应移除该坐标上 timestamp 不晚于请求 `created_at` 的每个版本,防止旧删除请求压制较新的 replacement。
+
+[Authorship is the security boundary](https://github.com/nostr-protocol/nips/blob/master/09.md#relay-behavior)。仅当被引用事件的 `pubkey` 与删除请求的 `pubkey` 匹配时,中继才应停止发布该事件,客户端在隐藏事件前必须执行该检查。中继可能不持有被引用事件,因此在接受请求时可能无法验证关系,客户端不能将中继接受视为删除已获授权的证明。规范还要求中继保留 kind `5` 请求,因为另一客户端可能已持有原始事件并在稍后遇到该请求。
+
+以下是一个 [signed kind `5` event](https://primal.net/e/6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943):
+
+```json
+{
+  "id": "6f39fd3d0d593d97dd093f21fabe8f78895579d6979a6ecf14e169bd85bb0943",
+  "pubkey": "5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743",
+  "created_at": 1786465675,
+  "kind": 5,
+  "tags": [
+    ["e", "f3d47f8b813928c5baf7ac993846be0220dc37a2e7c7b128fb49a4b92711f131"],
+    ["k", "30091"],
+    ["a", "30091:5877220aaae6e54a6f974602d5995c0fe24a3ea7ddabd8644bec795b9da00743:survey:0ad5cebc-608b-47d7-97fd-9e6c47787199"],
+    ["t", "nostr-survey"]
+  ],
+  "content": "Public survey summary deleted during privacy refresh",
+  "sig": "846be83b038dc5f91af0c9d03a4ac81aff9bc4cfde7d85c849fa2fdae890f75cc444a4072f45aa18883b0b3871e15381b220182d6e366892f0c9c6f9c0557244"
+}
+```
+
+删除仍是协作策略,而非撤销已签名对象。中继、缓存、截图或离线客户端可以保留原始字节,删除 kind `5` 请求本身也不会撤销它。客户端可以隐藏目标、标记为 disowned 或显示请求原因,但应告知用户无法保证普遍删除。这与 [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) 不同,后者通过 `expiration` 标签请求中继在发布时选定的时间后停止存储事件。NIP-09 处理作者稍后的决定,并可指向已分发的事件。
+
+当前实现在不同层应用该策略。[Divine PR #6623](https://github.com/divinevideo/divine-mobile/pull/6623) 从客户端 event store 移除已删除视频,[strfry PR #251](https://github.com/hoytech/strfry/pull/251) 将有效删除请求扩展到 gift-wrap 收件人,[Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md) 在其客户端中声明 NIP-09 支持。[nostrord's group client](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt) 提供另一条当前实现路径。
+
+### Reporting (NIP-56)
+
+[NIP-56](/zh/topics/nip-56/),由 [primary specification](https://github.com/nostr-protocol/nips/blob/master/56.md) 定义,标准化关于账户、事件或被引用 blob 的签名举报。它将举报信号与 moderation 决策分离,使每个客户端或中继可以选择信任哪些 reporter 以及何种响应符合其策略。
+
+举报使用 kind `1984`,必须在 `p` 标签中标识被举报账户。举报 note 还需要 event ID 的 `e` 标签。标签的第三个值携带指定类别之一:`nudity`、`malware`、`profanity`、`illegal`、`spam`、`impersonation` 或 `other`。关于 blob 的举报可以在 `x` 标签中使用其 hash,在 `e` 标签中使用引用该 blob 的事件,并可选使用 `server` 标签表示位置。来自 [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) 的可选 `L` 和 `l` 标签可以在固定类别列表不够精确时添加 namespaced label。
+
+[The event proves only that one key made an allegation](https://github.com/nostr-protocol/nips/blob/master/56.md#reporting)。被举报内容不会因存在有效 kind `1984` 而变为虚假、非法或可移除,开放中继也不能安全地将匿名举报计为投票。规范建议不要自动进行中继 moderation,因为举报容易被操纵,但允许中继管理员对其已信任的 moderator 的举报采取行动。客户端也可通过用户社交图谱对举报加权,例如在多个可信联系人标记同一账户后模糊内容。
+
+以下是一个 [signed kind `1984` event](https://primal.net/e/17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2):
+
+```json
+{
+  "id": "17301ea66066d34af9ba0b6957ed9d9d8854b9436939e682e21e7a5a8768e4b2",
+  "pubkey": "1ff02fb5cdc633c1be55368ab655490ec25d2f5dc2e364d4703bc3196d99eab1",
+  "created_at": 1786465319,
+  "kind": 1984,
+  "tags": [
+    ["p", "3a72b02cc05ee07310dc580874b6a9ca8271c6518b90655bd2e98003c9601e68", "impersonation"]
+  ],
+  "content": "",
+  "sig": "6362e415410feb19e0505654a4660e8456b6b2aec5ae39173a0429a6a8e5fa1381c9488198ca2982db43ee8198af056f2a25537705c763784062056d0ab2eb1a"
+}
+```
+
+[NIP-56 and NIP-09 solve different problems](https://github.com/nostr-protocol/nips/tree/master)。kind `1984` 举报可以针对他人的账户或事件,但不授予删除权限。kind `5` 请求表达原始作者意图,且仅对该作者自身事件有效。两者都不保证移除:NIP-56 有意将行动委托给本地 moderation 策略,而 NIP-09 依赖中继和客户端 honoring 经身份验证的请求。
+
+实现在不同产品中暴露这些选择。[Divine PR #6591](https://github.com/divinevideo/divine-mobile/pull/6591) 修正短视频客户端中的举报投递,[Conduit PR #250](https://github.com/Conduit-BTC/conduit-mono/pull/250) 将举报作为 marketplace 参与者的有界 context 读取,[nostrord's NIP-56 module](https://github.com/nostrord/nostrord/blob/862855e8e7130f509c458c6b4d36a3bd660f16d8/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt) 发布并处理举报事件。[Amethyst](https://github.com/vitorpamplona/amethyst/blob/278ddd27904dc721e54ffaca8803307d154f2e1d/README.md#nip-support) 也列出当前 NIP-56 支持。
+
+
+---
+
+发送 NIP-17 DM,通过 [Nostr Compass project](https://github.com/andotherstuff/nostr-compass) 分享项目或新闻。


### PR DESCRIPTION
Translations for Newsletter #35 (2026-08-12)

Translates:
- Newsletter #35 to 9 languages

References: #133

Languages: de, es, fr, it, ja, ko, nl, pt, zh

Character encoding verified ✓
Technical terms preserved ✓
Internal links updated ✓
