### PR TITLE
Add translations for Newsletter #29 and topic pages

### DIFF
--- a/content/de/newsletters/2026-07-01-newsletter.md
+++ b/content/de/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,372 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-08-27
+draft: false
+type: newsletters
+---
+
+Willkommen zurück bei Nostr Compass, eurem wöchentlichen Wegweiser für Nostr.
+
+**Diese Woche:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) liefert einen Nym-Mixnet-Transport, optionale mDNS-LAN-Discovery, unterbrechungsfreies Rekeying bei Paketverlust und eine Überarbeitung der Datenebene, wire-kompatibel mit v0.3.0. [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) erscheint als Desktop-Marmot-Client in Rust und Slint; ein Protokollvorschlag verlagert Nachrichteneffekte in ein eigenes Kind-9-Event. [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) startet als hardwaregestützter mobiler Identitäts-Tresor, der als NIP-46-Remote-Signer arbeitet und physische Zugangs-Challenges über NFC beantwortet. [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) startet Peer-to-Peer-nsite-Sharing über das FIPS-Mesh mit einem neuen BLE-L2CAP-Transport in v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) startet als Android-Steueroberfläche für einen lokalen Codex-Coding-Assistenten über verschlüsselte Nostr-DMs. [Amethysts unveröffentlichter Stand](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) ergänzt NIP-89-App-Handler-Parsing, einen Git-Repositories-Feed für NIP-34 und einen Discover-Bereich für nSites und napplets. [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) implementiert NIP-37, NIP-52 und NIP-22 in einer Woche. [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) veröffentlicht 12 Subpackage-Releases mit nbunksec-NIP-46-Helfern und einem Cashu-ts-v4-Wallet-Upgrade. [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) liefert Shared-Key Collaborative Lists auf dem adressierbaren Kind 35000. Das NIPs-Repository mergte fünf PRs, darunter ein Relay-Roles-Event, die Aufhebung des NIP-44-Limits von 65.535 Byte, NIP-34-Fork-Semantik, NIP-46-Client-Metadaten und eine NIP-86-`signevent`-Methode. Die Deep Dives behandeln [NIP-86 (Relay-Verwaltungs-API)](#nip-deep-dive-nip-86-relay-management-api) und [NIP-89 (empfohlene Application Handler)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Top-Storys
+
+### FIPS v0.4.0 liefert Nym-Mixnet-Transport, mDNS-Discovery und eine überarbeitete Datenebene {#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul}
+
+[FIPS](https://github.com/jmcorgan/fips) ist ein privates, selbstorganisierendes Peer-to-Peer-Mesh-Netzwerk für Nostr, in dem Nodes einander finden und Traffic ohne zentrale Infrastruktur routen. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) bringt einen Nym-Mixnet-Transport, optionale mDNS-LAN-Discovery, eine überarbeitete Datenebene, unterbrechungsfreies Rekeying bei Paketverlust, eine auf einem Render-Snapshot-Harness neu geschriebene `fipstop`-TUI, eine Observability-Ebene außerhalb des Hot Paths sowie neue Packaging-Ziele für OpenWrt apk und Nix flake. Alles bleibt wire-kompatibel mit v0.3.0, sodass gemischte Meshes während eines Rolling Upgrades interoperabel bleiben. Zwei neue Transporte für Peer-Discovery prägen das Release. Ein neuer [ausgehender Nym-Mixnet-Transport](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) routet FIPS-Traffic über einen `nym-socks5-client`-SOCKS5-Proxy und mischt ihn in das Cover-Traffic-Netzwerk von [Nym](https://nymtech.net/), sodass Beobachter auf Link-Ebene nicht korrelieren können, welche Mesh-Peers miteinander sprechen. Ein Verzeichnis `examples/sidecar-nostr-mixnet-relay/` demonstriert ein Nostr-relay, das über einen FIPS-Link erreichbar ist, der Ende zu Ende über das Mixnet peert. Optionale mDNS-/DNS-SD-LAN-Discovery lässt Nodes im selben lokalen Netz ohne Adresskonfiguration und ohne STUN zueinanderfinden; Peers werden über einen Standard-Service-Record bei `node.discovery.lan.enabled: true` angekündigt und übernommen.
+
+Die Datenebene wurde für höheren Durchsatz eines einzelnen Nodes überarbeitet. Ver- und Entschlüsselung pro Peer laufen nun auf eigenen Worker-Tasks außerhalb des Receive-Loops, sodass ein ausgelasteter Peer nicht mehr die Kryptografie des gesamten Nodes serialisiert. Der Linux-Sendepfad nutzt Generic Segmentation Offload und, wo verfügbar, einen verbundenen UDP-Socket; der Receive-Hot-Path vermeidet zuvor pro Paket angelegte Buffer-Kopien; macOS erhält einen gebündelten `recvmsg_x`-Receive als Gegenstück zum Linux-Batching mit `recvmmsg` aus v0.3.0. Die gesamte `show_*`-Leseoberfläche für `fipsctl` und `fipstop` bedient sich nun aus einem Snapshot pro Tick, den der Control-Accept-Task in ein lockfreies `ArcSwap` veröffentlicht. Operator-Abfragen antworten dadurch auch dann schnell, wenn der Receive-Loop eines Nodes ausgelastet ist. Eine neue reine Counter-Abfrage `show_metrics` (als `fipsctl stats metrics` verfügbar) ermöglicht Prometheus-Scraping ohne Kosten im Hot Path.
+
+FMP- und FSP-Session-Rekeying erfolgt nun bei Paketverlust und Neuordnung in beiden Richtungen ohne Unterbrechung: Eingehende Frames authentifizieren sich vor dem K-Bit-Cutover gegen die ausstehende Session, bevor diese hochgestuft wird, sodass ein veralteter oder gefälschter Frame das Rekeying nicht entgleisen lassen kann. Die erneute Übertragung von Rekey-Nachricht 1 ist begrenzt, der Link-Dead-Heartbeat berücksichtigt Rekeying, und Rennen durch beidseitige Initiierung auf Links mit hoher Latenz werden durch symmetrischen Jitter entzerrt. Die `fipstop`-TUI wurde auf einem Render-Snapshot-Harness neu aufgebaut, das das exakte Textraster und den Stil jeder Zelle jeder Ansicht gegen vorbereitete Control-Socket-Ausgaben prüft. Hinzu kommen neue Packaging-Ziele: ein OpenWrt-`.apk` für OpenWrt 25+ (SDK-frei gebaut, unter Wiederverwendung des bestehenden `.ipk`-Cross-Compiles und des installierten Dateisystem-Payloads) sowie eine `flake.nix` im Projektstamm, die alle vier Binaries (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) mit der gepinnten Toolchain aus dem Quellcode für Nix/NixOS baut.
+
+### Whitenoise Linux erscheint als Desktop-Marmot-Client {#whitenoise-linux-surfaces-as-a-desktop-marmot-client}
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) ist ein Desktop-[Marmot](/de/topics/marmot/)-Client: MLS-Gruppennachrichten über Nostr-relays, verpackt als einzelnes Rust-Binary mit einer Slint-UI, die jedes Geheimnis in einem passwortverschlüsselten Tresor hält.
+
+Der folgenreichste Thread dieser Woche schlägt vor, Whitenoise-Nachrichteneffekte als eigenes Kind-9-Event zu transportieren, das auf die übergeordnete Nachricht verweist. Das heutige Wire-Format hängt einen Marker wie `dmfx:sparkle` an das Ende des Nachrichtentextes an und verschmutzt damit den Text für jeden Renderer, der diese Konvention nicht kennt. Werden Effekte in ein eigenes Event verschoben, bleibt der Nachrichtentext sauber. Zugleich stellt sich eine Designfrage für den breiteren Marmot-Stack: Inline-Konventionen im Body oder Sidecar-Events für optionale Rich Features.
+
+### CustID startet als mobiler Identitäts-Tresor mit NIP-46 und NFC-Challenge-Flow {#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow}
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) ist die erste öffentliche Beta von CustID, einem auf Nostr und dem SISTR-Protokoll aufgebauten mobilen Identitäts-Tresor. CustID speichert mehrere Nostr-Identitäten in hardwaregestütztem sicherem Speicher, arbeitet für andere Clients als [NIP-46](/de/topics/nip-46/)-Remote-Signer und beantwortet physische und Online-Zugangs-Challenges über NFC und QR-Codes.
+
+Die Beta ist für den NIP-46-Signer und den NFC-Challenge-Response-Flow funktionsvollständig; Zugangsabläufe mit Zero-Knowledge-Proofs bleiben ein künftiger Meilenstein. Das Release entfernt außerdem die im Hintergrund laufende [NIP-65](/de/topics/nip-65/)-Keep-alive-Schicht der App. Sie hatte pro Profil und Read-relay einen WebSocket geöffnet und Kinds eingelesen, die der Client sofort verwarf. Im Hintergrund bleiben nun nur die NIP-46-Sockets aktiv, die Benachrichtigungen über Signieranforderungen transportieren. Erst diese Korrektur macht den Betrieb von CustID als Bunker für andere Clients auf einem Smartphone praktikabel.
+
+### myco startet Peer-to-Peer-nsite-Sharing über das FIPS-Mesh {#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh}
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) wurde diese Woche am 27. Juni geöffnet und erreichte am 1. Juli v0.1.0. myco ist eine Rust-Android-App, die Apps von Menschen in der Nähe installiert: Peer-to-Peer-[nsite](/de/topics/nip-5a/)-Sharing über ein FIPS-Mesh mit jedem Transport, den das Mesh tragen kann (UDP, TCP, Tor, Bluetooth), vollständig offline. Das Design verbindet FIPS direkt als Transportsubstrat mit dem Static-Website-Event-Format von NIP-5A als Payload. Eine als nsite verteilte App kann dadurch zwischen Mesh-Peers wandern, ohne von relays oder HTTP abhängig zu sein.
+
+v0.1.0 ergänzt einen L2CAP-Bluetooth-Funkpfad, über den zwei Smartphones mit installiertem FIPS ohne Netzwerk über BLE peeren können, dazu einen Speedtest pro Peer und NFC-ausgelöstes Sharing aus dem Circle-Bottom-Sheet der App. myco ist außerdem zur direkten Installation auf Zapstore veröffentlicht.
+
+### Nostr Codex Phone startet als mobile Steueroberfläche für einen lokalen Codex-Worker über Nostr {#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr}
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) startet diese Woche als Android-Client, der einen lokalen Codex-Coding-Assistant-Worker über verschlüsselte Nostr-Direktnachrichten steuert. Die App unterstützt mehrere Repository-Sessions, Sprachtranskription, geroutete Worker-Sessions, Blossom-Medien-Uploads und optionale gesprochene Antworten. Entwickler, die zu Hause einen Codex-Worker betreiben, können so von ihrem Smartphone überall dort Aufträge senden, wo das Telefon Relay-Zugriff hat.
+
+Das Projekt ist ein direktes Geschwister von [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), das in #28 startete. Beide bringen agentische Coding-Workflows mit verschlüsselten DMs auf den Nostr-Transport und nutzen Nostr als Pairing- und Messaging-Schicht, über die ein Smartphone einen heimischen Worker erreicht, ohne Löcher ins Netzwerk zu öffnen. Nostr als Control Plane für lokale Agenten entwickelt sich zu einem etablierten Muster.
+
+### Coop Mobile veröffentlicht seine ersten versionierten Builds
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) und [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) erschienen diese Woche als erste versionierte Builds von Coop Mobile, einem Android-Client für verschlüsselte [NIP-17](/de/topics/nip-17/)-Direktnachrichten. Die beiden Releases erhöhen die Absturzsicherheit beim Parsen von Nachrichten und beim QR-Handling und löschen beim Abmelden alle gespeicherten Daten.
+
+### Amethyst baut NIP-89-fähige UI, einen Git-Repositories-Feed und einen napplet-Discover-Bereich {#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section}
+
+[Amethysts](https://github.com/vitorpamplona/amethyst) Main-Branch baute diese Woche mehrere neue Oberflächen aus. Ein [Git-Repositories-Feed](https://github.com/vitorpamplona/amethyst/pull/3406) macht [NIP-34](/de/topics/nip-34/)-Repos zu einer durchsuchbaren Android-Timeline-Kategorie, filterbar nach Community und Autor, zusammen mit einem [Smart-HTTP-Git-Browser](https://github.com/vitorpamplona/amethyst/pull/3415), der Repository-Inhalte und Commits liest, ohne die App zu verlassen. Der napplet-Host erhielt einen [Discover-Bereich](https://github.com/vitorpamplona/amethyst/pull/3409), der kuratierte Web-Apps sowie gefolgte nSites und napplets aus [NIP-89](/de/topics/nip-89/)-Handler-Events und [NIP-5A](/de/topics/nip-5a/)-Site-Events auflistet. Die Notizanzeige [zeigt nun, welche Nostr-App ein Event verfasst hat](https://github.com/vitorpamplona/amethyst/pull/3422), und nutzt dafür NIP-89-Tags. Auf der Sync-Seite landet [NIP-77-Negentropy-Unterstützung](https://github.com/vitorpamplona/amethyst/pull/3434) mit Streaming-Reconciliation und automatischer `created_at`-Fensterung, um Relay-seitige Ergebnislimits zu umgehen. Das reduziert die Bandbreite, die nötig ist, um große lokale Event-Sets mit einem relay synchron zu halten.
+
+### Buzz v0.3.38 härtet die Relay-Angriffsfläche und ergänzt providerunabhängige Modellauswahl
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) härtet die [Relay-Angriffsfläche](https://github.com/block/buzz/pull/1369), die Buzz beim Veröffentlichen von Personas, Teams, verwalteten Agenten und NIP-OA-Owner-Attestierungen als signierte Nostr-Events exponiert. Ein Buzz-relay ist ein öffentliches Verzeichnis der Nostr-Identitäten eines Teams und ihres Zustands; dieses Release verschärft Eingabevalidierung und Replay-Schutz für die bekannten Event-Kinds, die Buzz definiert. Das Release verallgemeinert außerdem die Modellauswahl, sodass ein Buzz-Team jeden Provider ansprechen kann, für den Buzz Adapter besitzt, darunter ein neues Databricks-AI-Gateway-v2-Backend.
+
+### Notedeck implementiert NIP-37-Private-Sync-relays, NIP-52-Kalender und NIP-22-Kommentare {#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments}
+
+[Notedeck](https://github.com/damus-io/notedeck), der native Rust-Desktop-Client des Damus-Teams, implementierte in einer Woche drei Protokolle. Private-Sync-relays werden nun als Kind-`10013`-[NIP-37](/de/topics/nip-37/)-Liste gespeichert, getrennt vom öffentlichen NIP-65-Outbox-Set des Nutzers. Der Kalenderbereich `horizon` liest [NIP-52](/de/topics/nip-52/)-Events aus nostrdb und erhielt ein neu gestaltetes Dreispalten-Layout. Der Bereich `headway` ergänzte ein [NIP-22](/de/topics/nip-22/)-Kommentar-Event-Modell auf Kind `1111`, dem von NIP-22 definierten Kind für die einheitliche Kommentaroberfläche, die NIP-10-Reply-Threading ersetzt.
+
+
+
+### Applesauce bringt nbunksec-NIP-46-Sessions und ein Cashu-v4-Wallet-Upgrade {#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut}
+
+[Applesauce](https://github.com/hzrd149/applesauce), das modulare Nostr-Toolkit für Signer, relays, Wallets und Inhalte, veröffentlichte ein koordiniertes [6.2.x-Release](https://github.com/hzrd149/applesauce/releases) über seine Subpackages. Das Signers-Package erhielt Helfer zum Import und Export von `nbunksec`, die eine [NIP-46](/de/topics/nip-46/)-Bunker-Session als portables Artefakt behandeln, das zwischen Clients verschoben werden kann. Das Wallet-Package aktualisierte seine [Cashu](/de/topics/nip-60/)-Bindings auf `@cashu/cashu-ts` v4, wo Proof-Beträge zu `Amount`-Value-Objects werden und sich die Token-Decoding-API ändert.
+
+---
+
+## Getaggte Releases
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) bringt die nächste Protokolliteration für das [Mostro](/de/topics/nip-69/)-P2P-Fiat-Handelsnetzwerk. Das Release folgt auf [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) und erscheint zusammen mit [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), das den neuen Core übernimmt. Drei gemergte PRs landeten diese Woche im Core-Repository; der übrige Stack (mostro daemon und Mostro mobile) zielt auf v0.14.0 des gemeinsamen Types-Crates.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), das maßgebliche Git-over-Nostr-CLI für [NIP-34](/de/topics/nip-34/)-Repositories, implementiert die diese Woche gemergte [NIP-34-GRASP-06-Fork-Semantik](https://github.com/nostr-protocol/nips/pull/2395), die auf Repo-State-Events den `personal-fork`-Tag durch einen `u`-Tag ersetzt.
+
+### mesh-llm v0.72.0 und v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), die Inferenzkomponente des ContextVM-Stacks, die Open-Source-LLMs hinter einer über Nostr adressierbaren JSON-RPC-Oberfläche betreibt, veröffentlichte [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) und [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1) mit einer Korrektur für einen Batching-Absturz bei großen Einzel-Prompts und einer Migration der MCP-Bridge weg von veralteten Helfern.
+
+### Meiso v1.4.0 liefert Shared-Key Collaborative Lists, die MLS beim Teilen von Aufgaben ersetzen {#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing}
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) führt ein Modell für Shared-Key Collaborative Lists ein, das das bisherige MLS-basierte Teilen von Aufgaben durch ein einfacheres Design mit adressierbaren Events ersetzt. Jede geteilte Liste erzeugt einen eigenen, an Mitglieder verteilten Nostr-Schlüssel. Aufgaben sind adressierbare Events auf Kind `35000`, mit `d=task-id` gekennzeichnet und mit per [NIP-44](/de/topics/nip-44/) selbstverschlüsseltem Content; relays erzwingen Last-Write-Wins pro Aufgabe. Das Design gibt die Forward Secrecy und Post-Compromise Security von MLS zugunsten einer einfacheren Client-Implementierung und Relay-seitiger Konfliktauflösung auf.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) liefert einen „more-private-coordinator“-Track, der kurzlebige Sender-Pubkeys aus dem Veröffentlichen von Gruppennachrichten entfernt und den Join-Request-Flow gegen veraltete Neuanfragen härtet. Cordn ist der MLS-basierte Messaging-Stack aus dem [Cordn-Ad-hoc-CVM-Launch in #28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); dieses Release ist das passende Update auf Coordinator-Seite.
+
+---
+
+## Unveröffentlichte Änderungen
+
+### diVine bringt mit 108 gemergten PRs Feinschliff nach dem Launch
+
+[diVine](https://github.com/divinevideo/divine-mobile), der Kurzvideo-Looping-Client, der Vine zurückbringt, durchläuft eine intensive Feinschliffphase nach dem Launch. Die Nostr-sichtbare Arbeit dieser Woche ist eine Stabilitätsrunde für den [NIP-46](/de/topics/nip-46/)-Connect-Flow, die Fehler von `nostrconnect://` auf strukturierte Reason Codes migriert.
+
+### Zap Cooking setzt die projektübergreifende NIP-46-Korrektur und die Composer-Überarbeitung fort
+
+[Zap Cooking](https://github.com/zapcooking/frontend) ist ein Nostr-Client zum Teilen von Rezepten, in dem Rezepte als Nostr-Langform-Events veröffentlicht werden. Die Arbeit dieser Woche setzt die projektübergreifende [NIP-46](/de/topics/nip-46/)-Korrektur und Composer-Überarbeitung fort, die in [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes) als unveröffentlicht behandelt wurde.
+
+### Conduit härtet Listing-Ablauf und Marketplace-Korrektheit
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) ist ein Marketplace-Monorepo mit drei Apps auf Nostr: Käufermarkt, Händlerportal und Store-Builder. Die Arbeit dieser Woche setzt den Push für Marketplace-Korrektheit fort, der im [Launch-Bericht von #28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default) behandelt wurde, und baut auf der [NIP-99](/de/topics/nip-99/)-Commerce-Welle auf, die in der vorigen Ausgabe die Protokoll-Story bildete.
+
+### Pollerama v1.12 bis v1.13.1 ergänzen Client-Tag-Auswahl, Profil-Tabs und Thread-Limits
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), ein Android-Nostr-Client mit Schwerpunkt auf Umfragen und Notizen und einer starken Web-of-Trust-Discovery-Schicht, veröffentlichte diese Woche v1.12.0, v1.13.0 und v1.13.1 auf Zapstore. Nutzer können nun wählen, welcher Client-Tag ihren verfassten Notizen und Umfragen angehängt wird, entweder aus einer vorgegebenen Liste oder als eigene Eingabe. Tief verschachtelte Kommentar- und Reply-Ketten enden nun nach wenigen Ebenen und verlinken zum vollständigen Thread auf der Notizseite. Profilseiten öffnen standardmäßig mit Notizen, aufgeteilt in die Tabs Posts und Conversations. Ein Persistenzfehler, durch den neu gefolgte Konten nach einem App-Neustart verschwanden, ist behoben; Follow-Buttons zeigen nun den Fortschritt.
+
+### getwired.app und get-tao.app reparieren den NIP-13-Confess-Submission-Flow
+
+[getwired.app](https://github.com/smolgrrr/Wired) und [get-tao.app](https://github.com/smolgrrr/TAO), die einen gemeinsamen Ablauf für anonyme Posts verwenden und beim Absenden NIP-13-Proof-of-Work gegen Spam einsetzen, reparierten den [Confess-Submission-Flow](https://github.com/smolgrrr/Wired/pull/57), sodass die UX während des PoW-Minings schlüssig ist.
+
+### nostui ergänzt einen Mention-Timeline-Tab
+
+[nostui](https://github.com/akiomik/nostui), ein terminalbasierter Nostr-Client in Rust, ergänzte einen [Mention-Timeline-Tab](https://github.com/akiomik/nostui/pull/463), der Kind-1-Events, die den aktiven Pubkey taggen, als eigene Ansicht in der TUI zeigt.
+
+### Heartwood implementiert NIP-46-Bunker-URIs pro Identität und eine Signing-Bridge im HSM-Modus
+
+[Heartwood](https://github.com/forgesworn/heartwood) ist ein [NIP-46](/de/topics/nip-46/)-Signer, bei dem der Signierschlüssel den Client niemals erreicht: Der Client spricht NIP-46 mit einem kleinen relay, das relay über ein serielles Frame-Protokoll mit einem angeschlossenen Hardwaregerät, das die Signatur ausführt. Diese Woche implementierte das Projekt eine [Relay-zu-Serial-Signing-Bridge](https://github.com/forgesworn/heartwood/pull/11) und [Bunker-Verbindungen pro Identität](https://github.com/forgesworn/heartwood/pull/16), sodass ein einzelnes Hardwaregerät mit mehreren Identitäten für jede davon einen eigenen Bunker-URI exponiert.
+
+### Nostter überarbeitet Auth und Signer
+
+[Nostter](https://github.com/SnowCait/nostter) überarbeitete diese Woche seine [Auth- und Signer-Schicht](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth), verlegte den Login-Zustand auf ein einzelnes Signal und extrahierte den Signer-Dispatch in Strategie-Module. Ziel ist eine klare Signer-Abstraktion, in der NIP-07-Web-Extension, NIP-46-Remote-Bunker und roher nsec denselben Codepfad nutzen.
+
+### Dart NDK extrahiert den NIP-07-Signer und randomisiert NIP-59-Zeitstempel
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) verlagerte seinen [NIP-07](/de/topics/nip-07/)-Signer aus dem Core-Package nach `ndk_flutter`, wo die Flutter-WebView liegt, und [randomisierte seine NIP-59-Gift-Wrap-Zeitstempel](https://github.com/relaystr/dart_ndk/pull/667), um verschlüsselte Nachrichten gegen Timing-Korrelation zu härten.
+
+### Milk Market ergänzt NIP-23-Storefront-Seiten und Square-Zahlungsabwicklung
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), das Marketplace-Storefront des Shopstr-Teams, gab jedem Storefront eine Blog-Seite auf Basis der [NIP-23](/de/topics/nip-23/)-Langform-Events des Verkäufers, mit editierbaren Bereichen und einer direkten Route zu den Blog-Einstellungen. In derselben Woche kamen [Square](https://github.com/shopstr-eng/milk-market/pull/30) als alternative Zahlungsabwicklung für Verkäufer und automatische Versandetiketten-Käufe für bezahlte Bestellungen hinzu.
+
+### Calendar by Formstr veröffentlicht eine iOS-App
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) mergte diese Woche [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159) und brachte damit den [NIP-52](/de/topics/nip-52/)-Kalender-Client auf iOS. [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) korrigiert das Parsen von Kalenderdaten in lokaler Zeit, und [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) ergänzt einen durch ein `run-tests`-Label ausgelösten Playwright-E2E-Workflow.
+
+### cagliostr erzwingt NIP-22, NIP-09 nach Koordinate und NIP-13-Proof-of-Work
+
+[cagliostr](https://github.com/mattn/cagliostr), eine Go-Relay-Implementierung, verschärfte diese Woche drei Enforcement-Pfade: [konfigurierbarer NIP-13-Proof-of-Work](https://github.com/mattn/cagliostr/pull/7) für eingehende Events, [NIP-09-Löschung nach adressierbarer Koordinate](https://github.com/mattn/cagliostr/pull/8), sodass replaceable Events über ihren `a`-Tag gelöscht werden können, was eine Löschung nur nach Event-ID nicht erreicht, sowie [konfigurierbare NIP-22-Zeitstempellimits](https://github.com/mattn/cagliostr/pull/9), die Events ablehnen, deren Zeitstempel zu weit in Vergangenheit oder Zukunft liegt.
+
+---
+
+## Neu erfasst und entdeckt
+
+Die [Vanderwarker-Wellbeing-Suite](https://git.vanderwarker.family/wellbeing) veröffentlicht Telemetrie aus der physischen Welt als Nostr-Events unter einem gemeinsamen Publisher-Signierschlüssel. Sie besteht aus fünf Geschwister-Apps: [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) ist ein Schrittzähler, der Fitnessdaten als `kind:30078` in Nostr verankert; [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) veröffentlicht täglich die Zahl der Smartphone-Entsperrungen; [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) veröffentlicht die aktuelle Medienwiedergabe als User Status; [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) veröffentlicht alle 15 Minuten Akkustand, Spannung und Temperatur; [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) veröffentlicht den täglichen Datenverbrauch. Alle fünf erschienen zwischen dem 24. und 30. Juni auf Zapstore.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) ist eine verschlüsselte serverlose Android-App für Live-Standortfreigabe, in Rust und Slint gebaut und am 29. Juni veröffentlicht. Sie ist ein Geschwister des [Haven](https://github.com/mehmetefeumit/Haven-App)-Standortteilers auf [Marmot](/de/topics/marmot/)-Basis, der in [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot) behandelt wurde, besitzt aber eine andere Transportarchitektur: Verschlüsselte Nostr-DMs tragen die Standort-Updates, während Haven Marmot-Gruppennachrichten nutzt.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) ist ein frühes Application-Shell-Scaffold zum Bau von Nostr-Apps. Das Projekt veröffentlichte diese Woche seine erste nutzerorientierte Dokumentation.
+
+[NIPs by Pollerama](https://nips.pollerama.fun) (Repository [abh3po/better-nips](https://github.com/abh3po/better-nips), erstellt am 2026-06-29) ist ein neuer Client für die von der Community verfassten `kind:30817`-NIPs von [NostrHub](https://nostrhub.io), positioniert als vertrauensgewichtete Alternative zu nostrhub.io. Jedes `kind:30817`-NIP besitzt eine eigene teilbare URL (`#/nip/<naddr>`) mit vollständigem Markdown-Rendering und den von ihm definierten Event-Kinds. Der Client bietet drei Feeds: Following, Web of Trust (Follows-of-Follows) und Global, jeweils sortierbar nach vertrauensgewichteten Freigaben oder Neuheit. Freigaben werden als [NIP-32](/de/topics/nip-32/)-Labels auf Kind `1985` mit den Tags `["L","nostrhub"]` und `["l","approve","nostrhub"]` veröffentlicht, dazu ein `a`-Tag auf die NIP-Zieladresse und ein `client`-Tag für `better-nips`. Das ist exakt die Event-Form, die NostrHub selbst signiert, sodass Freigaben zwischen beiden Clients kompatibel sind. Die Freigabe eines direkt gefolgten Kontos wiegt im Ranking stärker als die eines Follows-of-Follows zweiten Grades.
+
+Der Signing-Stack ist [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer) mit einem vollständigen Login-Modal für [NIP-07](/de/topics/nip-07/), [NIP-46](/de/topics/nip-46/)-Bunker und nostrconnect, [NIP-49](/de/topics/nip-49/)-ncryptsec sowie [NIP-55](/de/topics/nip-55/)-Android-Signer; Sessions verbinden sich beim Neuladen still erneut. Die Netzwerkschicht läuft über [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), einen Web Worker, der die [NIP-65](/de/topics/nip-65/)-Outbox des Nutzers über relays verteilt, damit ein großes Web-of-Trust-Set nicht auf ein einziges relay auffächert. Die Designposition: Community-NIPs sind auf Protokollebene alle gleich, unabhängig davon, ob sie bei NostrHub, in `better-nips` oder bei künftigen Clients gehostet werden. Das Ranking stammt aus dem Social Graph, nicht aus Moderatorenkuration, passend zum NIP-32-Labeling-Flow, den der Deep Dive in [#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling) behandelte.
+
+Zwei neue [NIP-34](/de/topics/nip-34/)-Repo-Cluster erschienen diese Woche. [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) ist ein videofokussierter Nostr-Client, und ein [nostrapps.com-Cluster](wss://gitnostr.com) veröffentlicht drei Geschwisterprojekte: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git), eine napp-VM für den Desktop; [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git), ein anpassbarer Community-Client; und [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git), eine Spezifikation und Runtime für HTML-Microapps. Der Cluster liegt parallel zur [napplet](/de/topics/nip-5d/)-Arbeit aus der Top-Story der vorigen Ausgabe.
+
+---
+
+## Protokollarbeit und NIP-Updates
+
+### Gemergt: NIP-44 hebt das Payload-Limit von 65.535 Byte auf
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907) wurde am 28. Juni gemergt, nachdem er seit 2024-09 offen war. Die Änderung entfernt die Obergrenze von 65.535 Byte für den Plaintext-Payload eines versionierten [NIP-44](/de/topics/nip-44/)-Verschlüsselungs-Envelopes und erhöht sie auf 4 GiB (`uint32_max`). NIP-44 kodiert die Payload-Länge im Wire-Format als `uint16`, was die ursprüngliche Spezifikation strikt für Interoperabilität verlangte; die gemergte Änderung übernimmt ein längeres, im Versionsbyte gekennzeichnetes Längenfeld, sodass v2-Implementierungen wire-kompatibel bleiben und v3+-Implementierungen die größere Länge tragen. Clients, die NIP-44 für [NIP-17](/de/topics/nip-17/)-Direktnachrichten, [NIP-59](/de/topics/nip-59/)-Gift-Wraps, [NIP-46](/de/topics/nip-46/)-Remote-Signer-Payloads oder andere NIP-44-verschlüsselte Nostr-Nachrichten einsetzen, können nun einzelne Events über 64 KiB austauschen, ohne sie auf Anwendungsebene aufzuteilen.
+
+### Gemergt: NIP-86 erhält eine `signevent`-Methode und ein Relay-Roles-Event
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) ergänzt die [NIP-86](/de/topics/nip-86/)-JSON-RPC-API zur Relay-Verwaltung um eine `signevent`-Methode. Ein Administrator kann damit das relay bitten, ein Event mit dem eigenen Pubkey des relays zu signieren. Der begleitende [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) definiert ein Relay-Roles-Event: ein replaceable Event, das ein relay veröffentlicht, um seine Administratoren und Moderatoren zu deklarieren. Zusammen erlauben sie NIP-86-Clients, die Admin-Liste eines relays zu ermitteln und ohne Out-of-band-Vertrauen zu prüfen, ob eine authentifizierte Anfrage von einem aktuellen Admin stammt. Der Deep Dive weiter unten behandelt beide Änderungen.
+
+### Gemergt: NIP-34 ersetzt `personal-fork` durch `u` für GRASP-06
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395) wurde am 24. Juni gemergt und ersetzt auf Repo-State-Events (`kind:30618`) den `personal-fork`-Tag von [NIP-34](/de/topics/nip-34/) durch einen `u`-Tag für „upstream“. Damit entspricht das Wire-Format der GRASP-06-Fork-Semantik, die die GitWorkshop-Suite implementiert. Die Änderung schließt [PR #2384](https://github.com/nostr-protocol/nips/pull/2384) (`NIP-34: remove maintainers to solve expiry issues`), der eine andere Korrektur der Fork-Semantik vorgeschlagen hatte. Die gemergte Richtung wird von ngit v2.6.x implementiert; gemergte Spezifikation und Referenz-CLI stimmen nun überein. Bestehende Repos mit `personal-fork` bleiben interoperabel, neue Repos und die ngit-v2.6-Linie veröffentlichen den `u`-Tag.
+
+### Gemergt: NIP-46-Client-Metadaten, nun upstream, nachdem Amber sie ausgeliefert hat
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381) wurde am 23. Juni gemergt und ergänzt die [NIP-46](/de/topics/nip-46/)-`connect`-Anfrage um optionale Client-Metadaten. Ein Client kann beim Verbinden mit dem Signer seinen Namen, eine Icon-URL und eine Homepage-URL veröffentlichen. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) lieferte die Metadaten-Erweiterung bereits vorige Woche aus, behandelt in [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata); diese Woche zieht das Upstream-NIP mit der ausgelieferten Implementierung gleich.
+
+### Offen: epoch-basierte deterministische NIP-17-Wrapper-Schlüssel
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397) und [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) behandeln zwei konvergierende Vorschläge für NIP-17-Wrap-Schlüssel. PR #2397 schlägt vor, den kurzlebigen Signierschlüssel, der einen [NIP-59](/de/topics/nip-59/)-Gift-Wrap verfasst, deterministisch aus einem an eine grobe Zeitepoche gebundenen Seed pro Conversation abzuleiten. Ein Empfänger, der den Conversation Key kennt, kann dann vorhersagen, welche Pubkeys er abonnieren muss. Die aktuelle Spezifikation verlangt einen neuen zufälligen Schlüssel pro Wrap und macht diese Vorhersage unmöglich. PR #2396 ist die begleitende Änderung: Wraps für eine bestimmte Conversation sollen direkt mit dem Conversation Key signiert werden, sodass der Wrap-Pubkey zugleich als Conversation-Identifier dient. Zusammen definieren sie einen Weg zu filterbaren NIP-17-Conversations ohne Metadatenleckage. Beide sind offen und werden diskutiert.
+
+### Offen: NIP-59 soll Kind-13-Seal-Events am relay ablehnen
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399) schlägt vor, dass relays Kind-13-Events, das innere Seal eines [NIP-59](/de/topics/nip-59/)-Gift-Wraps, ablehnen sollen, wenn sie auf oberster Ebene einer Publish-Anfrage erscheinen. Ein Seal-Event ist nur innerhalb eines Wraps sinnvoll, und ein geleaktes Seal legt den Pubkey des Empfängers offen. Das begleitende [Issue #2398](https://github.com/nostr-protocol/nips/issues/2398) geht weiter und argumentiert, das Seal solle als kurzlebiges Kind neu definiert werden. Kurzlebige Kinds nach NIP-01 werden von relays nicht gespeichert; damit würde die Regel auf Protokollebene gehärtet und nicht mehr von der Policy einzelner relays abhängen.
+
+### Offen: NIP-29-Gruppenzustände
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372) ergänzt [NIP-29](/de/topics/nip-29/) (relay-basierte Gruppen) um explizite Gruppenzustandssemantik. Er definiert, was offene, geschlossene, öffentliche, private oder archivierte Gruppen bedeuten und wie Zustandsübergänge mit Member-Events interagieren. Der Vorschlag überführt bisher Client-spezifische Semantik in die Relay-Spezifikation.
+
+### Offen: optionale Multi-Maintainer-Unterstützung in NIP-34
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324) ist der begleitende Vorschlag zum gemergten [PR #2395](https://github.com/nostr-protocol/nips/pull/2395), dessen GRASP-06-Fork-Semantik oben behandelt wurde. PR #2324 ergänzt die Repo-Announcement-Events (`kind:30617`) von [NIP-34](/de/topics/nip-34/) um optionale Multi-Maintainer-Unterstützung. Ein Repository kann über wiederholte `maintainer`-Tags mehrere maßgebliche Maintainer-Pubkeys deklarieren. Von jedem deklarierten Maintainer signierte Patches und Issues gelten Clients dann als offiziell. Das schließt die langjährige Lücke, durch die NIP-34-Repos mit Co-Maintainern entweder alles über einen Pubkey leiten oder auf Koordination außerhalb des Protokolls ausweichen müssen.
+
+### Offen: NIP-91-AND-Operator für Filter, der Vorschlag ist offen, nicht gemergt
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252) ist der Vorschlag für einen AND-Operator in Nostr-[Filtern](/de/topics/nip-01/) und greift ein Design wieder auf, das erstmals im älteren geschlossenen [PR #1365](https://github.com/nostr-protocol/nips/pull/1365) diskutiert wurde. Implementierungen existieren bereits in [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst) und worker-relay; der Spezifikations-PR selbst bleibt jedoch offen.
+
+### Geschlossen: vier pats2sats-Commerce-NIPs
+
+Vier Commerce-on-Nostr-Vorschläge wurden diese Woche geschlossen: Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), eine [NIP-99](/de/topics/nip-99/)-Marketplace-Listing-Erweiterung ([#2346](https://github.com/nostr-protocol/nips/pull/2346)) und ein Accommodation-Listing-Profil ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). Dieselbe Commerce-Oberfläche wird nun in der [Gamma Market Spec](https://github.com/GammaMarkets/market-spec) konsolidiert, einem projekteigenen Extension-Repository, das auf NIP-99-Marketplace-Listings mit Bestellungen, Checkout, Escrow und Streitbeilegungssemantik aufbaut. Compass verfolgt dieses Repository nun neben Marmot und Blossom als Protokoll-Spec-Repo außerhalb des NIPs-Repository. Offene PRs dort umfassen diese Woche eine Klarstellung zur Client-Attribution ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), einen Supersedes-Tag für Änderungen der Produktidentität ([#8](https://github.com/GammaMarkets/market-spec/pull/8)) und Semantik für Händlerbewertungen ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Offen: Verknüpfung von Bitcoin-Identitäten
+
+Zwei Vorschläge zum Verknüpfen von Bitcoin- mit Nostr-Identitäten wurden diese Woche eröffnet: eine [NIP-352-Bitcoin-Silent-Payment-Adresse](https://github.com/nostr-protocol/nips/pull/2392) und ein [Bitcoin-OTC-Identity-Linkage-Proof](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## NIP Deep Dive: NIP-86 (Relay-Verwaltungs-API) {#nip-deep-dive-nip-86-relay-management-api}
+
+[NIP-86](/de/topics/nip-86/) definiert eine JSON-RPC-Schnittstelle zur Relay-Verwaltung, über die autorisierte Clients administrative Befehle über eine standardisierte API an relays senden können. Ein einzelner Client kann jedes NIP-86-kompatible relay ohne Relay-spezifische Werkzeuge verwalten. Zwei Spezifikations-Merges dieser Woche ([PR #2389](https://github.com/nostr-protocol/nips/pull/2389) und [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)) schließen den Kreis zwischen Relay-signierten Events und den von einem relay deklarierten Administratoren.
+
+### Der Transport
+
+Eine NIP-86-Verwaltungsanfrage ist ein HTTP POST an denselben URI, über den das relay WebSocket-Verbindungen bereitstellt, mit `Content-Type: application/nostr+json+rpc`. Der Request-Body ist ein JSON-Dokument der folgenden Form:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+Die Authentifizierung verwendet ein signiertes [NIP-98](/de/topics/nip-98/)-HTTP-Auth-Event im `Authorization`-Header. Das relay prüft vor dem Ausführen der Methode, ob der signierende Pubkey auf seiner Administratorliste steht. Die Antwort des relays ist ein JSON-Dokument der folgenden Form:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### Die bereits vor dieser Woche vorhandenen Methoden
+
+Die bestehende Methodenmenge umfasst Pubkey-Bans (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), Event-Bans (`banevent`, `allowevent`, `listbannedevents`), Relay-Metadaten (`changerelayname`, `changerelaydescription`, `changerelayicon`), die Verwaltung der Allowed-Pubkey-Liste (`allowkind`, `disallowkind`, `listallowedkinds`) und eine `stats`-Methode, die Relay-Statistiken zurückgibt. Die Form ist bewusst nah an einem standardmäßigen JSON-RPC-Service, sodass ein Client typisierte Bindings darüberlegen kann.
+
+### Was sich diese Woche geändert hat
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) ergänzt die Spezifikation um eine `signevent`-Methode. Sie übernimmt ein partielles Event-Template (Kind, Tags, Content) als Argument und bittet das relay, ein vollständiges Event mit dem eigenen Pubkey des relays im Feld `pubkey` zu signieren und zurückzugeben. Das ist die Voraussetzung dafür, dass ein relay Protokoll-Events über sich selbst veröffentlichen kann: Ankündigungen gesperrter Pubkeys, Relay-Metadaten und das neue Relay-Roles-Event weiter unten müssen alle mit dem vom Operator kontrollierten Schlüssel des relays signiert werden. Die meisten Relay-Operatoren wollen einen privaten Schlüssel jedoch nicht in ihrem administrativen Client halten.
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390) definiert ein Relay-Roles-Event: ein parameterized replaceable Event-Kind, das ein relay veröffentlicht, mit dem eigenen Pubkey über `signevent` signiert, um die Pubkeys seiner Administratoren und Moderatoren mit expliziter Rollensemantik zu deklarieren. Ein NIP-86-fähiger Client kann das Relay-Roles-Event von jedem erfassten relay abrufen, die Admin-Liste aus den Event-Tags erstellen und ohne Out-of-band-Vertrauen oder Relay-spezifische Konfiguration prüfen, ob eine authentifizierte NIP-86-Anfrage von einem aktuellen Admin stammt. Zusammen schließen die beiden PRs den Kreis: `signevent` ist der Mechanismus, Relay Roles das erste darauf aufbauende Event-Kind.
+
+### Beispiel einer NIP-86-Anfrage
+
+Eine vollständige NIP-86-`banpubkey`-Anfrage sieht so aus:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+mit einem `Authorization`-Header, der ein signiertes NIP-98-Event trägt:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+Der signierende Pubkey muss in der Admin-Menge des relays enthalten sein, die nun im Relay-Roles-Event deklariert wird. Der `u`-Tag muss mit der HTTPS-URL des relays übereinstimmen; der `payload`-Tag muss dem SHA-256 des JSON-Request-Bodys entsprechen. Das relay gibt zurück:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementierungen
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) liefert eine NIP-86-Oberfläche zur Relay-Verwaltung auf Android (v1.07.0+).
+- Zu den Referenz-relays, die die Spezifikation implementieren, gehören [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru) und mehrere kleinere Implementierungen, auf die die Spezifikation im Abschnitt `Implementation Status` verweist.
+
+NIP-86-fähige Clients werden das Relay-Roles-Event als maßgebliche Quelle für die Admin-Liste eines relays behandeln, sobald Implementierer die Änderungen an `signevent` und Relay Roles übernehmen.
+
+---
+
+## NIP Deep Dive: NIP-89 (Empfohlene Application Handler) {#nip-deep-dive-nip-89-recommended-application-handlers}
+
+[NIP-89](/de/topics/nip-89/) definiert zwei parameterized replaceable Event-Kinds: `kind:31990`, den von einem App-Entwickler veröffentlichten Application Handler, und `kind:31989`, die Empfehlung eines Nutzers für eine verwendete App. Zusammen ermöglichen sie Clients, Anwendungen für ein unbekanntes Event-Kind ohne Out-of-band-Koordination zu finden. Ein Langform-Reader, der auf ein `kind:30030`-Event trifft, das er nicht nativ behandelt, kann den NIP-89-Graph nach Handlern abfragen und dem Nutzer einen „Öffnen in ...“-Ablauf zu einer veröffentlichten App anbieten. NIP-89 ist die ursprüngliche Infrastruktur für dasselbe Cross-App-Routing-Problem, das die in dieser Ausgabe auftauchende napplet-/napps-Arbeit nun auf zusammensetzbare Nostr-native Applets erweitert.
+
+### Das Application-Handler-Event (`kind:31990`)
+
+Ein App-Entwickler veröffentlicht ein oder mehrere Handler-Events, die beschreiben, welche Event-Kinds die App unterstützt und wie eine Nostr-Entität in der App geöffnet wird:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+Der `d`-Tag identifiziert den Handler, sodass er ersetzt werden kann. Jeder `k`-Tag deklariert ein Event-Kind, das die App verarbeitet, und jeder Plattform-Tag (`web`, `ios`, `android`, ...) liefert ein URL-Template mit `<bech32>` als Platzhalter für eine [NIP-19](/de/topics/nip-19/)-kodierte Entität, die der aufrufende Client beim Öffnen einsetzt. Ein Handler-Event kann mehrere unterstützte Kinds bewerben, wenn sie dasselbe Routing-Muster teilen. Das hält App-Discovery kompakt und vermeidet ein Handler-Event pro Kind.
+
+### Das Empfehlungsevent des Nutzers (`kind:31989`)
+
+Ein Nutzer veröffentlicht eine Empfehlung, die angibt, welche Apps er für ein bestimmtes Event-Kind verwendet:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+Der `d`-Tag trägt das empfohlene Event-Kind. Jeder `a`-Tag ist ein NIP-01-Adresszeiger auf ein `kind:31990`-Handler-Event, zusammen mit dem vorgeschlagenen relay und der Plattform, für die die Empfehlung gilt. Dieselbe Empfehlung kann mehrere Apps für verschiedene Plattformen auflisten.
+
+### Der Client-Tag und der Datenschutz-Tradeoff
+
+NIP-89 definiert außerdem einen optionalen `client`-Tag, den jede veröffentlichende App an von ihr verfasste Events anhängen kann:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Damit kann jeder Client, der das Event anzeigt, die Herkunfts-App nennen, reichhaltigere Handler-Metadaten abrufen und vom Handler deklarierte Rendering-Hinweise beachten. Die Spezifikation weist ausdrücklich auch auf die Datenschutzkosten hin: Ein Client, der jedem Event einen `client`-Tag mitgibt, veröffentlicht die Softwareidentität des Nutzers und legt mit der Zeit Nutzungsmuster offen. Die Spezifikation empfiehlt Clients, Nutzern einen Opt-out anzubieten.
+
+Amethysts [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) parst und zeigt NIP-89-`t`-, `i`-, `a`- und `client`-Tags in der Event-Anzeige und macht direkt in der Timeline sichtbar, welche App eine Notiz verfasst hat.
+
+### So läuft der Discovery-Flow in der Praxis
+
+Ein Client, der ein unbekanntes Event-Kind empfängt, geht wie folgt vor. (1) Er fragt im Follow-Graph des Nutzers nach `kind:31989`-Events mit einem `d`-Tag, der dem Event-Kind entspricht. (2) Er löst jeden empfohlenen `a`-Tag zum zugehörigen `kind:31990`-Handler-Event auf. (3) Er wählt den Handler, dessen `web`-, `ios`- oder `android`-URL-Template zur aktuellen Plattform passt. (4) Er setzt die `bech32`-Kodierung der Entität in das URL-Template ein. (5) Er bietet dem Nutzer die resultierende URL als „Öffnen in ...“-Option an. Der Ablauf ist sozial gefiltert: Fragt ein Client beliebige Handler-Events von nicht vertrauenswürdigen relays ab, könnte er Nutzer zu schädlichen Apps umleiten. Bei Personen zu beginnen, denen der Nutzer folgt, ist daher ein sichererer Standard, als jeden veröffentlichten Handler als gleich vertrauenswürdig zu behandeln.
+
+### NIP-89 und die napplet-Schicht
+
+Amethysts Discover-Bereich, die napplet-Host-Runtime und die Anzeige von `client`-Tags bilden zusammen eine vollständige NIP-89-Consumer-Oberfläche auf Android. Die in der vorigen Ausgabe gestartete napplet-Spezifikation erweitert die Ziele dieser NIP-89-Handler-Events: sandboxed Applets, die eine zusammensetzbare Nostr-native Runtime über Nostr und Blossom ausführen. NIP-89 ist der Discovery- und Routing-Graph; die napplet-Runtime ist ein Ausführungsziel, auf das er zeigen kann.
+
+---
+
+*Feedback, Korrekturen und übersehene Projekte: Eröffnet ein Issue auf [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) oder erreicht uns per NIP-17-DM unter npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/es/newsletters/2026-07-01-newsletter.md
+++ b/content/es/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,372 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-08-27
+draft: false
+type: newsletters
+---
+
+Bienvenidos de nuevo a Nostr Compass, vuestra guía semanal de Nostr.
+
+**Esta semana:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) incorpora transporte mediante la mixnet de Nym, descubrimiento mDNS opcional en la LAN, cambio de claves sin interrupciones pese a pérdidas y una renovación del plano de datos, todo compatible a nivel de wire con v0.3.0. [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) aparece como cliente Marmot de escritorio en Rust y Slint, con una propuesta de protocolo para trasladar los efectos de mensaje a un event kind 9 específico. [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) se lanza como bóveda de identidad móvil respaldada por hardware que actúa como firmante remoto NIP-46 y responde por NFC a desafíos de acceso físico. [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) estrena el intercambio entre pares de nsites sobre la malla FIPS, con un nuevo transporte BLE L2CAP en v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) se lanza como superficie de control para Android de un asistente de programación Codex local mediante DMs cifrados de Nostr. [La línea aún no publicada de Amethyst](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) añade análisis de handlers de aplicaciones NIP-89, un feed de repositorios Git para NIP-34 y una sección Discover para nSites y napplets. [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) incorpora NIP-37, NIP-52 y NIP-22 en una semana. [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) publica 12 versiones coordinadas de subpaquetes con helpers nbunksec para NIP-46 y una actualización de cartera a Cashu-ts v4. [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) incorpora listas colaborativas con clave compartida sobre el kind 35000 direccionable. El repositorio de NIPs fusionó cinco PRs, incluidos un event de roles de relay, la eliminación del límite de 65.535 bytes de NIP-44, la semántica de forks de NIP-34, los metadatos de cliente NIP-46 y un método `signevent` de NIP-86. Los análisis detallados abordan [NIP-86 (API de gestión de relays)](#nip-deep-dive-nip-86-relay-management-api) y [NIP-89 (handlers de aplicaciones recomendados)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Historias principales
+
+### FIPS v0.4.0 incorpora transporte por la mixnet de Nym, descubrimiento mDNS y una renovación del plano de datos
+
+[FIPS](https://github.com/jmcorgan/fips) es una red en malla privada, autoorganizada y entre pares para Nostr, donde los nodos se descubren y enrutan tráfico sin infraestructura central. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) incorpora transporte mediante la mixnet de Nym, descubrimiento mDNS opcional en la LAN, una renovación del plano de datos, cambio de claves sin interrupciones pese a la pérdida de paquetes, una TUI `fipstop` reescrita sobre un harness de snapshots de renderizado, un plano de observabilidad fuera de la ruta crítica, y nuevos objetivos de empaquetado apk para OpenWrt y flake para Nix. Todo mantiene compatibilidad a nivel de wire con v0.3.0, de modo que las mallas mixtas interoperan durante una actualización gradual. Dos nuevos transportes para el descubrimiento de peers vertebran la versión. Un nuevo [transporte saliente por la mixnet de Nym](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) enruta el tráfico FIPS mediante un proxy SOCKS5 `nym-socks5-client` y lo mezcla en la red de tráfico de cobertura de [Nym](https://nymtech.net/), para impedir que observadores de nivel de enlace correlacionen qué peers de la malla se comunican. Un directorio `examples/sidecar-nostr-mixnet-relay/` demuestra un relay Nostr accesible mediante un enlace FIPS conectado de extremo a extremo a través de la mixnet. El descubrimiento mDNS / DNS-SD opcional en la LAN permite que los nodos del mismo enlace local se encuentren sin configurar direcciones ni usar STUN; anuncian y adoptan peers mediante un registro de servicio estándar cuando `node.discovery.lan.enabled: true`.
+
+El plano de datos se rediseñó para aumentar el rendimiento de un solo nodo. El cifrado y descifrado de cada peer se ejecutan ahora en tareas worker específicas fuera del bucle de recepción, por lo que un peer ocupado no puede serializar la criptografía de todo el nodo. La ruta de envío de Linux usa generic segmentation offload y un socket UDP conectado cuando están disponibles; la ruta crítica de recepción evita las copias de buffer que antes hacía por paquete; y macOS incorpora recepción por lotes con `recvmsg_x`, equivalente al procesamiento por lotes con `recvmmsg` de Linux introducido en v0.3.0. Toda la superficie de lectura `show_*` de `fipsctl` y `fipstop` sirve ahora desde un snapshot por tick, publicado en un `ArcSwap` sin locks desde la tarea de aceptación de control, así que las consultas de operadores responden con rapidez aunque el bucle de recepción del nodo esté ocupado. Una nueva consulta `show_metrics` limitada a contadores, expuesta como `fipsctl stats metrics`, permite que Prometheus recopile métricas sin coste en la ruta crítica.
+
+El cambio de claves de sesión FMP y FSP ya no causa interrupciones ante pérdida y reordenación de paquetes en ninguna dirección: los frames entrantes se autentican contra la sesión pendiente antes de que el cambio marcado por el bit K la promueva, de modo que un frame obsoleto o falsificado no puede desbaratar el cambio; la retransmisión del mensaje 1 de rekey queda acotada; el heartbeat que detecta enlaces caídos tiene en cuenta el rekey; y las carreras por iniciación simultánea en enlaces de alta latencia se desincronizan mediante jitter simétrico. La TUI `fipstop` se reconstruyó sobre un harness de snapshots de renderizado que compara la cuadrícula de texto exacta y el estilo de cada celda de todas las vistas con salidas preparadas del socket de control. También llegan nuevos objetivos de empaquetado: un `.apk` de OpenWrt para OpenWrt 25+ —compilado sin SDK, reutilizando la compilación cruzada `.ipk` existente y el payload del sistema de archivos instalado— y un `flake.nix` en la raíz del proyecto que compila desde el código fuente los cuatro binarios (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) en Nix/NixOS con el toolchain fijado.
+
+### Whitenoise Linux aparece como cliente Marmot de escritorio
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) es un cliente [Marmot](/es/topics/marmot/) de escritorio: mensajería de grupos MLS sobre relays Nostr, empaquetada como un único binario Rust con una interfaz Slint que guarda todos los secretos en una bóveda cifrada con contraseña.
+
+El hilo más relevante de esta semana propone transportar los efectos de mensaje de Whitenoise como un event kind 9 específico que referencia el mensaje padre. El formato de wire actual añade al final del cuerpo del mensaje un marcador como `dmfx:sparkle`, lo que contamina el texto para cualquier renderer que desconozca la convención. Trasladar los efectos a su propio event mantiene limpio el texto del mensaje y abre una cuestión de diseño que afrontará toda la pila Marmot: convenciones dentro del cuerpo o events sidecar para funciones enriquecidas opcionales.
+
+### CustID se lanza como bóveda de identidad móvil con NIP-46 y un flujo de desafíos NFC
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) es la primera beta pública de CustID, una bóveda de identidad móvil construida sobre Nostr y el protocolo SISTR. CustID almacena varias identidades Nostr en almacenamiento seguro respaldado por hardware, actúa como firmante remoto [NIP-46](/es/topics/nip-46/) para otros clientes y responde a desafíos de acceso físico y en línea mediante NFC y códigos QR.
+
+La beta ofrece todas las funciones previstas para el firmante NIP-46 y el flujo de desafío-respuesta NFC; los flujos de acceso con pruebas de conocimiento cero quedan como objetivo futuro. Esta versión también elimina la capa keep-alive [NIP-65](/es/topics/nip-65/) en segundo plano de la app, que abría un WebSocket por perfil y por relay de lectura e ingería kinds que el cliente descartaba inmediatamente. Ahora solo se mantienen activos en segundo plano los sockets NIP-46 que transportan notificaciones de solicitudes de firma, la corrección que hace viable ejecutar CustID como bunker para otros clientes en un teléfono.
+
+### myco se lanza para compartir nsites entre pares sobre la malla FIPS
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) abrió esta semana, el 27 de junio, y alcanzó v0.1.0 el 1 de julio. myco es una app Android en Rust que instala aplicaciones de personas cercanas: intercambio entre pares de [nsites](/es/topics/nip-5a/) sobre una malla FIPS, mediante cualquier transporte que admita la malla (UDP, TCP, Tor, Bluetooth) y con funcionamiento totalmente offline. El diseño empareja directamente FIPS como sustrato de transporte con el formato de events de sitios web estáticos de NIP-5A como payload, lo que permite que una app distribuida como nsite pase entre peers de la malla sin depender de relays ni HTTP.
+
+v0.1.0 añade una ruta de radio Bluetooth L2CAP para que dos teléfonos con FIPS instalado puedan conectarse como peers por BLE sin ninguna red, además de una prueba de velocidad por peer y el intercambio activado por NFC desde el bottom sheet Circle de la app. myco también está publicada en Zapstore para su instalación directa.
+
+### Nostr Codex Phone se lanza como superficie de control móvil de un worker Codex local mediante Nostr
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) se lanza esta semana como cliente Android que controla un worker local del asistente de programación Codex mediante mensajes directos cifrados de Nostr. La app admite varias sesiones de repositorios, transcripción de voz, sesiones enrutadas de workers, subidas de medios a Blossom y respuestas habladas opcionales, de modo que un desarrollador que ejecute un worker Codex en casa pueda enviar solicitudes desde el teléfono allí donde este tenga acceso a relays.
+
+El proyecto es hermano directo de [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), lanzado en el número 28. Ambos llevan los flujos de programación agéntica al transporte de Nostr mediante DMs cifrados, y ambos tratan Nostr como la capa de emparejamiento y mensajería que permite a un teléfono acceder a un worker doméstico sin abrir agujeros en la red. Nostr como plano de control para agentes locales se está convirtiendo en un patrón consolidado.
+
+### Coop Mobile publica sus primeras builds versionadas
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) y [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) llegaron esta semana como las primeras builds versionadas de Coop Mobile, un cliente Android de mensajes directos cifrados [NIP-17](/es/topics/nip-17/). Las dos versiones refuerzan la resistencia a fallos al analizar mensajes y manejar códigos QR, y borran todos los datos almacenados al cerrar sesión.
+
+### Amethyst desarrolla una interfaz compatible con NIP-89, un feed de repositorios Git y una sección Discover de napplets
+
+La rama principal de [Amethyst](https://github.com/vitorpamplona/amethyst) incorporó varias superficies nuevas esta semana. Un [feed de repositorios Git](https://github.com/vitorpamplona/amethyst/pull/3406) convierte los repos [NIP-34](/es/topics/nip-34/) en una categoría navegable del timeline de Android, filtrable por comunidad y autor, junto con un [navegador git smart-HTTP](https://github.com/vitorpamplona/amethyst/pull/3415) que lee el contenido y los commits del repo sin salir de la app. El host de napplets recibió una [sección Discover](https://github.com/vitorpamplona/amethyst/pull/3409) que enumera aplicaciones web seleccionadas, además de nSites y napplets seguidos, a partir de events de handlers [NIP-89](/es/topics/nip-89/) y events de sitios [NIP-5A](/es/topics/nip-5a/). La visualización de notas ahora [revela qué app Nostr creó un event](https://github.com/vitorpamplona/amethyst/pull/3422) mediante tags NIP-89. En sincronización, llega la [compatibilidad con negentropy NIP-77](https://github.com/vitorpamplona/amethyst/pull/3434), con reconciliación en streaming y ventanas automáticas de `created_at` para sortear los límites de resultados de los relays, reduciendo el ancho de banda necesario para mantener sincronizados grandes conjuntos locales de events con un relay.
+
+### Buzz v0.3.38 refuerza la superficie de ataque del relay y añade selección de modelos independiente del proveedor
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) refuerza la [superficie de ataque del relay](https://github.com/block/buzz/pull/1369) que Buzz expone al publicar personas, equipos, agentes gestionados y declaraciones de propietario NIP-OA como events Nostr firmados. Un relay de Buzz es un registro público de las identidades Nostr del equipo y de su estado; esta versión endurece la validación de entradas y la protección contra replay en los kinds conocidos que define Buzz. También generaliza la selección de modelos para que un equipo de Buzz pueda usar cualquier proveedor para el que Buzz disponga de adaptadores, incluido un nuevo backend Databricks AI Gateway v2.
+
+### Notedeck implementa relays de sincronización privada NIP-37, calendario NIP-52 y comentarios NIP-22
+
+[Notedeck](https://github.com/damus-io/notedeck), el cliente de escritorio nativo en Rust del equipo de Damus, incorporó tres implementaciones de protocolo en una semana. Los relays de sincronización privada ahora persisten como una lista [NIP-37](/es/topics/nip-37/) de kind `10013`, que separa el conjunto de relays de contenido privado del usuario de su outbox público NIP-65. El panel de calendario `horizon` lee events [NIP-52](/es/topics/nip-52/) desde nostrdb y recibió un rediseño de tres paneles. El panel `headway` añadió un modelo de event de comentarios [NIP-22](/es/topics/nip-22/) en el kind `1111`, el kind que NIP-22 define para la superficie unificada de comentarios que sustituye el encadenado de respuestas NIP-10.
+
+
+
+### Applesauce incorpora sesiones NIP-46 nbunksec y actualiza la cartera a Cashu v4
+
+[Applesauce](https://github.com/hzrd149/applesauce), el toolkit modular de Nostr para firmantes, relays, carteras y contenido, publicó una [versión coordinada 6.2.x](https://github.com/hzrd149/applesauce/releases) de sus subpaquetes. El paquete de firmantes obtuvo helpers para importar y exportar `nbunksec`, tratando una sesión bunker [NIP-46](/es/topics/nip-46/) como artefacto portable que puede trasladarse entre clientes. El paquete de cartera actualizó sus bindings de [Cashu](/es/topics/nip-60/) a `@cashu/cashu-ts` v4, donde los importes de proofs pasan a ser objetos de valor `Amount` y cambia la API de decodificación de tokens.
+
+---
+
+## Versiones etiquetadas
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) incorpora la siguiente iteración del protocolo de la red de intercambio P2P de dinero fiat [Mostro](/es/topics/nip-69/). La versión sucede a [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) y llega junto con [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), que adopta el nuevo core. Tres PRs fusionados llegaron al repositorio core esta semana; el resto de la pila —el daemon mostro y Mostro mobile— sigue la versión v0.14.0 del crate de tipos compartidos.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), la CLI canónica de git sobre Nostr para repositorios [NIP-34](/es/topics/nip-34/), implementa la [semántica de forks GRASP-06 de NIP-34](https://github.com/nostr-protocol/nips/pull/2395) fusionada esta semana, que sustituye el tag `personal-fork` por un tag `u` en los events de estado del repo.
+
+### mesh-llm v0.72.0 y v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), el componente de inferencia de la pila ContextVM que ejecuta LLMs de código abierto tras una superficie JSON-RPC direccionable por Nostr, publicó [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) y [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1), con una corrección para un fallo del procesamiento por lotes ante prompts individuales grandes y la migración del puente MCP para abandonar helpers obsoletos.
+
+### Meiso v1.4.0 incorpora listas colaborativas con clave compartida que sustituyen MLS para compartir tareas
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) introduce un modelo de listas colaborativas con clave compartida que sustituye el anterior intercambio de tareas basado en MLS por un diseño más sencillo de events direccionables. Cada lista compartida genera una clave Nostr específica que se distribuye a sus miembros; las tareas son events direccionables de kind `35000`, identificados por `d=task-id` y con contenido autocifrado mediante [NIP-44](/es/topics/nip-44/); y los relays aplican Last-Write-Wins por tarea. El diseño renuncia al forward secrecy y a la seguridad posterior al compromiso de MLS a cambio de una implementación de cliente más sencilla y resolución de conflictos a nivel de relay.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) incorpora una línea «more-private-coordinator» que elimina las pubkeys efímeras de remitentes al publicar mensajes de grupo y refuerza el flujo de solicitudes de ingreso frente a nuevas solicitudes obsoletas. Cordn es la pila de mensajería basada en MLS tratada en el [lanzamiento del CVM ad hoc de Cordn del número 28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); esta versión es la actualización correspondiente del lado del coordinador.
+
+---
+
+## Cambios aún no publicados
+
+### diVine impulsa 108 PRs fusionados de pulido posterior al lanzamiento
+
+[diVine](https://github.com/divinevideo/divine-mobile), el cliente de vídeos breves en bucle que recupera Vine, atraviesa una intensa etapa de pulido posterior al lanzamiento. El trabajo visible para Nostr esta semana es una ronda de estabilidad del flujo de conexión [NIP-46](/es/topics/nip-46/) que traslada los fallos de `nostrconnect://` a códigos de motivo estructurados.
+
+### Zap Cooking continúa la corrección transversal de NIP-46 y la renovación del compositor
+
+[Zap Cooking](https://github.com/zapcooking/frontend) es un cliente para compartir recetas en Nostr, donde las recetas se publican como events Nostr de formato largo. El trabajo de esta semana continúa la corrección transversal de [NIP-46](/es/topics/nip-46/) y la renovación del compositor tratadas como trabajo aún no publicado en el [número 28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes).
+
+### Conduit refuerza el flujo de anuncios y la corrección del marketplace
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) es un monorepo de marketplace con tres aplicaciones sobre Nostr: mercado de compradores, portal de comerciantes y creador de tiendas. El trabajo de esta semana continúa el impulso a la corrección del marketplace tratado en la [cobertura del lanzamiento del número 28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default), sobre la [oleada comercial de NIP-99](/es/topics/nip-99/) que protagonizó la vertiente de protocolo del número anterior.
+
+### Pollerama v1.12 a v1.13.1 añaden selección del client tag, pestañas de perfil y límites a los hilos
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), un cliente Nostr para Android centrado en encuestas y notas con una potente capa de descubrimiento basada en la web of trust, publicó v1.12.0, v1.13.0 y v1.13.1 en Zapstore esta semana. Los usuarios ya pueden elegir qué client tag se adjunta a las notas y encuestas que crean, ya sea de una lista predeterminada o introduciendo uno propio. Las cadenas de comentarios y respuestas muy anidadas se detienen ahora tras varios niveles y enlazan al hilo completo en la página de la nota. Las páginas de perfil abren de forma predeterminada en Notes, divididas en una pestaña Posts y otra Conversations. Se corrigió un fallo de persistencia de follows por el que las cuentas recién seguidas desaparecían al reiniciar la app, y los botones para seguir ahora muestran el progreso.
+
+### getwired.app y get-tao.app corrigen el flujo de envío confess de NIP-13
+
+[getwired.app](https://github.com/smolgrrr/Wired) y [get-tao.app](https://github.com/smolgrrr/TAO), que comparten un flujo de publicación anónima que añade proof-of-work NIP-13 para frenar el spam en el momento del envío, corrigieron el [flujo de envío confess](https://github.com/smolgrrr/Wired/pull/57) para que la UX durante el minado de PoW sea coherente.
+
+### nostui añade una pestaña de timeline de menciones
+
+[nostui](https://github.com/akiomik/nostui), un cliente Nostr de terminal en Rust, añadió una [pestaña de timeline de menciones](https://github.com/akiomik/nostui/pull/463) que presenta en una vista específica de la TUI los events de kind 1 que incluyen un tag con la pubkey activa.
+
+### Heartwood incorpora URIs bunker NIP-46 por identidad y un puente de firma en modo HSM
+
+[Heartwood](https://github.com/forgesworn/heartwood) es un firmante [NIP-46](/es/topics/nip-46/) en el que la clave de firma nunca llega al cliente: este se comunica mediante NIP-46 con un pequeño relay, y el relay usa un protocolo de frames serie para comunicarse con un dispositivo de hardware conectado que realiza la firma. Esta semana el proyecto incorporó un [puente de firma entre relay y puerto serie](https://github.com/forgesworn/heartwood/pull/11) y [conexiones bunker por identidad](https://github.com/forgesworn/heartwood/pull/16), de modo que un solo dispositivo de hardware con varias identidades expone una URI bunker distinta para cada una.
+
+### Refactorización de autenticación y firmantes de Nostter
+
+[Nostter](https://github.com/SnowCait/nostter) rediseñó esta semana su [capa de autenticación y firmantes](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth), trasladando el estado de sesión a una única signal y extrayendo el despacho de firmantes a módulos de estrategia. La dirección es una abstracción limpia de firmantes donde la extensión web NIP-07, el bunker remoto NIP-46 y el nsec sin procesar comparten una sola ruta de código.
+
+### Dart NDK extrae el firmante NIP-07 y aleatoriza las marcas de tiempo NIP-59
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) trasladó su firmante [NIP-07](/es/topics/nip-07/) fuera del paquete core y a `ndk_flutter` —donde reside el WebView de Flutter—, y [aleatorizó las marcas de tiempo de sus gift wraps NIP-59](https://github.com/relaystr/dart_ndk/pull/667) para reforzar la protección de los mensajes cifrados frente a la correlación temporal.
+
+### Milk Market añade páginas de tienda NIP-23 y procesamiento de pagos con Square
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), el escaparate de marketplace del equipo de Shopstr, añadió a cada tienda una página de blog respaldada por los events de formato largo [NIP-23](/es/topics/nip-23/) del vendedor, con secciones editables y una ruta directa a la configuración del blog. Esa misma semana incorporó [Square](https://github.com/shopstr-eng/milk-market/pull/30) como procesador de pagos alternativo para vendedores y la compra automática de etiquetas de envío para pedidos pagados.
+
+### Calendar by Formstr publica una app para iOS
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) fusionó esta semana el [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159), llevando a iOS el cliente de calendario [NIP-52](/es/topics/nip-52/). El [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) corrige el análisis de fechas de calendario en hora local, y el [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) añade un flujo E2E de Playwright activado mediante una etiqueta `run-tests`.
+
+### cagliostr aplica NIP-22, NIP-09 por coordenada y proof-of-work NIP-13
+
+[cagliostr](https://github.com/mattn/cagliostr), una implementación de relay en Go, reforzó esta semana tres rutas de aplicación de reglas: [proof-of-work NIP-13 configurable](https://github.com/mattn/cagliostr/pull/7) para events entrantes, [eliminación NIP-09 por coordenada direccionable](https://github.com/mattn/cagliostr/pull/8) para que los events reemplazables puedan eliminarse mediante su tag `a` —algo inaccesible solo con la eliminación por id del event—, y [límites configurables de timestamp NIP-22](https://github.com/mattn/cagliostr/pull/9) que rechazan events fechados demasiado lejos en el pasado o el futuro.
+
+---
+
+## Proyectos recién rastreados y descubiertos
+
+La [suite de bienestar Vanderwarker](https://git.vanderwarker.family/wellbeing) publica telemetría del mundo físico como events Nostr bajo una clave de firma compartida del publicador. Consta de cinco apps hermanas: [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) es un contador de pasos que ancla datos de actividad física en Nostr como `kind:30078`; [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) publica un contador diario de desbloqueos del teléfono; [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) publica la reproducción multimedia actual como User Status; [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) publica el nivel, voltaje y temperatura de la batería cada 15 minutos; y [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) publica el uso diario de datos. Las cinco aparecieron en Zapstore entre el 24 y el 30 de junio.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) es una app Android serverless para compartir ubicación en directo de forma cifrada, construida en Rust y Slint y publicada el 29 de junio. Es hermana de [Haven](https://github.com/mehmetefeumit/Haven-App), la app para compartir ubicaciones basada en [Marmot](/es/topics/marmot/) tratada en el [número 28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), pero usa una arquitectura de transporte distinta: DMs cifrados de Nostr transportan las actualizaciones de ubicación, mientras Haven emplea mensajes de grupo Marmot.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) es un scaffold incipiente de shell de aplicaciones para construir apps Nostr. El proyecto publicó esta semana su primera documentación dirigida a usuarios.
+
+[NIPs by Pollerama](https://nips.pollerama.fun) —repositorio [abh3po/better-nips](https://github.com/abh3po/better-nips), creado el 2026-06-29— es un nuevo cliente para los NIPs `kind:30817` creados por la comunidad de [NostrHub](https://nostrhub.io), presentado como una superficie alternativa a nostrhub.io ponderada por confianza. Cada NIP `kind:30817` tiene su propia URL compartible (`#/nip/<naddr>`), con renderizado Markdown completo y los event kinds que define. El cliente ofrece tres feeds: Following, Web of Trust —follows de follows— y Global, cada uno ordenable por aprobaciones ponderadas por confianza o por novedad. Las aprobaciones se publican como labels [NIP-32](/es/topics/nip-32/) en el kind `1985`, con tags `["L","nostrhub"]` y `["l","approve","nostrhub"]`, además de un tag `a` que apunta a la dirección del NIP objetivo y un tag `client` que anuncia `better-nips`. Es exactamente la forma de event que firma NostrHub, por lo que las aprobaciones son compatibles entre ambos clientes. La aprobación de un follow directo pesa más en el ranking que la de un follow de segundo grado.
+
+La pila de firma usa [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer), con un modal de inicio de sesión completo que cubre [NIP-07](/es/topics/nip-07/), bunker y nostrconnect de [NIP-46](/es/topics/nip-46/), ncryptsec de [NIP-49](/es/topics/nip-49/) y firmante Android [NIP-55](/es/topics/nip-55/); las sesiones vuelven a conectarse silenciosamente al recargar. La capa de red se ejecuta mediante [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), un Web Worker que reparte el outbox [NIP-65](/es/topics/nip-65/) del usuario entre relays para que un gran conjunto de web of trust no se propague a un único relay. La posición de diseño es que todos los NIPs comunitarios —alojados en NostrHub, en `better-nips` o en futuros clientes— son iguales a nivel de protocolo; el ranking procede del grafo social, no de la selección de moderadores. Esto encaja directamente con el flujo de labels NIP-32 que abordó el análisis detallado del [número 25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling).
+
+Esta semana aparecieron dos nuevos grupos de repos [NIP-34](/es/topics/nip-34/). [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) es un cliente Nostr centrado en vídeo, y un [grupo de nostrapps.com](wss://gitnostr.com) publica tres proyectos hermanos: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git), una VM de napps para escritorio; [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git), un cliente de comunidades personalizable; y [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git), una especificación y runtime de microapps HTML. El grupo discurre en paralelo al trabajo de [napplets](/es/topics/nip-5d/) tratado en la historia principal del número anterior.
+
+---
+
+## Trabajo de protocolo y actualizaciones de NIPs
+
+### Fusionado: NIP-44 elimina el límite de payload de 65.535 bytes
+
+El [PR #1907](https://github.com/nostr-protocol/nips/pull/1907) se fusionó el 28 de junio tras permanecer abierto desde 2024-09. El cambio elimina el límite superior de 65.535 bytes para el payload en texto plano de un sobre de cifrado versionado [NIP-44](/es/topics/nip-44/) y lo eleva a un máximo de 4 GiB (`uint32_max`). NIP-44 codifica la longitud del payload como un `uint16` en el formato de wire, algo que la especificación original exigía estrictamente para la interoperabilidad; el cambio fusionado adopta un campo de longitud mayor indicado en el byte de versión, de modo que las implementaciones v2 conservan la compatibilidad a nivel de wire y las v3+ transportan la longitud ampliada. Los clientes que usan NIP-44 para mensajes directos [NIP-17](/es/topics/nip-17/), gift wraps [NIP-59](/es/topics/nip-59/), payloads de firmantes remotos [NIP-46](/es/topics/nip-46/) o cualquier otro mensaje Nostr cifrado con NIP-44 ya pueden intercambiar events individuales mayores de 64 KiB sin dividirlos en la capa de aplicación.
+
+### Fusionado: NIP-86 obtiene un método signevent y un event de roles de relay
+
+El [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) añade un método `signevent` a la API JSON-RPC de gestión de relays [NIP-86](/es/topics/nip-86/), que permite a un administrador pedir al relay que firme un event con la propia pubkey del relay. El [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) complementario define un event de roles de relay: un event reemplazable que publica un relay para declarar sus administradores y moderadores. Juntos permiten que los clientes NIP-86 consulten la lista de administradores de un relay y verifiquen que una solicitud autenticada procede de un administrador vigente, sin confianza fuera de banda. Más abajo se analizan ambos cambios en detalle.
+
+### Fusionado: NIP-34 sustituye personal-fork por `u` para GRASP-06
+
+El [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) se fusionó el 24 de junio y sustituye el tag `personal-fork` de [NIP-34](/es/topics/nip-34/) en los events de estado de repos (`kind:30618`) por un tag `u` —de «upstream»—, alineando el formato de wire con la semántica de forks GRASP-06 que implementa la suite GitWorkshop. El cambio cierra el [PR #2384](https://github.com/nostr-protocol/nips/pull/2384) (`NIP-34: remove maintainers to solve expiry issues`), que proponía otra corrección de la semántica de forks. La dirección fusionada es la que implementa ngit v2.6.x, por lo que la especificación fusionada y la CLI de referencia quedan alineadas. Los repos existentes que usan `personal-fork` siguen interoperando; los nuevos repos y la línea ngit v2.6 publican el tag `u`.
+
+### Fusionado: metadatos de cliente NIP-46, ya en upstream tras su llegada a Amber
+
+El [PR #2381](https://github.com/nostr-protocol/nips/pull/2381) se fusionó el 23 de junio y añade metadatos opcionales de cliente a la solicitud `connect` de [NIP-46](/es/topics/nip-46/), lo que permite que un cliente publique su nombre, una URL de icono y una URL de página principal al conectar con el firmante. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) incorporó la extensión de metadatos la semana anterior, según la [cobertura del número 28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata); esta semana el NIP upstream alcanza a la implementación ya publicada.
+
+### Abierto: claves deterministas de wrapper NIP-17 basadas en epochs
+
+Los [PR #2397](https://github.com/nostr-protocol/nips/pull/2397) y [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) abordan dos propuestas convergentes de claves de wrap NIP-17. El PR #2397 propone que la clave de firma efímera usada para crear un gift wrap [NIP-59](/es/topics/nip-59/) se derive de forma determinista de una seed por conversación vinculada a un epoch temporal aproximado, de modo que un destinatario que conozca la clave de conversación pueda predecir a qué pubkeys suscribirse. La especificación actual exige una clave aleatoria nueva por wrap, lo que imposibilita esa predicción. El PR #2396 es el cambio complementario: los wraps de una conversación dada deberían firmarse directamente con la clave de conversación para que la pubkey del wrap sirva también como identificador de la conversación. Juntos trazan un camino hacia conversaciones NIP-17 filtrables sin filtrar metadatos. Ambos siguen abiertos y en discusión.
+
+### Abierto: NIP-59 debería rechazar en el relay los events seal de kind 13
+
+El [PR #2399](https://github.com/nostr-protocol/nips/pull/2399) propone que los relays rechacen los events de kind 13 —el seal interno de un gift wrap [NIP-59](/es/topics/nip-59/)— cuando aparezcan en el nivel superior de una solicitud de publicación, porque un event seal solo tiene sentido dentro de un wrap y un seal filtrado expone la pubkey del destinatario. El [issue #2398](https://github.com/nostr-protocol/nips/issues/2398) complementario va más lejos y sostiene que el seal debería redefinirse como kind efímero —los kinds efímeros NIP-01 no se almacenan en relays—, lo que reforzaría la regla a nivel de protocolo y eliminaría la dependencia de la política de cada relay.
+
+### Abierto: estados de grupos NIP-29
+
+El [PR #2372](https://github.com/nostr-protocol/nips/pull/2372) añade a [NIP-29](/es/topics/nip-29/) —grupos basados en relays— una semántica explícita de estados de grupo, que define qué significa que un grupo sea abierto, cerrado, público, privado o archivado, y cómo interactúan las transiciones de estado con los events de miembros. La propuesta incorpora a la especificación del relay semánticas que hasta ahora eran específicas de cada cliente.
+
+### Abierto: compatibilidad opcional con varios maintainers en NIP-34
+
+El [PR #2324](https://github.com/nostr-protocol/nips/pull/2324) es la propuesta complementaria al [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) fusionado —la semántica de forks GRASP-06 tratada arriba—. El PR #2324 añade compatibilidad opcional con varios maintainers a los events de anuncio de repos [NIP-34](/es/topics/nip-34/) (`kind:30617`), permitiendo que un repositorio declare más de una pubkey de maintainer canónico mediante tags `maintainer` repetidos. Los clientes consideran entonces oficiales los patches e issues firmados por cualquier maintainer declarado, lo que resuelve la carencia histórica por la que los repos NIP-34 con varios maintainers deben canalizarlo todo por una sola pubkey o recurrir a coordinación fuera del protocolo.
+
+### Abierto: operador AND de NIP-91 para filtros, propuesta abierta y no fusionada
+
+El [PR #2252](https://github.com/nostr-protocol/nips/pull/2252) es la propuesta de operador AND para los [filtros](/es/topics/nip-01/) de Nostr, que reabre un diseño debatido por primera vez en el anterior [PR #1365](https://github.com/nostr-protocol/nips/pull/1365), ya cerrado. Ya existen implementaciones en [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst) y worker-relay, pero el PR de la especificación sigue abierto.
+
+### Cerradas: cuatro NIPs comerciales de pats2sats
+
+Esta semana se cerraron cuatro propuestas comerciales sobre Nostr: Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), una extensión de anuncios de marketplace [NIP-99](/es/topics/nip-99/) ([#2346](https://github.com/nostr-protocol/nips/pull/2346)) y un perfil de anuncios de alojamiento ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). Esa misma superficie comercial se consolida ahora en [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), un repositorio de extensiones propio del proyecto que se compone sobre los anuncios de marketplace NIP-99 con semánticas de pedidos, checkout, escrow y disputas. Compass ya rastrea este repositorio junto con Marmot y Blossom como repo de especificación de protocolo externo al propio repositorio de NIPs; entre sus PRs abiertos esta semana están la aclaración de atribución de clientes ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), un tag supersedes para cambios en la identidad de productos ([#8](https://github.com/GammaMarkets/market-spec/pull/8)) y semántica para reseñas de comerciantes ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Abierto: vinculación de identidades Bitcoin
+
+Esta semana se abrieron dos propuestas para vincular identidades Bitcoin con identidades Nostr: una [dirección de pago silencioso de Bitcoin NIP-352](https://github.com/nostr-protocol/nips/pull/2392) y una [prueba de vinculación de identidad Bitcoin-OTC](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## Análisis detallado de NIP: NIP-86 (API de gestión de relays)
+
+[NIP-86](/es/topics/nip-86/) define una interfaz JSON-RPC para gestionar relays, que permite a clientes autorizados enviar comandos administrativos a relays mediante una API estandarizada. Un único cliente puede gestionar cualquier relay compatible con NIP-86 sin herramientas específicas para cada uno. Dos fusiones de la especificación esta semana —[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) y [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)— cierran el círculo entre events firmados por relays y administradores declarados por relays.
+
+### El transporte
+
+Una solicitud de gestión NIP-86 es un HTTP POST dirigido a la misma URI desde la que el relay sirve conexiones WebSocket, con `Content-Type: application/nostr+json+rpc`. El cuerpo de la solicitud es un documento JSON con esta forma:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+La autenticación usa en el header `Authorization` un event firmado de autenticación HTTP [NIP-98](/es/topics/nip-98/). El relay verifica que la pubkey firmante esté en su lista de administradores antes de ejecutar el método. La respuesta del relay es un documento JSON con esta forma:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### Los métodos que existían antes de esta semana
+
+El conjunto de métodos preexistente cubre bloqueos de pubkeys (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), bloqueos de events (`banevent`, `allowevent`, `listbannedevents`), metadatos del relay (`changerelayname`, `changerelaydescription`, `changerelayicon`), gestión de la lista de pubkeys permitidas (`allowkind`, `disallowkind`, `listallowedkinds`) y un método `stats` que devuelve estadísticas del relay. La forma se aproxima deliberadamente a un servicio JSON-RPC estándar, para que un cliente pueda superponer bindings tipados.
+
+### Qué cambió esta semana
+
+El [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) añade un método `signevent` a la especificación. El método recibe como argumento una plantilla parcial de event —kind, tags y content— y pide al relay que firme y devuelva un event completo con la propia pubkey del relay en el campo `pubkey`. Es la condición previa para que un relay publique events sobre sí mismo a nivel de protocolo: los anuncios de pubkeys bloqueadas, los metadatos del relay y el nuevo event de roles de relay descrito a continuación exigen que el relay firme con la clave controlada por su operador, pero la mayoría de los operadores no quieren guardar una clave privada en su cliente administrativo.
+
+El [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) define un event de roles de relay: un event reemplazable parametrizado que publica un relay —firmado con su propia pubkey mediante `signevent`— para declarar las pubkeys de sus administradores y moderadores con semánticas de roles explícitas. Un cliente compatible con NIP-86 puede obtener el event de roles de cualquier relay rastreado, construir la lista de administradores a partir de los tags del event y validar que una solicitud NIP-86 autenticada procede de un administrador actual, sin confianza fuera de banda ni configuración específica del relay. Los dos PRs cierran juntos el círculo: `signevent` es el mecanismo y los roles de relay son el primer event kind construido sobre él.
+
+### Ejemplo de solicitud NIP-86
+
+Una solicitud completa `banpubkey` de NIP-86 tiene este aspecto:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+con un header `Authorization` que transporta un event firmado NIP-98:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+La pubkey firmante debe figurar en el conjunto de administradores del relay —ahora declarado en el event de roles del relay—; el tag `u` debe coincidir con la URL HTTPS del relay; y el tag `payload` debe coincidir con el SHA-256 del cuerpo JSON de la solicitud. El relay devuelve:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementaciones
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) incluye una interfaz de gestión de relays NIP-86 en Android (v1.07.0+).
+- Entre los relays de referencia que implementan la especificación están [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru) y varias implementaciones menores enlazadas por la especificación desde su sección `Implementation Status`.
+
+Los clientes compatibles con NIP-86 empezarán a tratar el event de roles de relay como fuente canónica de la lista de administradores del relay cuando las implementaciones adopten los cambios `signevent` y Relay Roles.
+
+---
+
+## Análisis detallado de NIP: NIP-89 (handlers de aplicaciones recomendados)
+
+[NIP-89](/es/topics/nip-89/) define dos event kinds reemplazables parametrizados: `kind:31990`, el handler de aplicación que publica el desarrollador de una app, y `kind:31989`, la recomendación que publica un usuario sobre una app que utiliza. Juntos permiten que los clientes descubran aplicaciones capaces de manejar un event kind desconocido sin coordinación fuera de banda: un lector de formato largo que encuentre un event `kind:30030` que no maneje de forma nativa puede consultar el grafo NIP-89 en busca de handlers y ofrecer al usuario un flujo «Open in...» hacia una app publicada que sí lo haga. NIP-89 es la infraestructura original para el mismo problema de enrutamiento entre apps que el trabajo de napplets/napps presente en este número amplía ahora hacia applets componibles nativos de Nostr.
+
+### El event de handler de aplicación (`kind:31990`)
+
+El desarrollador de una app publica uno o varios events de handler que describen qué event kinds admite la app y cómo abrir una entidad Nostr en ella:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+El tag `d` identifica el handler —para que pueda reemplazarse—, cada tag `k` declara un event kind que maneja la app, y cada tag de plataforma (`web`, `ios`, `android`, ...) proporciona una plantilla de URL con `<bech32>` como placeholder de una entidad codificada mediante [NIP-19](/es/topics/nip-19/) que el cliente llamante sustituye al abrirla. Un solo event de handler puede anunciar varios kinds compatibles si comparten el mismo patrón de enrutamiento, lo que mantiene compacto el descubrimiento de apps y evita un event de handler por kind.
+
+### El event de recomendación de usuario (`kind:31989`)
+
+Un usuario publica una recomendación que declara qué apps utiliza para un event kind determinado:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+El tag `d` contiene el event kind recomendado. Cada tag `a` es un puntero de dirección NIP-01 a un event de handler `kind:31990`, junto con el relay sugerido y la plataforma a la que se aplica la recomendación. Una misma recomendación puede enumerar varias apps para distintas plataformas.
+
+### El client tag y el compromiso de privacidad
+
+NIP-89 también define un tag `client` opcional que cualquier app publicadora puede adjuntar a los events que crea:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Esto permite que cualquier cliente que muestre el event revele de qué app procede, consulte metadatos más completos del handler y respete las indicaciones de renderizado declaradas por este. La especificación también señala explícitamente el coste de privacidad: un cliente que emite un tag `client` en cada event publica la identidad del software del usuario, lo que revela patrones de uso con el tiempo. La especificación recomienda que los clientes permitan desactivarlo.
+
+El [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) de Amethyst analiza y muestra los tags `t`, `i`, `a` y `client` de NIP-89 al presentar events, revelando directamente en el timeline qué app creó una nota.
+
+### Cómo funciona en la práctica el flujo de descubrimiento
+
+Un cliente que recibe un event kind desconocido sigue estos pasos. (1) Consulta en el grafo de follows del usuario events `kind:31989` con un tag `d` que coincida con el event kind. (2) Resuelve cada tag `a` recomendado hasta su event de handler `kind:31990`. (3) Elige el handler cuya plantilla de URL `web`, `ios` o `android` coincida con la plataforma actual. (4) Sustituye en la plantilla de URL la codificación `bech32` de la entidad. (5) Ofrece al usuario la URL resultante como opción «Open in...». El flujo está filtrado socialmente: un cliente que consulte events de handlers arbitrarios en relays no confiables podría redirigir a los usuarios a apps maliciosas, así que partir de personas a las que sigue el usuario es una opción predeterminada más segura que tratar por igual a todos los handlers publicados.
+
+### NIP-89 y la capa napplet
+
+La sección Discover de Amethyst, el runtime host de napplets y la visualización de client tags construyen juntos una superficie completa de consumo de NIP-89 en Android. La especificación napplet, lanzada en el número anterior, amplía los posibles destinos de esos events de handlers NIP-89: applets en sandbox que ejecutan un runtime componible nativo de Nostr sobre Nostr y Blossom. NIP-89 es el grafo de descubrimiento y enrutamiento; el runtime napplet es uno de los objetivos de ejecución a los que puede apuntar.
+
+---
+
+*Comentarios, correcciones y proyectos que se nos hayan escapado: abrid un issue en [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) o contactad con nosotros mediante un DM NIP-17 en npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/fr/newsletters/2026-07-01-newsletter.md
+++ b/content/fr/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-08-27
+draft: false
+type: newsletters
+---
+
+Bon retour sur Nostr Compass, votre guide hebdomadaire de Nostr.
+
+**Cette semaine :** [FIPS v0.4.0](#fips-v040-livre-un-transport-mixnet-nym-la-découverte-mdns-et-une-refonte-du-plan-de-données) livre un transport mixnet Nym, la découverte LAN mDNS facultative, un renouvellement de clés sans interruption malgré les pertes et une refonte du plan de données, compatible sur le fil avec la v0.3.0. [Whitenoise Linux](#whitenoise-linux-se-présente-comme-client-marmot-de-bureau) se présente comme client Marmot de bureau en Rust et Slint, avec une proposition de protocole visant à déplacer les effets de message vers un événement dédié de kind 9. [CustID v0.1.10-beta](#custid-se-lance-comme-coffre-didentités-mobile-avec-nip-46-et-flux-de-défi-nfc) se lance comme coffre d'identités mobile adossé au matériel, qui agit comme signataire distant NIP-46 et répond aux défis d'accès physique par NFC. [myco](#myco-lance-le-partage-nsite-pair-à-pair-sur-le-mesh-fips) lance le partage nsite pair à pair sur le mesh FIPS avec un nouveau transport BLE L2CAP dans la v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-se-lance-comme-surface-de-contrôle-mobile-pour-un-worker-codex-local-via-nostr) se lance comme surface de contrôle Android pour un assistant de programmation Codex local via des DM Nostr chiffrés. [La branche non publiée d'Amethyst](#amethyst-construit-une-interface-compatible-nip-89-un-flux-git-repositories-et-une-section-discover-pour-les-napplets) ajoute l'analyse des handlers d'app NIP-89, un flux Git Repositories pour NIP-34 et une section Discover pour les nSites et napplets. [Notedeck](#notedeck-implémente-les-relays-de-synchronisation-privée-nip-37-le-calendrier-nip-52-et-les-commentaires-nip-22) intègre NIP-37, NIP-52 et NIP-22 en une semaine. [Applesauce](#applesauce-publie-12-sous-paquets-dans-une-sortie-coordonnée-62x) publie 12 sous-paquets avec des helpers nbunksec NIP-46 et une mise à niveau du wallet vers Cashu-ts v4. [Meiso v1.4.0](#meiso-v140-livre-des-listes-collaboratives-à-clé-partagée-qui-remplacent-mls-pour-le-partage-de-tâches) livre des listes collaboratives à clé partagée sur le kind adressable 35000. Le dépôt des NIP a fusionné cinq PR, dont un événement Relay Roles, la suppression de la limite de 65 535 octets de NIP-44, la sémantique des forks NIP-34, les métadonnées client NIP-46 et une méthode `signevent` NIP-86. Les analyses approfondies portent sur [NIP-86 (API de gestion des relays)](#analyse-approfondie-de-nip-86-api-de-gestion-des-relays) et [NIP-89 (handlers d'application recommandés)](#analyse-approfondie-de-nip-89-handlers-dapplication-recommandés).
+
+---
+
+## À la une
+
+### FIPS v0.4.0 livre un transport mixnet Nym, la découverte mDNS et une refonte du plan de données
+
+[FIPS](https://github.com/jmcorgan/fips) est un réseau maillé pair à pair privé et auto-organisé pour Nostr, où les nœuds se découvrent et acheminent le trafic sans infrastructure centrale. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) apporte un transport mixnet Nym, la découverte LAN mDNS facultative, une refonte du plan de données, un renouvellement de clés sans interruption malgré les pertes de paquets, une TUI `fipstop` réécrite sur un banc de snapshots de rendu, un plan d'observabilité hors du chemin critique et de nouvelles cibles de packaging apk OpenWrt et flake Nix. Le tout reste compatible sur le fil avec la v0.3.0, afin que les mesh mixtes interopèrent pendant une mise à niveau progressive. Deux nouveaux transports de découverte des pairs structurent cette version. Un nouveau [transport mixnet Nym sortant](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) fait passer le trafic FIPS par un proxy SOCKS5 `nym-socks5-client`, le mêlant au réseau de trafic de couverture de [Nym](https://nymtech.net/) afin que les observateurs au niveau de la liaison ne puissent pas corréler les pairs du mesh qui communiquent. Un répertoire `examples/sidecar-nostr-mixnet-relay/` montre un relay Nostr accessible par une liaison FIPS appairée de bout en bout à travers le mixnet. La découverte LAN mDNS / DNS-SD facultative permet aux nœuds d'une même liaison locale de se trouver sans configuration d'adresse ni STUN, en annonçant et adoptant des pairs via un enregistrement de service standard lorsque `node.discovery.lan.enabled: true`.
+
+Le plan de données a été remanié pour accroître le débit d'un nœud unique. Le chiffrement et le déchiffrement par pair s'exécutent désormais dans des tâches worker dédiées, hors de la boucle de réception, de sorte qu'un pair très actif ne puisse pas sérialiser la cryptographie de tout le nœud. Sous Linux, le chemin d'envoi utilise la generic segmentation offload et, lorsqu'elle est disponible, une socket UDP connectée ; le chemin critique de réception évite les copies de buffer auparavant effectuées pour chaque paquet ; et macOS reçoit un `recvmsg_x` par lots, miroir du traitement `recvmmsg` de Linux introduit en v0.3.0. Toute la surface de lecture `show_*` de `fipsctl` et `fipstop` est maintenant servie depuis un snapshot par tick publié dans un `ArcSwap` sans verrou par la tâche d'acceptation de contrôle, ce qui permet aux requêtes opérateur de répondre rapidement même lorsque la boucle de réception du nœud est occupée. Une nouvelle requête `show_metrics`, limitée aux compteurs et exposée sous `fipsctl stats metrics`, permet le scraping Prometheus sans coût sur le chemin critique.
+
+Le renouvellement de clés des sessions FMP et FSP est désormais sans interruption malgré les pertes et le réordonnancement de paquets dans les deux sens : les frames entrantes s'authentifient contre la session en attente avant que la bascule du bit K ne la promeuve (ainsi, une frame périmée ou usurpée ne peut pas faire dérailler le renouvellement), la retransmission du message 1 est bornée, le heartbeat de lien mort tient compte du renouvellement et les courses d'initialisation simultanée sur les liaisons à forte latence sont désynchronisées par une gigue symétrique. La TUI `fipstop` est reconstruite sur un banc de snapshots de rendu qui vérifie la grille de texte exacte et le style de chaque cellule de toutes les vues à partir de sorties prédéfinies de la socket de contrôle. De nouvelles cibles de packaging accompagnent la version : un `.apk` OpenWrt pour OpenWrt 25+ (construit sans SDK, en réutilisant la compilation croisée `.ipk` et la charge utile du système de fichiers installé) et un `flake.nix` à la racine du projet qui compile depuis les sources les quatre binaires (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) sous Nix/NixOS avec la toolchain épinglée.
+
+### Whitenoise Linux se présente comme client Marmot de bureau
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) est un client [Marmot](/fr/topics/marmot/) de bureau : messagerie de groupe MLS sur des relays Nostr, empaquetée dans un binaire Rust unique avec une interface Slint qui conserve chaque secret dans un coffre chiffré par mot de passe.
+
+Le fil le plus important de la semaine propose de transporter les effets de message de Whitenoise dans un événement dédié de kind 9 référençant le message parent. Le format actuel ajoute un marqueur tel que `dmfx:sparkle` à la fin du corps du message, ce qui pollue le texte pour tout renderer qui ignore cette convention. Déplacer les effets vers leur propre événement garde le texte propre et ouvre une question de conception à laquelle toute la stack Marmot devra répondre : conventions intégrées au corps ou événements sidecar pour les fonctions enrichies facultatives.
+
+### CustID se lance comme coffre d'identités mobile avec NIP-46 et flux de défi NFC
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) est la première bêta publique de CustID, un coffre d'identités mobile construit sur Nostr et le protocole SISTR. CustID stocke plusieurs identités Nostr dans un stockage sécurisé adossé au matériel, agit comme signataire distant [NIP-46](/fr/topics/nip-46/) pour d'autres clients et répond à des défis d'accès physiques et en ligne au moyen de NFC et de codes QR.
+
+La bêta est complète pour le signataire NIP-46 et le flux défi-réponse NFC ; les flux d'accès par preuve à divulgation nulle de connaissance restent un jalon futur. Cette version supprime aussi la couche keep-alive [NIP-65](/fr/topics/nip-65/) en arrière-plan, qui ouvrait une WebSocket par profil et par relay de lecture pour ingérer des kinds que le client rejetait aussitôt. Seules les sockets NIP-46 qui transportent les notifications de demandes de signature restent maintenant ouvertes en arrière-plan, correction qui rend viable l'utilisation de CustID comme bunker pour d'autres clients sur un téléphone.
+
+### myco lance le partage nsite pair à pair sur le mesh FIPS
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) a ouvert cette semaine, le 27 juin, et atteint la v0.1.0 le 1er juillet. myco est une app Android en Rust qui installe des apps venues des personnes autour de vous : partage [nsite](/fr/topics/nip-5a/) pair à pair sur un mesh FIPS, avec tout transport pris en charge par le mesh (UDP, TCP, Tor, Bluetooth), entièrement hors ligne. La conception associe directement FIPS comme substrat de transport au format d'événement de site statique de NIP-5A comme charge utile, ce qui permet à une app distribuée comme nsite de passer d'un pair du mesh à l'autre sans dépendre de relays ni de HTTP.
+
+La v0.1.0 ajoute un chemin radio Bluetooth L2CAP afin que deux téléphones équipés de FIPS puissent s'appairer par BLE sans aucun réseau, ainsi qu'un speedtest par pair et le partage déclenché par NFC depuis le bottom sheet Circle de l'app. myco est aussi publié sur Zapstore pour installation directe.
+
+### Nostr Codex Phone se lance comme surface de contrôle mobile pour un worker Codex local via Nostr
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) se lance cette semaine comme client Android contrôlant un worker local de l'assistant de programmation Codex via des messages directs Nostr chiffrés. L'app prend en charge plusieurs sessions de dépôt, la transcription vocale, les sessions worker routées, l'upload de médias Blossom et les réponses parlées facultatives, afin qu'un développeur exécutant chez lui un worker Codex puisse envoyer des demandes depuis son téléphone partout où celui-ci accède à des relays.
+
+Le projet est directement apparenté à [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), lancé dans le #28. Tous deux placent les workflows de programmation agentique sur le transport Nostr avec des DM chiffrés, et traitent Nostr comme couche d'appairage et de messagerie permettant à un téléphone d'atteindre un worker à domicile sans ouvrir de brèche dans le réseau. Nostr comme plan de contrôle d'agents locaux devient un modèle établi.
+
+### Coop Mobile publie ses premiers builds versionnés
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) et [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) sont sortis cette semaine comme premiers builds versionnés de Coop Mobile, un client de messages directs chiffrés [NIP-17](/fr/topics/nip-17/) pour Android. Les deux versions renforcent la résistance aux crashes lors de l'analyse des messages et du traitement des QR, et effacent toutes les données stockées à la déconnexion.
+
+### Amethyst construit une interface compatible NIP-89, un flux Git Repositories et une section Discover pour les napplets
+
+La branche principale d'[Amethyst](https://github.com/vitorpamplona/amethyst) a construit plusieurs nouvelles surfaces cette semaine. Un [flux Git Repositories](https://github.com/vitorpamplona/amethyst/pull/3406) transforme les dépôts [NIP-34](/fr/topics/nip-34/) en catégorie de timeline Android consultable et filtrable par communauté et auteur, avec un [navigateur git smart-HTTP](https://github.com/vitorpamplona/amethyst/pull/3415) qui lit le contenu et les commits du dépôt sans quitter l'app. L'hôte de napplets reçoit une [section Discover](https://github.com/vitorpamplona/amethyst/pull/3409) qui répertorie des apps web sélectionnées ainsi que les nSites et napplets suivis, à partir des événements de handler [NIP-89](/fr/topics/nip-89/) et des événements de site [NIP-5A](/fr/topics/nip-5a/). L'affichage des notes [révèle désormais quelle app Nostr a créé un événement](https://github.com/vitorpamplona/amethyst/pull/3422) grâce aux tags NIP-89. Côté synchronisation, la [prise en charge de la negentropy NIP-77](https://github.com/vitorpamplona/amethyst/pull/3434) apporte la réconciliation en streaming et un fenêtrage automatique de `created_at` pour contourner les plafonds de résultats des relays, réduisant la bande passante nécessaire pour garder de grands ensembles locaux d'événements synchronisés avec un relay.
+
+### Buzz v0.3.38 renforce la surface d'attaque des relays et ajoute la sélection de modèle indépendante du fournisseur
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) renforce la [surface d'attaque des relays](https://github.com/block/buzz/pull/1369) exposée lorsque Buzz publie des personas, équipes, agents gérés et attestations de propriétaire NIP-OA comme événements Nostr signés. Un relay Buzz constitue un registre public des identités Nostr de l'équipe et de leur état ; cette version durcit la validation des entrées et la protection contre le replay sur les kinds d'événement bien connus définis par Buzz. Elle généralise aussi la sélection de modèle afin qu'une équipe Buzz puisse choisir tout fournisseur pour lequel Buzz possède un adapter, dont un nouveau backend Databricks AI Gateway v2.
+
+### Notedeck implémente les relays de synchronisation privée NIP-37, le calendrier NIP-52 et les commentaires NIP-22
+
+[Notedeck](https://github.com/damus-io/notedeck), le client de bureau natif en Rust de l'équipe Damus, a intégré trois protocoles en une semaine. Les relays de synchronisation privée persistent maintenant sous forme d'une liste [NIP-37](/fr/topics/nip-37/) de kind `10013`, séparant l'ensemble des relays de contenu privé de l'utilisateur de son outbox NIP-65 public. Le panneau de calendrier `horizon` lit les événements [NIP-52](/fr/topics/nip-52/) depuis nostrdb et reçoit une nouvelle disposition à trois volets. Le panneau `headway` ajoute un modèle d'événement de commentaire [NIP-22](/fr/topics/nip-22/) sur le kind `1111`, celui que NIP-22 définit pour la surface unifiée de commentaires remplaçant les fils de réponse NIP-10.
+
+### Applesauce publie 12 sous-paquets dans une sortie coordonnée 6.2.x
+
+[Applesauce](https://github.com/hzrd149/applesauce), la boîte à outils Nostr modulaire pour signataires, relays, wallets et contenu, a réalisé une [sortie 6.2.x coordonnée](https://github.com/hzrd149/applesauce/releases) de ses sous-paquets. Le paquet de signataires reçoit des helpers d'import et d'export `nbunksec`, qui traitent une session bunker [NIP-46](/fr/topics/nip-46/) comme un artefact portable entre clients. Le paquet wallet met à niveau ses bindings [Cashu](/fr/topics/nip-60/) vers `@cashu/cashu-ts` v4, où les montants des proofs deviennent des objets valeur `Amount` et où l'API de décodage des tokens change.
+
+---
+
+## Versions taguées
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) apporte la prochaine itération du protocole au réseau de commerce fiat P2P [Mostro](/fr/topics/nip-69/). La version suit la [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) et accompagne [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), qui adopte le nouveau core. Trois PR fusionnées ont rejoint le dépôt core cette semaine ; la stack environnante (daemon mostro et Mostro mobile) suit la v0.14.0 du crate de types partagé.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), le CLI git-over-nostr canonique pour les dépôts [NIP-34](/fr/topics/nip-34/), implémente la [sémantique de fork GRASP-06 de NIP-34](https://github.com/nostr-protocol/nips/pull/2395) fusionnée cette semaine, qui remplace le tag `personal-fork` par un tag `u` sur les événements d'état de dépôt.
+
+### mesh-llm v0.72.0 et v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), le composant d'inférence de la stack ContextVM qui exécute des LLM open source derrière une surface JSON-RPC adressable via Nostr, a publié les [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) et [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1), avec un correctif pour un crash du batching sur les grands prompts uniques et une migration du pont MCP hors de helpers dépréciés.
+
+### Meiso v1.4.0 livre des listes collaboratives à clé partagée qui remplacent MLS pour le partage de tâches
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) introduit un modèle de listes collaboratives à clé partagée qui remplace l'ancien partage de tâches fondé sur MLS par une conception plus simple d'événements adressables. Chaque liste partagée génère une clé Nostr dédiée distribuée aux membres ; les tâches sont des événements adressables de kind `35000`, indexés par `d=task-id`, au contenu auto-chiffré avec [NIP-44](/fr/topics/nip-44/) ; et les relays appliquent Last-Write-Wins pour chaque tâche. La conception abandonne la forward secrecy et la sécurité post-compromission de MLS en échange d'une implémentation client plus simple et d'une résolution des conflits au niveau du relay.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) livre une branche « more-private-coordinator » qui supprime les pubkeys éphémères des expéditeurs lors de la publication des messages de groupe et durcit le flux de demande d'adhésion contre les nouvelles demandes périmées. Cordn est la stack de messagerie fondée sur MLS présentée dans [le lancement de Cordn Ad-hoc CVM du #28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator) ; cette version constitue la mise à jour correspondante côté coordinateur.
+
+---
+
+## Changements non publiés
+
+### diVine pousse 108 PR fusionnées de finitions après lancement
+
+[diVine](https://github.com/divinevideo/divine-mobile), le client de vidéos courtes en boucle qui ressuscite Vine, traverse une importante vague de finitions après lancement. Le travail visible sur Nostr cette semaine est une passe de stabilité du flux de connexion [NIP-46](/fr/topics/nip-46/) qui fait migrer les échecs `nostrconnect://` vers des codes de motif structurés.
+
+### Zap Cooking poursuit le correctif NIP-46 transversal et la refonte du compositeur
+
+[Zap Cooking](https://github.com/zapcooking/frontend) est un client Nostr de partage de recettes, où celles-ci sont publiées comme événements Nostr long-form. Le travail de la semaine poursuit le correctif [NIP-46](/fr/topics/nip-46/) transversal et la refonte du compositeur présentés parmi les changements non publiés du [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes).
+
+### Conduit renforce le flux d'annonces et la justesse de la marketplace
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) est un monorepo de marketplace comprenant trois apps sur Nostr : marché acheteur, portail marchand et constructeur de boutique. Le travail de la semaine poursuit l'effort de justesse de la marketplace présenté dans [la couverture du lancement du #28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default), en s'appuyant sur la vague commerciale [NIP-99](/fr/topics/nip-99/) qui constituait le sujet protocolaire du dernier numéro.
+
+### Pollerama v1.12 à v1.13.1 ajoutent le choix du tag client, des onglets de profil et des limites de profondeur des fils
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), un client Nostr Android centré sur les sondages et les notes avec une forte couche de découverte par web of trust, a publié les v1.12.0, v1.13.0 et v1.13.1 sur Zapstore cette semaine. Les utilisateurs peuvent désormais choisir le tag client joint aux notes et sondages qu'ils créent, à partir d'une liste prédéfinie ou en saisissant le leur. Les chaînes de commentaires et de réponses très imbriquées s'arrêtent maintenant après quelques niveaux et renvoient vers le fil complet sur la page de la note. Les pages de profil s'ouvrent par défaut sur Notes, divisées en onglets Posts et Conversations. Un bug de persistance des follows, qui faisait disparaître après redémarrage de l'app les comptes nouvellement suivis, est corrigé, et les boutons follow affichent désormais la progression.
+
+### getwired.app et get-tao.app corrigent le flux d'envoi confess de NIP-13
+
+[getwired.app](https://github.com/smolgrrr/Wired) et [get-tao.app](https://github.com/smolgrrr/TAO), qui partagent un flux de publication anonyme ajoutant la preuve de travail NIP-13 afin de limiter le spam au moment de l'envoi, ont corrigé le [flux d'envoi confess](https://github.com/smolgrrr/Wired/pull/57) afin de rendre cohérente l'UX pendant le minage PoW.
+
+### nostui ajoute un onglet de timeline des mentions
+
+[nostui](https://github.com/akiomik/nostui), un client Nostr de terminal en Rust, ajoute un [onglet de timeline des mentions](https://github.com/akiomik/nostui/pull/463) qui présente dans une vue TUI dédiée les événements de kind 1 taguant la pubkey active.
+
+### Heartwood intègre des URI bunker NIP-46 par identité et un pont de signature en mode HSM
+
+[Heartwood](https://github.com/forgesworn/heartwood) est un signataire [NIP-46](/fr/topics/nip-46/) dans lequel la clé de signature n'atteint jamais le client : le client parle NIP-46 à un petit relay, qui échange des frames série avec un appareil matériel connecté chargé de la signature. Cette semaine, le projet a intégré un [pont de signature relay-vers-série](https://github.com/forgesworn/heartwood/pull/11) et des [connexions bunker par identité](https://github.com/forgesworn/heartwood/pull/16), afin qu'un seul appareil matériel contenant plusieurs identités expose une URI bunker distincte pour chacune.
+
+### Refactorisation de l'authentification et du signataire de Nostter
+
+[Nostter](https://github.com/SnowCait/nostter) a remanié cette semaine sa [couche d'authentification et de signature](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth), en déplaçant l'état de connexion vers un signal unique et en extrayant le dispatch du signataire dans des modules de stratégie. La trajectoire vise une abstraction propre du signataire, où extension web NIP-07, bunker distant NIP-46 et nsec brut partagent le même chemin de code.
+
+### Dart NDK extrait le signataire NIP-07 et randomise les timestamps NIP-59
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) a déplacé son signataire [NIP-07](/fr/topics/nip-07/) hors du paquet core vers `ndk_flutter` (où réside la WebView Flutter), et [randomisé les timestamps de ses gift wraps NIP-59](https://github.com/relaystr/dart_ndk/pull/667) pour mieux résister à la corrélation temporelle des messages chiffrés.
+
+### Milk Market ajoute des pages de boutique NIP-23 et le traitement des paiements Square
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), la vitrine marketplace de l'équipe Shopstr, a donné à chaque boutique une page de blog alimentée par les événements long-form [NIP-23](/fr/topics/nip-23/) du vendeur, avec sections modifiables et route directe vers les réglages du blog. La même semaine a ajouté [Square](https://github.com/shopstr-eng/milk-market/pull/30) comme processeur de paiement alternatif pour les vendeurs et l'achat automatique d'étiquettes d'expédition pour les commandes payées.
+
+### Calendar by Formstr livre une app iOS
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) a fusionné cette semaine la [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159), qui porte le client de calendrier [NIP-52](/fr/topics/nip-52/) sur iOS. La [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) corrige l'analyse des dates du calendrier en heure locale, et la [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) ajoute un workflow E2E Playwright déclenché par un label `run-tests`.
+
+### cagliostr applique NIP-22, NIP-09 par coordonnée et la preuve de travail NIP-13
+
+[cagliostr](https://github.com/mattn/cagliostr), une implémentation de relay en Go, a durci trois chemins d'application cette semaine : [preuve de travail NIP-13 configurable](https://github.com/mattn/cagliostr/pull/7) sur les événements entrants, [suppression NIP-09 par coordonnée adressable](https://github.com/mattn/cagliostr/pull/8) afin que les événements remplaçables puissent être supprimés par leur tag `a` (ce que la suppression par id d'événement ne peut atteindre), et [limites de timestamp NIP-22 configurables](https://github.com/mattn/cagliostr/pull/9) rejetant les événements horodatés trop loin dans le passé ou le futur.
+
+---
+
+## Nouveaux projets suivis et découverts
+
+La [suite wellbeing de Vanderwarker](https://git.vanderwarker.family/wellbeing) publie des télémétries du monde physique comme événements Nostr sous une clé de signature d'éditeur partagée. Elle comprend cinq apps sœurs : [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) est un podomètre qui ancre les données de fitness dans Nostr sous `kind:30078`, [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) publie un compteur quotidien de déverrouillages du téléphone, [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) publie la lecture média en cours sous forme de User Status, [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) publie le niveau, la tension et la température de la batterie toutes les 15 minutes, et [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) publie la consommation quotidienne de données. Les cinq sont apparues sur Zapstore entre le 24 et le 30 juin.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) est une app Android chiffrée et sans serveur de partage de localisation en direct, construite en Rust et Slint et publiée le 29 juin. Elle est apparentée à [Haven](https://github.com/mehmetefeumit/Haven-App), l'app de partage de localisation fondée sur [Marmot](/fr/topics/marmot/) présentée dans le [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), mais adopte une autre architecture de transport : les DM Nostr chiffrés portent les mises à jour de localisation, là où Haven utilise des messages de groupe Marmot.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) est un échafaudage précoce de shell applicatif pour construire des apps Nostr. Le projet a publié cette semaine sa première documentation destinée aux utilisateurs.
+
+[NIPs by Pollerama](https://nips.pollerama.fun) (dépôt [abh3po/better-nips](https://github.com/abh3po/better-nips), créé le 2026-06-29) est un nouveau client pour les NIP communautaires de `kind:30817` de [NostrHub](https://nostrhub.io), présenté comme une surface alternative à nostrhub.io pondérée par la confiance. Chaque NIP de `kind:30817` dispose de sa propre URL partageable (`#/nip/<naddr>`), avec rendu Markdown complet et les kinds d'événement qu'elle définit. Le client propose trois flux : Following, Web of Trust (follows-of-follows) et Global, chacun triable selon les approbations pondérées par la confiance ou par nouveauté. Les approbations sont publiées comme labels [NIP-32](/fr/topics/nip-32/) sur le kind `1985`, avec les tags `["L","nostrhub"]` et `["l","approve","nostrhub"]`, plus un tag `a` pointant vers l'adresse de la NIP cible et un tag `client` annonçant `better-nips`. C'est la forme d'événement exacte que NostrHub signe lui-même, de sorte que les approbations sont compatibles entre les deux clients. L'approbation d'un compte directement suivi pèse davantage dans le classement que celle d'un follow-of-follow au second degré.
+
+La stack de signature est [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer), avec une modale de connexion complète couvrant l'extension [NIP-07](/fr/topics/nip-07/), le bunker et nostrconnect [NIP-46](/fr/topics/nip-46/), ncryptsec [NIP-49](/fr/topics/nip-49/) et le signataire Android [NIP-55](/fr/topics/nip-55/) ; les sessions se reconnectent silencieusement au rechargement. La couche réseau passe par [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), un Web Worker qui répartit l'outbox [NIP-65](/fr/topics/nip-65/) de l'utilisateur entre les relays afin qu'un grand web of trust ne soit pas diffusé en éventail vers un relay unique. Le parti pris est que les NIP communautaires, qu'elles soient hébergées sur NostrHub, dans `better-nips` ou par de futurs autres clients, sont toutes égales au niveau du protocole ; le classement vient du graphe social et non d'une curation par des modérateurs, ce qui s'accorde directement avec le flux de labellisation NIP-32 présenté dans l'analyse approfondie du [#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling).
+
+Deux nouveaux clusters de dépôts [NIP-34](/fr/topics/nip-34/) sont apparus cette semaine. [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) est un client Nostr centré sur la vidéo, et un [cluster nostrapps.com](wss://gitnostr.com) publie trois projets frères : [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git) (une VM napp pour ordinateur), [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git) (un client de communautés personnalisable) et [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git) (une spécification et un runtime de micro-apps HTML). Le cluster évolue en parallèle du travail [napplet](/fr/topics/nip-5d/) présenté à la une du dernier numéro.
+
+---
+
+## Travail protocolaire et mises à jour des NIP
+
+### Fusionné : NIP-44 relève la limite de charge utile de 65 535 octets
+
+La [PR #1907](https://github.com/nostr-protocol/nips/pull/1907) a été fusionnée le 28 juin après être restée ouverte depuis 2024-09. Le changement supprime la limite supérieure de 65 535 octets sur la charge utile en clair d'une enveloppe de chiffrement versionnée [NIP-44](/fr/topics/nip-44/), la relevant à 4 Gio (`uint32_max`). NIP-44 encode la longueur de la charge utile comme `uint16` dans le format sur le fil, ce que la spécification d'origine exigeait strictement pour l'interopérabilité ; le changement fusionné adopte un champ de longueur étendu signalé dans l'octet de version, de sorte que les implémentations v2 restent compatibles sur le fil et que les v3+ portent la longueur accrue. Les clients qui emploient NIP-44 pour les messages directs [NIP-17](/fr/topics/nip-17/), les gift wraps [NIP-59](/fr/topics/nip-59/), les charges utiles de signataire distant [NIP-46](/fr/topics/nip-46/) ou tout autre message Nostr chiffré avec NIP-44 peuvent désormais échanger des événements uniques dépassant 64 Kio sans découpage dans la couche applicative.
+
+### Fusionné : NIP-86 reçoit une méthode signevent et un événement Relay Roles
+
+La [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) ajoute une méthode `signevent` à l'API JSON-RPC de gestion des relays [NIP-86](/fr/topics/nip-86/), permettant à un administrateur de demander au relay de signer un événement avec sa propre pubkey. La [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) associée définit un événement Relay Roles : un événement remplaçable publié par un relay pour déclarer ses administrateurs et modérateurs. Ensemble, elles permettent aux clients NIP-86 d'inspecter la liste d'administrateurs d'un relay et de vérifier qu'une demande authentifiée vient d'un administrateur actuel, sans confiance hors bande. Analyse approfondie des deux changements ci-dessous.
+
+### Fusionné : NIP-34 remplace personal-fork par `u` pour GRASP-06
+
+La [PR #2395](https://github.com/nostr-protocol/nips/pull/2395), fusionnée le 24 juin, remplace le tag `personal-fork` de [NIP-34](/fr/topics/nip-34/) sur les événements d'état de dépôt (`kind:30618`) par un tag `u` (pour « upstream »), alignant le format sur le fil avec la sémantique de fork GRASP-06 qu'implémente la suite GitWorkshop. Le changement ferme la [PR #2384](https://github.com/nostr-protocol/nips/pull/2384) (`NIP-34: remove maintainers to solve expiry issues`), qui proposait un autre correctif de sémantique des forks. La direction fusionnée est celle qu'implémente ngit v2.6.x : la spécification et le CLI de référence sont donc alignés. Les dépôts existants utilisant `personal-fork` continuent d'interopérer ; les nouveaux dépôts et la branche ngit v2.6 publient le tag `u`.
+
+### Fusionné : métadonnées client NIP-46, désormais upstream après leur livraison par Amber
+
+La [PR #2381](https://github.com/nostr-protocol/nips/pull/2381), fusionnée le 23 juin, ajoute des métadonnées client facultatives à la demande `connect` [NIP-46](/fr/topics/nip-46/), permettant à un client de publier son nom, l'URL d'une icône et l'URL de sa page d'accueil lors de la connexion au signataire. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) a livré cette extension de métadonnées la semaine dernière, comme présenté dans le [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata) ; cette semaine, la NIP upstream rattrape l'implémentation déjà publiée.
+
+### Ouvert : clés de wrapper NIP-17 déterministes par epoch
+
+Les [PR #2397](https://github.com/nostr-protocol/nips/pull/2397) et [#2396](https://github.com/nostr-protocol/nips/pull/2396) couvrent deux propositions convergentes de clés de wrap NIP-17. La PR #2397 propose que la clé de signature éphémère utilisée pour créer un gift wrap [NIP-59](/fr/topics/nip-59/) soit dérivée de façon déterministe d'une seed par conversation liée à un epoch temporel grossier, afin qu'un destinataire connaissant la clé de conversation puisse prédire les pubkeys auxquelles s'abonner. La spécification actuelle exige une nouvelle clé aléatoire pour chaque wrap, rendant cette prédiction impossible. La PR #2396 apporte le changement associé : les wraps d'une conversation donnée devraient être signés directement avec la clé de conversation, de sorte que la pubkey du wrap serve aussi d'identifiant de conversation. Ensemble, elles tracent une voie vers des conversations NIP-17 filtrables sans fuite de métadonnées. Toutes deux sont ouvertes et en discussion.
+
+### Ouvert : NIP-59 devrait faire rejeter les événements seal de kind 13 par le relay
+
+La [PR #2399](https://github.com/nostr-protocol/nips/pull/2399) propose que les relays rejettent les événements de kind 13, le seal interne d'un gift wrap [NIP-59](/fr/topics/nip-59/), lorsqu'ils apparaissent au premier niveau d'une demande de publication, car un événement seal n'a de sens qu'à l'intérieur d'un wrap et qu'un seal divulgué expose la pubkey du destinataire. L'[issue #2398](https://github.com/nostr-protocol/nips/issues/2398) associée va plus loin et soutient que le seal devrait être redéfini comme kind éphémère (les kinds éphémères de NIP-01 ne sont pas stockés par les relays), ce qui durcirait la règle au niveau du protocole et supprimerait la dépendance aux politiques propres à chaque relay.
+
+### Ouvert : états de groupe NIP-29
+
+La [PR #2372](https://github.com/nostr-protocol/nips/pull/2372) ajoute à [NIP-29](/fr/topics/nip-29/), les groupes fondés sur des relays, une sémantique explicite des états de groupe. Elle définit ce que signifie pour un groupe d'être ouvert, fermé, public, privé ou archivé, et comment les transitions d'état interagissent avec les événements de membre. La proposition fait entrer dans la spécification du relay des sémantiques auparavant propres aux clients.
+
+### Ouvert : prise en charge facultative de plusieurs mainteneurs dans NIP-34
+
+La [PR #2324](https://github.com/nostr-protocol/nips/pull/2324) accompagne la [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) fusionnée, dont la sémantique de fork GRASP-06 est présentée plus haut. Elle ajoute aux événements d'annonce de dépôt [NIP-34](/fr/topics/nip-34/) (`kind:30617`) la prise en charge facultative de plusieurs mainteneurs, permettant à un dépôt de déclarer plus d'une pubkey de mainteneur canonique par répétition de tags `maintainer`. Les patches et issues signés par tout mainteneur déclaré sont alors reconnus comme officiels par les clients, comblant une lacune ancienne : les dépôts NIP-34 à plusieurs mainteneurs doivent sinon tout faire passer par une seule pubkey ou revenir à une coordination hors protocole.
+
+### Ouvert : opérateur AND de NIP-91 pour les filtres, proposition ouverte et non fusionnée
+
+La [PR #2252](https://github.com/nostr-protocol/nips/pull/2252) propose un opérateur AND pour les [filtres](/fr/topics/nip-01/) Nostr, rouvrant une conception déjà abordée dans l'ancienne [PR #1365](https://github.com/nostr-protocol/nips/pull/1365), désormais fermée. Des implémentations existent déjà dans [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst) et worker-relay, mais la PR de spécification elle-même reste ouverte.
+
+### Fermé : quatre NIP commerciales de pats2sats
+
+Quatre propositions de commerce sur Nostr ont fermé cette semaine : Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), une Marketplace Listing Extension [NIP-99](/fr/topics/nip-99/) ([#2346](https://github.com/nostr-protocol/nips/pull/2346)) et un Accommodation Listing Profile ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). La même surface commerciale se consolide désormais dans la [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), un dépôt d'extensions propre au projet qui complète les annonces marketplace NIP-99 avec une sémantique de commandes, checkout, escrow et litiges. Compass suit maintenant ce dépôt aux côtés de Marmot et Blossom comme dépôt de spécification de protocole externe au dépôt des NIP ; ses PR ouvertes cette semaine comprennent une clarification de l'attribution client ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), un tag supersedes pour les changements d'identité d'un produit ([#8](https://github.com/GammaMarkets/market-spec/pull/8)) et la sémantique des évaluations de marchands ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Ouvert : liaison d'identités Bitcoin
+
+Deux propositions ont été ouvertes cette semaine pour lier identités Bitcoin et Nostr : une [adresse Bitcoin Silent Payment NIP-352](https://github.com/nostr-protocol/nips/pull/2392) et une [preuve de liaison d'identité Bitcoin-OTC](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## Analyse approfondie de NIP-86 (API de gestion des relays)
+
+[NIP-86](/fr/topics/nip-86/) définit une interface JSON-RPC de gestion des relays, permettant aux clients autorisés d'envoyer des commandes administratives aux relays par une API standardisée. Un client unique peut gérer tout relay compatible NIP-86 sans outillage propre à chacun. Deux fusions de spécification cette semaine, les [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) et [#2390](https://github.com/nostr-protocol/nips/pull/2390), ferment la boucle entre événements signés par le relay et administrateurs déclarés par celui-ci.
+
+### Le transport
+
+Une demande de gestion NIP-86 est un POST HTTP vers la même URI depuis laquelle le relay sert les connexions WebSocket, avec `Content-Type: application/nostr+json+rpc`. Le corps de la demande est un document JSON de la forme :
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+L'authentification utilise dans le header `Authorization` un événement signé d'authentification HTTP [NIP-98](/fr/topics/nip-98/). Avant d'exécuter la méthode, le relay vérifie que la pubkey signataire figure dans sa liste d'administrateurs. La réponse du relay est un document JSON de la forme :
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### Les méthodes qui existaient avant cette semaine
+
+L'ensemble de méthodes existant couvre le bannissement de pubkeys (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), le bannissement d'événements (`banevent`, `allowevent`, `listbannedevents`), les métadonnées du relay (`changerelayname`, `changerelaydescription`, `changerelayicon`), la gestion de la liste des kinds autorisés (`allowkind`, `disallowkind`, `listallowedkinds`) et une méthode `stats` qui renvoie les statistiques du relay. La forme reste intentionnellement proche d'un service JSON-RPC standard, afin qu'un client puisse y superposer des bindings typés.
+
+### Ce qui a changé cette semaine
+
+La [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) ajoute une méthode `signevent` à la spécification. Elle reçoit en argument un modèle d'événement partiel (kind, tags, content) et demande au relay de signer puis renvoyer un événement complet dont le champ `pubkey` contient sa propre pubkey. C'est le prérequis pour qu'un relay publie des événements de niveau protocolaire à son propre sujet : annonces de pubkeys bloquées, métadonnées du relay et nouvel événement Relay Roles ci-dessous exigent tous une signature avec la clé contrôlée par l'opérateur du relay, mais la plupart des opérateurs ne souhaitent pas conserver de clé privée dans leur client d'administration.
+
+La [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) définit un événement Relay Roles : un kind d'événement remplaçable paramétré publié par un relay, signé avec sa propre pubkey via `signevent`, qui déclare les pubkeys de ses administrateurs et modérateurs avec une sémantique explicite des rôles. Un client compatible NIP-86 peut récupérer l'événement Relay Roles de tout relay suivi, construire la liste d'administrateurs depuis ses tags et valider qu'une demande NIP-86 authentifiée vient d'un administrateur actuel sans confiance hors bande ni configuration propre au relay. Ensemble, les deux PR ferment la boucle : `signevent` est le mécanisme, Relay Roles le premier kind d'événement construit dessus.
+
+### Exemple de demande NIP-86
+
+Une demande `banpubkey` NIP-86 complète ressemble à ceci :
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+avec un header `Authorization` portant un événement NIP-98 signé :
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+La pubkey signataire doit figurer dans l'ensemble des administrateurs du relay, désormais déclaré dans l'événement relay-roles ; le tag `u` doit correspondre à l'URL HTTPS du relay ; le tag `payload` doit correspondre au SHA-256 du corps JSON de la demande. Le relay renvoie :
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implémentations
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) livre une interface de gestion de relay NIP-86 sur Android (v1.07.0+).
+- Les relays de référence qui implémentent la spécification comprennent [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru) et plusieurs implémentations plus petites liées depuis la section `Implementation Status` de la spécification.
+
+Les clients compatibles NIP-86 commenceront à traiter l'événement relay-roles comme source canonique de la liste d'administrateurs d'un relay, une fois que les implémenteurs auront adopté les changements `signevent` et Relay Roles.
+
+---
+
+## Analyse approfondie de NIP-89 (handlers d'application recommandés)
+
+[NIP-89](/fr/topics/nip-89/) définit deux kinds d'événements remplaçables paramétrés : `kind:31990`, le handler d'application publié par le développeur d'une app, et `kind:31989`, la recommandation qu'un utilisateur publie pour une app qu'il emploie. Ensemble, ils permettent aux clients de découvrir les applications qui savent traiter un kind d'événement inconnu sans coordination hors bande : un lecteur long-form qui rencontre un événement `kind:30030` qu'il ne traite pas nativement peut interroger le graphe NIP-89 à la recherche de handlers et proposer à l'utilisateur un flux « Open in... » vers une app publiée qui sait le faire. NIP-89 constitue l'infrastructure d'origine pour le même problème de routage entre apps que le travail napplet/napps visible dans tout ce numéro étend maintenant à des applets Nostr-native composables.
+
+### L'événement handler d'application (`kind:31990`)
+
+Le développeur d'une app publie un ou plusieurs événements handler décrivant les kinds d'événement pris en charge et la manière d'ouvrir une entité Nostr dans l'app :
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+Le tag `d` identifie le handler, afin qu'il puisse être remplacé ; chaque tag `k` déclare un kind d'événement géré par l'app ; et chaque tag de plateforme (`web`, `ios`, `android`, ...) fournit un modèle d'URL où `<bech32>` sert d'espace réservé pour une entité encodée selon [NIP-19](/fr/topics/nip-19/), que le client appelant substitue à l'ouverture. Un événement handler peut annoncer plusieurs kinds pris en charge lorsqu'ils partagent le même modèle de routage, ce qui garde la découverte des apps compacte et évite un événement handler par kind.
+
+### L'événement de recommandation utilisateur (`kind:31989`)
+
+Un utilisateur publie une recommandation déclarant les apps qu'il emploie pour un kind d'événement donné :
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+Le tag `d` porte le kind d'événement recommandé. Chaque tag `a` est un pointeur d'adresse NIP-01 vers un événement handler de `kind:31990`, avec le relay suggéré et la plateforme concernée. Une même recommandation peut répertorier plusieurs apps pour différentes plateformes.
+
+### Le tag client et le compromis de confidentialité
+
+NIP-89 définit aussi un tag `client` facultatif que toute app de publication peut joindre aux événements qu'elle crée :
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Cela permet à tout client affichant l'événement de faire apparaître l'app d'origine, de récupérer des métadonnées de handler plus riches et de respecter les indications de rendu déclarées par le handler. La spécification signale aussi explicitement le coût en matière de confidentialité : un client qui émet un tag `client` sur chaque événement publie l'identité du logiciel de l'utilisateur, ce qui révèle avec le temps ses habitudes d'utilisation. Elle recommande aux clients de proposer une option de désactivation.
+
+La [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) d'Amethyst analyse et affiche les tags NIP-89 `t`, `i`, `a` et `client` lors de l'affichage des événements, montrant directement dans la timeline quelle app a créé une note.
+
+### Fonctionnement pratique du flux de découverte
+
+Un client qui reçoit un kind d'événement inconnu suit les étapes suivantes. (1) Interroger le graphe de follows de l'utilisateur à la recherche d'événements `kind:31989` dont le tag `d` correspond au kind d'événement. (2) Résoudre chaque tag `a` recommandé vers son événement handler `kind:31990`. (3) Choisir le handler dont le modèle d'URL `web`, `ios` ou `android` correspond à la plateforme actuelle. (4) Substituer l'encodage `bech32` de l'entité dans le modèle d'URL. (5) Proposer l'URL obtenue à l'utilisateur comme choix « Open in... ». Le flux est filtré socialement : un client qui interrogerait des événements handler arbitraires sur des relays non fiables pourrait rediriger les utilisateurs vers des apps malveillantes ; commencer par les personnes suivies par l'utilisateur est donc un choix par défaut plus sûr que de considérer comme également fiable chaque handler publié.
+
+### NIP-89 et la couche napplet
+
+La section Discover d'Amethyst, le runtime hôte de napplets et l'affichage du tag `client` construisent ensemble une surface complète de consommation de NIP-89 sur Android. La spécification napplet, lancée dans le dernier numéro, étend ce que peuvent cibler ces événements handler NIP-89 : des applets sandboxées qui exécutent un runtime Nostr-native composable sur Nostr et Blossom. NIP-89 est le graphe de découverte et de routage ; le runtime napplet constitue l'une des cibles d'exécution vers lesquelles il peut pointer.
+
+---
+
+*Retours, corrections et projets que nous avons manqués : ouvrez une issue sur [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) ou contactez-nous par DM NIP-17 à npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/it/newsletters/2026-07-01-newsletter.md
+++ b/content/it/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,372 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+Bentornati su Nostr Compass, la vostra guida settimanale a Nostr.
+
+**Questa settimana:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) introduce un trasporto sulla mixnet Nym, la scoperta mDNS facoltativa sulla LAN, il rekey senza interruzioni in caso di perdita di pacchetti e una revisione del data plane, mantenendo la compatibilità wire con v0.3.0. [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) emerge come client Marmot desktop in Rust e Slint, con una proposta di protocollo per spostare gli effetti dei messaggi in un evento kind 9 dedicato. [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) debutta come cassaforte mobile per identità protetta dall'hardware, che opera da signer remoto NIP-46 e risponde tramite NFC alle richieste di accesso fisico. [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) inaugura la condivisione peer-to-peer di nsite sulla mesh FIPS con un nuovo trasporto BLE L2CAP nella v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) debutta come superficie di controllo Android per un assistente di programmazione Codex locale, raggiunto tramite DM Nostr cifrati. [Il ramo non ancora rilasciato di Amethyst](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) aggiunge il parsing degli application handler NIP-89, un feed Git Repositories per NIP-34 e una sezione Discover per nSite e napplet. [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) implementa NIP-37, NIP-52 e NIP-22 in una sola settimana. [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) pubblica 12 release coordinate dei suoi sottopacchetti, con helper nbunksec per NIP-46 e un aggiornamento del wallet a Cashu-ts v4. [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) introduce Shared-Key Collaborative Lists su eventi indirizzabili kind 35000. Il repository NIPs ha integrato cinque PR, fra cui un evento Relay Roles, la rimozione del limite di 65.535 byte di NIP-44, la semantica dei fork di NIP-34, i metadati client di NIP-46 e un metodo `signevent` per NIP-86. Gli approfondimenti riguardano [NIP-86 (API di gestione dei relay)](#nip-deep-dive-nip-86-relay-management-api) e [NIP-89 (application handler consigliati)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Storie principali
+
+### FIPS v0.4.0 introduce il trasporto sulla mixnet Nym, la scoperta mDNS e una revisione del data plane
+
+[FIPS](https://github.com/jmcorgan/fips) è una rete mesh peer-to-peer privata e auto-organizzata per Nostr, nella quale i nodi si scoprono e instradano il traffico senza infrastruttura centrale. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) porta un trasporto sulla mixnet Nym, la scoperta mDNS facoltativa sulla LAN, una revisione del data plane, il rekey senza interruzioni in caso di perdita di pacchetti, una TUI `fipstop` riscritta su un harness di snapshot del rendering, un piano di osservabilità fuori dall'hot path e nuovi target di packaging apk per OpenWrt e flake per Nix. Tutto resta compatibile a livello wire con v0.3.0, così le mesh miste continuano a interoperare durante un aggiornamento progressivo. Due nuovi trasporti per la scoperta dei peer sono al centro della release. Un nuovo [trasporto in uscita sulla mixnet Nym](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) instrada il traffico FIPS attraverso un proxy SOCKS5 `nym-socks5-client`, mescolandolo nella rete di cover traffic di [Nym](https://nymtech.net/) affinché gli osservatori a livello di collegamento non possano correlare quali peer della mesh stiano comunicando; un esempio `examples/sidecar-nostr-mixnet-relay` mostra come esporre un relay Nostr locale attraverso quel percorso. Sulla LAN, la nuova scoperta mDNS è esplicitamente facoltativa e pubblicizza solo un identificatore di nodo e una porta, senza chiavi o metadati dell'utente.
+
+Il data plane è stato rielaborato per aumentare il throughput di un singolo nodo. La cifratura e la decifratura per peer ora vengono eseguite da task worker dedicati fuori dal ciclo di ricezione, così un peer molto attivo non può serializzare la crittografia dell'intero nodo. Il percorso di invio Linux usa generic segmentation offload e, dove disponibile, un socket UDP connesso; l'hot path di ricezione evita le copie dei buffer effettuate in precedenza per ogni pacchetto, mentre macOS riceve una modalità di ricezione in batch `recvmsg_x` analoga al batching Linux `recvmmsg` introdotto nella v0.3.0. L'intera superficie di lettura `show_*` per `fipsctl` e `fipstop` ora viene servita da uno snapshot per tick, pubblicato in un `ArcSwap` lock-free dal task che accetta le connessioni di controllo, così le richieste degli operatori ricevono risposta rapidamente anche quando il ciclo di ricezione del nodo è occupato. Una nuova query `show_metrics` di soli contatori, esposta come `fipsctl stats metrics`, consente lo scraping Prometheus senza costi sull'hot path.
+
+Il rekey delle sessioni FMP e FSP ora avviene senza interruzioni in presenza di perdita e riordinamento dei pacchetti in entrambe le direzioni: i frame in ingresso vengono autenticati rispetto alla sessione in attesa prima che il passaggio con K-bit la promuova, così un frame obsoleto o contraffatto non può mandare fuori strada il rekey; la ritrasmissione del messaggio 1 del rekey è limitata, l'heartbeat che rileva un collegamento interrotto tiene conto del rekey e le corse dovute all'avvio simultaneo su collegamenti ad alta latenza vengono desincronizzate con jitter simmetrico. La TUI `fipstop` è stata ricostruita su un harness di snapshot del rendering che verifica l'esatta griglia di testo e lo stile di ogni cella per ciascuna vista, usando output predefiniti del socket di controllo. Arrivano anche nuovi target di packaging: un `.apk` per OpenWrt 25+ costruito senza SDK, riutilizzando la cross-compilazione `.ipk` esistente e il payload del filesystem installato, e un `flake.nix` nella radice del progetto che compila dal sorgente tutti e quattro i binari (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) su Nix/NixOS con la toolchain fissata.
+
+### Whitenoise Linux emerge come client Marmot desktop
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) è un client [Marmot](/it/topics/marmot/) desktop: messaggistica di gruppo MLS su relay Nostr, distribuita come singolo binario Rust con un'interfaccia Slint che conserva ogni segreto in una cassaforte cifrata con password.
+
+Il filone più rilevante di questa settimana propone di trasportare gli effetti dei messaggi Whitenoise come eventi kind 9 dedicati che fanno riferimento al messaggio padre. L'attuale formato wire aggiunge alla fine del corpo un marcatore come `dmfx:sparkle`, sporcando il testo per qualsiasi renderer che non conosca questa convenzione. Spostare gli effetti in eventi propri mantiene pulito il testo dei messaggi e apre una questione progettuale che l'intero stack Marmot dovrà affrontare: convenzioni inline nel corpo oppure eventi sidecar per le funzionalità avanzate facoltative.
+
+### CustID debutta come cassaforte mobile per identità con NIP-46 e richieste via NFC
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) è la prima beta pubblica di CustID, una cassaforte mobile per identità costruita su Nostr e sul protocollo SISTR. CustID memorizza più identità Nostr in un archivio sicuro protetto dall'hardware, opera come signer remoto [NIP-46](/it/topics/nip-46/) per altri client e risponde a richieste di accesso fisiche e online tramite NFC e codici QR.
+
+La beta è completa nelle funzionalità del signer NIP-46 e del flusso challenge-response NFC; i flussi di accesso basati su zero-knowledge proof restano un traguardo futuro. Questa release elimina inoltre il livello keep-alive [NIP-65](/it/topics/nip-65/) in background dell'app, che apriva un WebSocket per profilo per ciascun relay di lettura e acquisiva kind poi scartati immediatamente dal client. Ora restano attivi in background soltanto i socket NIP-46 che trasportano le notifiche delle richieste di firma: è la correzione che rende praticabile l'uso di CustID come bunker per altri client su un telefono.
+
+### myco inaugura la condivisione peer-to-peer di nsite sulla mesh FIPS
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) è comparso questa settimana, il 27 giugno, e ha raggiunto v0.1.0 il 1° luglio. myco è un'app Android in Rust che installa applicazioni provenienti dalle persone vicine: condivisione peer-to-peer di [nsite](/it/topics/nip-5a/) su una mesh FIPS, attraverso qualsiasi trasporto supportato dalla mesh (UDP, TCP, Tor, Bluetooth), funzionante interamente offline. Il progetto abbina direttamente FIPS come substrato di trasporto al formato di eventi per siti web statici di NIP-5A come payload, consentendo a un'app distribuita come nsite di spostarsi fra peer della mesh senza dipendere da relay o HTTP.
+
+La v0.1.0 aggiunge un percorso radio Bluetooth L2CAP, così due telefoni con FIPS installato possono collegarsi in peer tramite BLE senza alcuna rete, oltre a uno speedtest per peer e alla condivisione attivata via NFC dal bottom sheet Circle dell'app. myco è pubblicato anche su Zapstore per l'installazione diretta.
+
+### Nostr Codex Phone debutta come superficie di controllo mobile per un worker Codex locale tramite Nostr
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) debutta questa settimana come client Android che controlla un worker locale dell'assistente di programmazione Codex tramite messaggi diretti Nostr cifrati. L'app supporta più sessioni di repository, trascrizione vocale, sessioni worker instradate, upload di media su Blossom e risposte vocali facoltative, così uno sviluppatore che esegue un worker Codex a casa può inviare richieste dal telefono ovunque questo abbia accesso ai relay.
+
+Il progetto è un diretto parente di [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), presentato nel numero 28. Entrambi portano su un trasporto Nostr i flussi di programmazione agentica con DM cifrati ed entrambi usano Nostr come livello di associazione e messaggistica che permette a un telefono di raggiungere un worker domestico senza aprire varchi nella rete. L'uso di Nostr come control plane per agenti locali sta diventando uno schema consolidato.
+
+### Coop Mobile pubblica le sue prime build con versione
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) e [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) sono uscite questa settimana come prime build con versione di Coop Mobile, un client Android per messaggi diretti cifrati [NIP-17](/it/topics/nip-17/). Le due release migliorano la sicurezza contro i crash durante il parsing dei messaggi e la gestione dei QR e cancellano tutti i dati memorizzati al logout.
+
+### Amethyst sviluppa un'interfaccia consapevole di NIP-89, un feed Git Repositories e una sezione Discover per napplet
+
+Il ramo principale di [Amethyst](https://github.com/vitorpamplona/amethyst) ha sviluppato diverse nuove superfici questa settimana. Un [feed Git Repositories](https://github.com/vitorpamplona/amethyst/pull/3406) trasforma i repository [NIP-34](/it/topics/nip-34/) in una categoria consultabile della timeline Android, filtrabile per community e autore, abbinata a un [browser git smart-HTTP](https://github.com/vitorpamplona/amethyst/pull/3415) che legge contenuti e commit dei repository senza uscire dall'app. L'host per napplet ha ricevuto una [sezione Discover](https://github.com/vitorpamplona/amethyst/pull/3409) che elenca web app curate insieme agli nSite e ai napplet seguiti, ricavati dagli eventi handler [NIP-89](/it/topics/nip-89/) e dagli eventi site [NIP-5A](/it/topics/nip-5a/). La visualizzazione delle note ora [rivela quale app Nostr ha creato un evento](https://github.com/vitorpamplona/amethyst/pull/3422) tramite i tag NIP-89. Sul fronte della sincronizzazione arriva il [supporto alla negentropy NIP-77](https://github.com/vitorpamplona/amethyst/pull/3434), con riconciliazione in streaming e finestre `created_at` automatiche per aggirare i limiti ai risultati imposti dai relay, riducendo la banda necessaria a mantenere sincronizzati con un relay grandi insiemi locali di eventi.
+
+### Buzz v0.3.38 irrobustisce la superficie di attacco dei relay e aggiunge la selezione dei modelli indipendente dal provider
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) irrobustisce la [superficie di attacco dei relay](https://github.com/block/buzz/pull/1369) esposta da Buzz quando pubblica persona, team, agenti gestiti e attestazioni dei proprietari NIP-OA come eventi Nostr firmati. Un relay Buzz è un registro pubblico delle identità Nostr del team e del loro stato; questa release rafforza la validazione degli input e la protezione dai replay sui kind di evento ben noti definiti da Buzz. La release generalizza inoltre la selezione dei modelli, così un team Buzz può scegliere qualsiasi provider per cui Buzz disponga di adapter, incluso un nuovo backend Databricks AI Gateway v2.
+
+### Notedeck implementa relay di sincronizzazione privata NIP-37, calendario NIP-52 e commenti NIP-22
+
+[Notedeck](https://github.com/damus-io/notedeck), il client desktop nativo in Rust del team Damus, ha implementato tre protocolli in una sola settimana. I relay di sincronizzazione privata ora vengono memorizzati come lista kind `10013` [NIP-37](/it/topics/nip-37/), separando l'insieme di relay per contenuti privati dell'utente dall'outbox pubblica NIP-65. Il pannello calendario `horizon` legge eventi [NIP-52](/it/topics/nip-52/) da nostrdb e ha ricevuto una nuova disposizione a tre riquadri. Il pannello `headway` ha aggiunto un modello di eventi commento [NIP-22](/it/topics/nip-22/) su kind `1111`, il kind definito da NIP-22 per la superficie unificata dei commenti che sostituisce il concatenamento delle risposte NIP-10.
+
+
+
+### Applesauce introduce sessioni NIP-46 nbunksec e aggiorna il wallet a Cashu v4
+
+[Applesauce](https://github.com/hzrd149/applesauce), il toolkit modulare Nostr per signer, relay, wallet e contenuti, ha pubblicato una serie coordinata di [release 6.2.x](https://github.com/hzrd149/applesauce/releases) nei suoi sottopacchetti. Il pacchetto signers ha ricevuto helper per importare ed esportare `nbunksec`, trattando una sessione bunker [NIP-46](/it/topics/nip-46/) come un artefatto portabile che può spostarsi fra client. Il pacchetto wallet ha aggiornato i binding [Cashu](/it/topics/nip-60/) a `@cashu/cashu-ts` v4, dove gli importi delle proof diventano value object `Amount` e cambia l'API di decodifica dei token.
+
+---
+
+## Release con tag
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) introduce la successiva iterazione del protocollo per la rete [Mostro](/it/topics/nip-69/) di scambio P2P di valuta fiat. La release segue [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) ed esce insieme a [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), che adotta il nuovo core. Questa settimana sono state integrate tre PR nel repository core; lo stack circostante, mostro daemon e Mostro mobile, si allinea alla v0.14.0 del crate di tipi condivisi.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), la CLI canonica per git su Nostr nei repository [NIP-34](/it/topics/nip-34/), implementa la [semantica dei fork GRASP-06 di NIP-34](https://github.com/nostr-protocol/nips/pull/2395) integrata questa settimana, che sostituisce il tag `personal-fork` con un tag `u` negli eventi repo-state.
+
+### mesh-llm v0.72.0 e v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), il componente di inferenza dello stack ContextVM che esegue LLM open source dietro una superficie JSON-RPC indirizzabile via Nostr, ha pubblicato [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) e [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1), con una correzione per un crash del batching su singoli prompt di grandi dimensioni e una migrazione del bridge MCP che abbandona helper deprecati.
+
+### Meiso v1.4.0 introduce Shared-Key Collaborative Lists che sostituiscono MLS per la condivisione dei task
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) introduce un modello Shared-Key Collaborative Lists che sostituisce la precedente condivisione dei task basata su MLS con un design più semplice di eventi indirizzabili. Ogni lista condivisa genera una chiave Nostr dedicata distribuita ai membri; i task sono eventi indirizzabili kind `35000`, identificati da `d=task-id`, con contenuto auto-cifrato tramite [NIP-44](/it/topics/nip-44/), mentre i relay applicano Last-Write-Wins per ciascun task. Il design rinuncia alla forward secrecy e alla sicurezza post-compromissione di MLS in cambio di un'implementazione più semplice nei client e della risoluzione dei conflitti a livello di relay.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) introduce un filone "more-private-coordinator" che rimuove le pubkey effimere dei mittenti dalla pubblicazione dei messaggi di gruppo e irrobustisce il flusso delle richieste di ingresso contro nuove richieste obsolete. Cordn è lo stack di messaggistica basato su MLS presentato nel [lancio del CVM ad hoc di Cordn nel numero 28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); questa release è il corrispondente aggiornamento lato coordinatore.
+
+---
+
+## Modifiche non ancora rilasciate
+
+### diVine integra 108 PR di rifiniture successive al lancio
+
+[diVine](https://github.com/divinevideo/divine-mobile), il client per brevi video in loop che riporta in vita Vine, attraversa un'intensa fase di rifinitura successiva al lancio. Il lavoro visibile su Nostr questa settimana consiste in un passaggio di stabilizzazione del flusso di connessione [NIP-46](/it/topics/nip-46/), che migra gli errori `nostrconnect://` verso codici di motivo strutturati.
+
+### Zap Cooking prosegue la correzione NIP-46 trasversale ai progetti e la revisione del compositore
+
+[Zap Cooking](https://github.com/zapcooking/frontend) è un client Nostr per condividere ricette, pubblicate come eventi Nostr long-form. Il lavoro di questa settimana prosegue la correzione [NIP-46](/it/topics/nip-46/) trasversale ai progetti e la revisione del compositore descritte fra le modifiche non ancora rilasciate nel [numero 28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes).
+
+### Conduit irrobustisce il flusso degli annunci e la correttezza del marketplace
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) è un monorepo di marketplace su Nostr composto da tre app: mercato per acquirenti, portale per commercianti e generatore di negozi. Il lavoro di questa settimana prosegue la spinta sulla correttezza del marketplace descritta nella [copertura del lancio nel numero 28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default), sulla scia dell'ondata commerciale [NIP-99](/it/topics/nip-99/) che ha costituito la storia di protocollo dello scorso numero.
+
+### Pollerama dalla v1.12 alla v1.13.1 aggiunge la scelta del client tag, schede del profilo e limiti ai thread
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), un client Nostr Android incentrato su sondaggi e note con un forte livello di scoperta basato sul web of trust, ha pubblicato questa settimana su Zapstore v1.12.0, v1.13.0 e v1.13.1. Ora gli utenti possono scegliere quale client tag allegare alle note e ai sondaggi che creano, selezionandolo da un elenco predefinito o inserendone uno proprio. Le catene di commenti e risposte molto annidate si interrompono ora dopo pochi livelli e rimandano al thread completo nella pagina della nota. Le pagine dei profili si aprono per impostazione predefinita su Notes, suddivise nelle schede Posts e Conversations. È stato corretto un bug di persistenza dei follow, per cui gli account appena seguiti scomparivano al riavvio dell'app, e i pulsanti di follow ora mostrano l'avanzamento.
+
+### getwired.app e get-tao.app correggono il flusso di invio confess di NIP-13
+
+[getwired.app](https://github.com/smolgrrr/Wired) e [get-tao.app](https://github.com/smolgrrr/TAO), che condividono un flusso di pubblicazione anonima che aggiunge proof-of-work NIP-13 al momento dell'invio per limitare lo spam, hanno corretto il [flusso di invio confess](https://github.com/smolgrrr/Wired/pull/57) affinché l'esperienza utente durante il mining PoW sia coerente.
+
+### nostui aggiunge una scheda della timeline delle menzioni
+
+[nostui](https://github.com/akiomik/nostui), un client Nostr da terminale in Rust, ha aggiunto una [scheda della timeline delle menzioni](https://github.com/akiomik/nostui/pull/463) che presenta in una vista TUI dedicata gli eventi kind 1 che taggano la pubkey attiva.
+
+### Heartwood introduce URI bunker NIP-46 per identità e un bridge di firma in modalità HSM
+
+[Heartwood](https://github.com/forgesworn/heartwood) è un signer [NIP-46](/it/topics/nip-46/) nel quale la chiave di firma non raggiunge mai il client: quest'ultimo comunica tramite NIP-46 con un piccolo relay, che a sua volta usa un protocollo di frame seriali per parlare con un dispositivo hardware collegato ed eseguire la firma. Questa settimana il progetto ha integrato un [bridge di firma da relay a seriale](https://github.com/forgesworn/heartwood/pull/11) e [connessioni bunker per identità](https://github.com/forgesworn/heartwood/pull/16), così un singolo dispositivo hardware che custodisce più identità espone un URI bunker distinto per ciascuna.
+
+### Refactoring dell'autenticazione e dei signer di Nostter
+
+Questa settimana [Nostter](https://github.com/SnowCait/nostter) ha rielaborato il proprio [livello di autenticazione e signer](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth), spostando lo stato di login su un unico signal ed estraendo il dispatch del signer in moduli di strategia. La direzione è un'astrazione pulita del signer, nella quale estensione web NIP-07, bunker remoto NIP-46 e nsec grezzo condividono un solo percorso di codice.
+
+### Dart NDK estrae il signer NIP-07 e randomizza i timestamp NIP-59
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) ha spostato il signer [NIP-07](/it/topics/nip-07/) fuori dal pacchetto core e dentro `ndk_flutter`, dove risiede la WebView Flutter, e ha [randomizzato i timestamp dei gift wrap NIP-59](https://github.com/relaystr/dart_ndk/pull/667) per rafforzare la protezione contro la correlazione temporale dei messaggi cifrati.
+
+### Milk Market aggiunge pagine vetrina NIP-23 e pagamenti tramite Square
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), la vetrina marketplace del team Shopstr, ha dotato ogni negozio di una pagina blog basata sugli eventi long-form [NIP-23](/it/topics/nip-23/) del venditore, con sezioni modificabili e una route diretta per le impostazioni del blog. Nella stessa settimana ha aggiunto [Square](https://github.com/shopstr-eng/milk-market/pull/30) come processore di pagamenti alternativo per i venditori e l'acquisto automatico delle etichette di spedizione per gli ordini pagati.
+
+### Calendar by Formstr pubblica un'app iOS
+
+Questa settimana [Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) ha integrato la [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159), portando su iOS il client calendario [NIP-52](/it/topics/nip-52/). La [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) corregge il parsing delle date del calendario nell'ora locale e la [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) aggiunge un flusso E2E Playwright attivato da un'etichetta `run-tests`.
+
+### cagliostr applica NIP-22, NIP-09 per coordinate e proof-of-work NIP-13
+
+[cagliostr](https://github.com/mattn/cagliostr), un'implementazione di relay in Go, ha rafforzato questa settimana tre percorsi di applicazione delle regole: [proof-of-work NIP-13 configurabile](https://github.com/mattn/cagliostr/pull/7) sugli eventi in ingresso, [eliminazione NIP-09 per coordinate indirizzabili](https://github.com/mattn/cagliostr/pull/8), così gli eventi sostituibili possono essere eliminati tramite il loro tag `a`, cosa impossibile con la sola eliminazione per id evento, e [limiti temporali NIP-22 configurabili](https://github.com/mattn/cagliostr/pull/9), che rifiutano eventi datati troppo nel passato o nel futuro.
+
+---
+
+## Nuovi progetti monitorati e scoperti
+
+La [suite per il benessere Vanderwarker](https://git.vanderwarker.family/wellbeing) pubblica telemetria del mondo fisico come eventi Nostr tramite una chiave di firma condivisa del publisher. Comprende cinque app collegate: [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) è un contapassi che registra dati di fitness su Nostr come `kind:30078`; [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) pubblica ogni giorno il numero di sblocchi del telefono; [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) pubblica la riproduzione multimediale corrente come User Status; [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) pubblica ogni 15 minuti livello, tensione e temperatura della batteria; [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) pubblica il consumo giornaliero di dati. Tutte e cinque sono apparse su Zapstore fra il 24 e il 30 giugno.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) è un'app Android serverless per la condivisione cifrata della posizione in tempo reale, realizzata in Rust e Slint e pubblicata il 29 giugno. È un progetto collegato a [Haven](https://github.com/mehmetefeumit/Haven-App), il sistema di condivisione della posizione basato su [Marmot](/it/topics/marmot/) descritto nel [numero 28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), ma usa un'architettura di trasporto diversa: gli aggiornamenti della posizione viaggiano in DM Nostr cifrati, mentre Haven usa messaggi di gruppo Marmot.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) è uno scaffold iniziale di shell applicativa per costruire app Nostr. Questa settimana il progetto ha pubblicato la sua prima documentazione rivolta agli utenti.
+
+[NIPs by Pollerama](https://nips.pollerama.fun), repository [abh3po/better-nips](https://github.com/abh3po/better-nips) creato il 2026-06-29, è un nuovo client per i NIP `kind:30817` scritti dalla community di [NostrHub](https://nostrhub.io), proposto come superficie alternativa a nostrhub.io con ponderazione basata sulla fiducia. Ogni NIP `kind:30817` ha un proprio URL condivisibile (`#/nip/<naddr>`), con rendering Markdown completo e i kind di evento che definisce. Il client offre tre feed, Following, Web of Trust (follow dei follow) e Global, ciascuno ordinabile per approvazioni ponderate in base alla fiducia o per data. Le approvazioni vengono pubblicate come label [NIP-32](/it/topics/nip-32/) su kind `1985`, con i tag `["L","nostrhub"]` e `["l","approve","nostrhub"]`, oltre a un tag `a` che punta all'indirizzo del NIP obiettivo e a un tag `client` che dichiara `better-nips`. È esattamente la forma di evento firmata dallo stesso NostrHub, così le approvazioni sono compatibili fra i due client. L'approvazione di un follow diretto pesa nella classifica più di quella proveniente da un follow di secondo grado.
+
+Lo stack di firma è [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer), con una finestra di login completa che comprende signer [NIP-07](/it/topics/nip-07/), bunker e nostrconnect [NIP-46](/it/topics/nip-46/), ncryptsec [NIP-49](/it/topics/nip-49/) e signer Android [NIP-55](/it/topics/nip-55/); le sessioni si ricollegano silenziosamente al ricaricamento. Il livello di rete passa attraverso [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), un Web Worker che suddivide l'outbox [NIP-65](/it/topics/nip-65/) dell'utente fra i relay, impedendo che un grande insieme web of trust venga inoltrato in massa a un singolo relay. La posizione progettuale è che i NIP della community, ospitati da NostrHub, in `better-nips` o da altri client futuri, siano tutti uguali a livello di protocollo; la classifica deriva dal grafo sociale, non dalla selezione dei moderatori, collegandosi direttamente al flusso di labeling NIP-32 esaminato nell'approfondimento del [numero 25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling).
+
+Questa settimana sono comparsi due nuovi cluster di repository [NIP-34](/it/topics/nip-34/). [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) è un client Nostr incentrato sui video, mentre un [cluster nostrapps.com](wss://gitnostr.com) pubblica tre progetti collegati: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git), una VM per napp desktop; [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git), un client personalizzabile per community; e [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git), una specifica e runtime per microapp HTML. Il cluster si colloca in parallelo al lavoro sui [napplet](/it/topics/nip-5d/) trattato nella storia principale dello scorso numero.
+
+---
+
+## Lavoro sul protocollo e aggiornamenti dei NIP
+
+### Integrata: NIP-44 elimina il limite di payload di 65.535 byte
+
+La [PR #1907](https://github.com/nostr-protocol/nips/pull/1907) è stata integrata il 28 giugno dopo essere rimasta aperta dal 2024-09. La modifica rimuove il limite massimo di 65.535 byte per il payload in chiaro di un envelope di cifratura versionata [NIP-44](/it/topics/nip-44/), portandolo a un massimo di 4 GiB (`uint32_max`). NIP-44 codifica la lunghezza del payload come `uint16` nel formato wire, requisito imposto rigidamente dalla specifica originale per l'interoperabilità; la modifica integrata adotta un campo di lunghezza maggiore indicato nel byte di versione, così le implementazioni v2 restano compatibili a livello wire e quelle v3+ trasportano la lunghezza estesa. I client che usano NIP-44 per messaggi diretti [NIP-17](/it/topics/nip-17/), gift wrap [NIP-59](/it/topics/nip-59/), payload dei signer remoti [NIP-46](/it/topics/nip-46/) o qualsiasi altro messaggio Nostr cifrato con NIP-44 possono ora scambiare singoli eventi più grandi di 64 KiB senza suddividerli a livello applicativo.
+
+### Integrate: NIP-86 riceve un metodo signevent e un evento Relay Roles
+
+La [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) aggiunge un metodo `signevent` all'API JSON-RPC di gestione dei relay [NIP-86](/it/topics/nip-86/), permettendo a un amministratore di chiedere al relay di firmare un evento con la pubkey del relay stesso. La [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) associata definisce un evento Relay Roles: un evento sostituibile pubblicato dal relay per dichiarare i propri amministratori e moderatori. Insieme consentono ai client NIP-86 di ricavare l'elenco degli amministratori di un relay e verificare che una richiesta autenticata provenga da un amministratore corrente, senza fiducia fuori banda. Entrambe le modifiche sono approfondite più avanti.
+
+### Integrata: NIP-34 sostituisce personal-fork con `u` per GRASP-06
+
+La [PR #2395](https://github.com/nostr-protocol/nips/pull/2395), integrata il 24 giugno, sostituisce il tag `personal-fork` di [NIP-34](/it/topics/nip-34/) negli eventi repo-state (`kind:30618`) con un tag `u`, per "upstream", allineando il formato wire alla semantica dei fork GRASP-06 implementata dalla suite GitWorkshop. La modifica chiude la [PR #2384](https://github.com/nostr-protocol/nips/pull/2384), `NIP-34: remove maintainers to solve expiry issues`, che proponeva una diversa correzione alla semantica dei fork. La direzione integrata è quella implementata da ngit v2.6.x, quindi specifica e CLI di riferimento sono ora allineate. I repository esistenti che usano `personal-fork` continuano a interoperare; i nuovi repository e la linea ngit v2.6 pubblicano il tag `u`.
+
+### Integrati: metadati client NIP-46, ora upstream dopo l'implementazione in Amber
+
+La [PR #2381](https://github.com/nostr-protocol/nips/pull/2381), integrata il 23 giugno, aggiunge metadati client facoltativi alla richiesta `connect` di [NIP-46](/it/topics/nip-46/), consentendo a un client di pubblicare nome, URL dell'icona e URL della homepage durante la connessione al signer. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) ha introdotto l'estensione dei metadati la scorsa settimana, come descritto nel [numero 28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata); questa settimana il NIP upstream raggiunge l'implementazione già distribuita.
+
+### Aperte: chiavi wrapper NIP-17 deterministiche basate su epoche
+
+La [PR #2397](https://github.com/nostr-protocol/nips/pull/2397) e la [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) riguardano due proposte convergenti per le chiavi di wrapping NIP-17. La PR #2397 propone che la chiave di firma effimera usata per creare un gift wrap [NIP-59](/it/topics/nip-59/) sia derivata in modo deterministico da un seed per conversazione, legato a un'epoca temporale approssimativa, così un destinatario che conosce la chiave della conversazione può prevedere a quali pubkey sottoscriversi. La specifica attuale richiede una nuova chiave casuale per ogni wrap, rendendo impossibile tale previsione. La PR #2396 è la modifica complementare: i wrap di una determinata conversazione dovrebbero essere firmati direttamente con la chiave della conversazione, così la pubkey del wrap funge anche da identificatore della conversazione. Insieme definiscono un percorso verso conversazioni NIP-17 filtrabili senza perdita di metadati. Entrambe sono aperte e in discussione.
+
+### Aperta: NIP-59 dovrebbe far rifiutare ai relay gli eventi seal kind 13
+
+La [PR #2399](https://github.com/nostr-protocol/nips/pull/2399) propone che i relay rifiutino gli eventi kind 13, il seal interno di un gift wrap [NIP-59](/it/topics/nip-59/), quando compaiono al livello superiore di una richiesta di pubblicazione, perché un evento seal ha senso soltanto dentro un wrap e un seal esposto rivela la pubkey del destinatario. La [issue #2398](https://github.com/nostr-protocol/nips/issues/2398) associata va oltre e sostiene che il seal dovrebbe essere ridefinito come kind effimero, poiché i kind effimeri NIP-01 non vengono memorizzati dai relay; ciò irrobustirebbe la regola a livello di protocollo ed eliminerebbe la dipendenza dalle policy dei singoli relay.
+
+### Aperta: stati dei gruppi NIP-29
+
+La [PR #2372](https://github.com/nostr-protocol/nips/pull/2372) aggiunge una semantica esplicita degli stati dei gruppi a [NIP-29](/it/topics/nip-29/), dedicato ai gruppi basati su relay, definendo cosa significhi che un gruppo sia aperto, chiuso, pubblico, privato o archiviato e come le transizioni di stato interagiscano con gli eventi dei membri. La proposta porta nella specifica del relay una semantica finora specifica dei singoli client.
+
+### Aperta: supporto facoltativo per più maintainer in NIP-34
+
+La [PR #2324](https://github.com/nostr-protocol/nips/pull/2324) è la proposta complementare alla [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) integrata, relativa alla semantica dei fork GRASP-06 trattata sopra. La PR #2324 aggiunge il supporto facoltativo per più maintainer agli eventi di annuncio dei repository [NIP-34](/it/topics/nip-34/) (`kind:30617`), permettendo a un repository di dichiarare più di una pubkey di maintainer canonico tramite tag `maintainer` ripetuti. Patch e issue firmate da qualsiasi maintainer dichiarato vengono quindi considerate ufficiali dai client, colmando la lacuna storica per cui i repository NIP-34 con più maintainer devono convogliare tutto attraverso una pubkey oppure ricorrere al coordinamento fuori protocollo.
+
+### Aperta: operatore AND di NIP-91 per i filtri, la proposta non è integrata
+
+La [PR #2252](https://github.com/nostr-protocol/nips/pull/2252) propone un operatore AND per i [filtri](/it/topics/nip-01/) Nostr, riaprendo un progetto discusso per la prima volta nella precedente [PR #1365](https://github.com/nostr-protocol/nips/pull/1365), poi chiusa. Esistono già implementazioni in [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst) e worker-relay, ma la PR della specifica resta aperta.
+
+### Chiuse: quattro NIP commerciali di pats2sats
+
+Questa settimana sono state chiuse quattro proposte per il commercio su Nostr: Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), una Marketplace Listing Extension [NIP-99](/it/topics/nip-99/) ([#2346](https://github.com/nostr-protocol/nips/pull/2346)) e un Accommodation Listing Profile ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). La stessa superficie commerciale viene ora consolidata nella [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), un repository di estensioni di proprietà del progetto costruito sugli annunci marketplace NIP-99, con semantica per ordini, checkout, escrow e controversie. Compass ora monitora questo repository insieme a Marmot e Blossom come repository di specifiche di protocollo esterno allo stesso repository NIPs; le PR aperte questa settimana comprendono chiarimenti sull'attribuzione del client ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), un tag supersedes per le modifiche all'identità dei prodotti ([#8](https://github.com/GammaMarkets/market-spec/pull/8)) e la semantica delle recensioni dei commercianti ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Aperte: collegamento delle identità Bitcoin
+
+Questa settimana sono state aperte due proposte per collegare identità Bitcoin a identità Nostr: un [indirizzo Bitcoin Silent Payment NIP-352](https://github.com/nostr-protocol/nips/pull/2392) e una [proof di collegamento dell'identità Bitcoin-OTC](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## Approfondimento NIP: NIP-86 (API di gestione dei relay)
+
+[NIP-86](/it/topics/nip-86/) definisce un'interfaccia JSON-RPC per la gestione dei relay, consentendo ai client autorizzati di inviare comandi amministrativi ai relay tramite un'API standardizzata. Un unico client può gestire qualsiasi relay compatibile con NIP-86 senza strumenti specifici per ciascuno. Due modifiche alla specifica integrate questa settimana, [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) e [PR #2390](https://github.com/nostr-protocol/nips/pull/2390), chiudono il circuito fra eventi firmati dai relay e amministratori dichiarati dai relay.
+
+### Il trasporto
+
+Una richiesta di gestione NIP-86 è un HTTP POST allo stesso URI dal quale il relay serve le connessioni WebSocket, con `Content-Type: application/nostr+json+rpc`. Il corpo della richiesta è un documento JSON della forma:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+L'autenticazione usa un evento firmato di autenticazione HTTP [NIP-98](/it/topics/nip-98/) nell'header `Authorization`. Prima di eseguire il metodo, il relay verifica che la pubkey firmataria sia nel proprio elenco di amministratori. La risposta del relay è un documento JSON della forma:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### I metodi esistenti prima di questa settimana
+
+L'insieme di metodi preesistente comprende ban delle pubkey (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), ban degli eventi (`banevent`, `allowevent`, `listbannedevents`), metadati del relay (`changerelayname`, `changerelaydescription`, `changerelayicon`), gestione dell'elenco dei kind consentiti (`allowkind`, `disallowkind`, `listallowedkinds`) e un metodo `stats` che restituisce statistiche del relay. La forma è volutamente simile a quella di un servizio JSON-RPC standard, così un client può costruirvi sopra binding tipizzati.
+
+### Cosa è cambiato questa settimana
+
+La [PR #2389](https://github.com/nostr-protocol/nips/pull/2389) aggiunge alla specifica un metodo `signevent`. Il metodo riceve come argomento un template di evento parziale, con kind, tag e content, e chiede al relay di firmare e restituire un evento completo usando la pubkey del relay nel campo `pubkey`. È il prerequisito affinché un relay possa pubblicare eventi di protocollo su se stesso: annunci di pubkey bloccate, metadati del relay e il nuovo evento Relay Roles descritto sotto richiedono tutti che il relay firmi con la chiave controllata dall'operatore, ma la maggior parte degli operatori non vuole custodire una chiave privata nel proprio client amministrativo.
+
+La [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) definisce un evento Relay Roles: un kind di evento sostituibile parametrizzato che un relay pubblica, firmato con la propria pubkey tramite `signevent`, per dichiarare le pubkey dei suoi amministratori e moderatori con una semantica esplicita dei ruoli. Un client consapevole di NIP-86 può recuperare l'evento Relay Roles da qualsiasi relay monitorato, costruire l'elenco degli amministratori dai tag dell'evento e verificare che una richiesta NIP-86 autenticata provenga da un amministratore corrente, senza fiducia fuori banda né configurazione specifica per relay. Le due PR chiudono insieme il circuito: `signevent` è il meccanismo, Relay Roles è il primo kind di evento costruito su di esso.
+
+### Esempio di richiesta NIP-86
+
+Una richiesta NIP-86 `banpubkey` completa ha questa forma:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+con un header `Authorization` che trasporta un evento firmato NIP-98:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+La pubkey firmataria deve comparire nell'insieme degli amministratori del relay, ora dichiarato nell'evento relay-roles; il tag `u` deve corrispondere all'URL HTTPS del relay; il tag `payload` deve corrispondere allo SHA-256 del corpo JSON della richiesta. Il relay restituisce:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementazioni
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) offre su Android un'interfaccia di gestione dei relay NIP-86 dalla v1.07.0 in poi.
+- Fra i relay di riferimento che implementano la specifica vi sono [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru) e diverse implementazioni minori collegate dalla sezione `Implementation Status` della specifica.
+
+I client consapevoli di NIP-86 inizieranno a trattare l'evento relay-roles come fonte canonica dell'elenco degli amministratori di un relay, quando gli implementatori adotteranno le modifiche `signevent` e Relay Roles.
+
+---
+
+## Approfondimento NIP: NIP-89 (application handler consigliati)
+
+[NIP-89](/it/topics/nip-89/) definisce due kind di eventi sostituibili parametrizzati, `kind:31990`, l'application handler pubblicato dallo sviluppatore di un'app, e `kind:31989`, la raccomandazione pubblicata dall'utente per un'app che utilizza. Insieme permettono ai client di scoprire applicazioni capaci di gestire un kind di evento sconosciuto senza coordinamento fuori banda: un lettore long-form che incontra un evento `kind:30030` non gestito nativamente può interrogare il grafo NIP-89 alla ricerca di handler e offrire all'utente un flusso `Open in...` verso un'app pubblicata che sappia gestirlo. NIP-89 è l'infrastruttura originaria per lo stesso problema di instradamento fra app che il lavoro su napplet e napps presente in questo numero sta ora estendendo ad applet componibili native di Nostr.
+
+### L'evento application handler (`kind:31990`)
+
+Lo sviluppatore di un'app pubblica uno o più eventi handler che descrivono quali kind di evento sono supportati dall'app e come aprire un'entità Nostr al suo interno:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+Il tag `d` identifica l'handler, così può essere sostituito; ogni tag `k` dichiara un kind di evento gestito dall'app e ogni tag di piattaforma (`web`, `ios`, `android`, ...) fornisce un template URL con `<bech32>` come segnaposto per un'entità codificata secondo [NIP-19](/it/topics/nip-19/), che il client chiamante sostituisce al momento dell'apertura. Un singolo evento handler può pubblicizzare più kind supportati se condividono lo stesso schema di instradamento, mantenendo compatta la scoperta delle app ed evitando un evento handler per ogni kind.
+
+### L'evento di raccomandazione dell'utente (`kind:31989`)
+
+Un utente pubblica una raccomandazione che dichiara quali app usa per un determinato kind di evento:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+Il tag `d` contiene il kind di evento raccomandato. Ogni tag `a` è un puntatore di indirizzo NIP-01 a un evento handler `kind:31990`, con il relay suggerito e la piattaforma a cui si applica la raccomandazione. La stessa raccomandazione può elencare più app per piattaforme differenti.
+
+### Il client tag e il compromesso sulla privacy
+
+NIP-89 definisce inoltre un tag `client` facoltativo che qualsiasi app di pubblicazione può allegare agli eventi di cui è autrice:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Ciò consente a qualsiasi client che mostra l'evento di presentare l'app da cui proviene, recuperare metadati più ricchi dell'handler e rispettare i suggerimenti di rendering dichiarati dall'handler. La specifica segnala esplicitamente anche il costo per la privacy: un client che emette un tag `client` su ogni evento pubblica l'identità del software dell'utente, rivelando nel tempo schemi di utilizzo. La specifica raccomanda ai client di offrire agli utenti la possibilità di disattivarlo.
+
+La [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) di Amethyst analizza e mostra i tag NIP-89 `t`, `i`, `a` e `client` nella visualizzazione degli eventi, indicando direttamente nella timeline quale app ha creato una nota.
+
+### Come funziona in pratica il flusso di scoperta
+
+Un client che riceve un kind di evento sconosciuto segue questi passaggi. (1) Interroga il grafo dei follow dell'utente alla ricerca di eventi `kind:31989` con un tag `d` corrispondente al kind dell'evento. (2) Risolve ogni tag `a` raccomandato nel relativo evento handler `kind:31990`. (3) Sceglie l'handler il cui template URL `web`, `ios` o `android` corrisponde alla piattaforma corrente. (4) Sostituisce nel template URL la codifica `bech32` dell'entità. (5) Offre all'utente l'URL risultante come opzione `Open in...`. Il flusso è filtrato socialmente: un client che interroghi eventi handler arbitrari da relay non fidati potrebbe reindirizzare gli utenti verso app malevole, quindi partire dalle persone seguite dall'utente è un'impostazione predefinita più sicura che considerare ugualmente affidabile ogni handler pubblicato.
+
+### NIP-89 e il livello napplet
+
+La sezione Discover di Amethyst, il runtime host per napplet e la visualizzazione dei tag `client` costruiscono insieme una superficie completa di consumo NIP-89 su Android. La specifica napplet, introdotta nello scorso numero, estende ciò a cui possono puntare gli eventi handler NIP-89: applet in sandbox che vengono eseguite in un runtime componibile nativo di Nostr, sopra Nostr e Blossom. NIP-89 è il grafo di scoperta e instradamento; il runtime napplet è uno dei target di esecuzione a cui può puntare.
+
+---
+
+*Per segnalazioni, correzioni e progetti che ci sono sfuggiti, aprite una issue su [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) oppure contattateci tramite DM NIP-17 all'indirizzo npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/ja/newsletters/2026-07-01-newsletter.md
+++ b/content/ja/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+Nostrの週刊ガイド、Nostr Compassへようこそ。
+
+**今週:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul)はNym mixnetトランスポート、オプトインのmDNS LANディスカバリ、パケット損失下でも途切れないrekey、データプレーンの全面改修を出荷し、v0.3.0とのwire互換性を維持します。[Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client)はRustとSlintで構築されたデスクトップMarmotクライアントとして登場し、メッセージエフェクトを専用kind 9イベントへ移すprotocol提案を示します。[CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow)は、NIP-46リモートsignerとして動作し、NFCで物理アクセスのチャレンジに応答するハードウェア保護型モバイルidentity vaultとして登場します。[myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh)はv0.1.0の新しいBLE L2CAPトランスポートを使い、FIPS mesh上でピアツーピアのnsite共有を開始します。[Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr)は、暗号化Nostr DMを介してローカルのCodexコーディングアシスタントを操作するAndroidコントロール画面として登場します。[Amethystの未リリース版](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section)はNIP-89アプリハンドラー解析、NIP-34向けGit Repositoriesフィード、nSiteとnapplet向けDiscoverセクションを追加します。[Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments)は1週間でNIP-37、NIP-52、NIP-22を実装しました。[Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut)は12個のサブパッケージをリリースし、nbunksec NIP-46ヘルパーとCashu-ts v4 walletへの更新を行います。[Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing)はaddressableなkind 35000上でShared-Key Collaborative Listsを出荷します。NIPsリポジトリではrelay rolesイベント、NIP-44の65,535バイト制限撤廃、NIP-34のfork semantics、NIP-46のclient metadata、NIP-86の`signevent`メソッドを含む5件のPRがマージされました。ディープダイブでは[NIP-86（Relay Management API）](#nip-deep-dive-nip-86-relay-management-api)と[NIP-89（Recommended Application Handlers）](#nip-deep-dive-nip-89-recommended-application-handlers)を取り上げます。
+
+---
+
+## トップストーリー
+
+### FIPS v0.4.0はNym mixnetトランスポート、mDNSディスカバリ、データプレーン全面改修を出荷
+
+[FIPS](https://github.com/jmcorgan/fips)は、中央インフラを使わずにノード同士が互いを発見しトラフィックをルーティングする、Nostr向けの非公開・自己組織型ピアツーピアmeshネットワークです。[FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0)はNym mixnetトランスポート、オプトインのmDNS LANディスカバリ、データプレーン全面改修、パケット損失下でも途切れないrekey、render-snapshot harness上に再構築した`fipstop` TUI、hot path外のobservability plane、新しいOpenWrt apkおよびNix flakeパッケージングを導入します。すべてv0.3.0とwire互換で、ローリングアップグレード中も混在meshが相互運用できます。リリースの中核はピア発見向けの2つの新トランスポートです。新しい[アウトバウンドNym mixnetトランスポート](https://github.com/jmcorgan/fips/releases/tag/v0.4.0)は、FIPSトラフィックを`nym-socks5-client` SOCKS5プロキシ経由で[Nym](https://nymtech.net/)のcover-trafficネットワークに混ぜ、リンクレベルの観測者が通信中のmesh peer同士を相関できないようにします。`examples/sidecar-nostr-mixnet-relay/`ディレクトリは、mixnet越しにend-to-endでpeer接続したFIPSリンクから到達できるNostr relayを実演します。オプトインのmDNS / DNS-SD LANディスカバリにより、同じローカルリンク上のノードはアドレス設定もSTUNも使わず、`node.discovery.lan.enabled: true`の標準service recordを通じてpeerを広告・採用できます。
+
+データプレーンは単一ノードのスループット向上に向けて再設計されました。peerごとの暗号化と復号は受信ループ外の専用worker taskで動くため、1つの多忙なpeerがノード全体の暗号処理を直列化しません。Linux送信経路は利用可能な場合にgeneric segmentation offloadとconnected UDP socketを使い、受信hot pathは従来パケットごとに行っていたbuffer copyを避けます。macOSには、v0.3.0でLinuxに導入された`recvmmsg` batchingに対応する`recvmsg_x` batched receiveが追加されました。`fipsctl`と`fipstop`の`show_*`読み取り面全体は、control accept taskからlock-freeな`ArcSwap`へ公開されるtickごとのsnapshotを使うため、受信ループが多忙なノードでもoperator queryへ迅速に応答します。counterのみの新しい`show_metrics` query（`fipsctl stats metrics`として公開）により、hot pathへ負荷を加えずPrometheusでscrapeできます。
+
+FMPとFSPのsession rekeyは、双方向のパケット損失や並べ替えがあっても途切れなくなりました。inbound frameはK-bit cutoverが昇格させる前にpending sessionに対して認証されるため、古いframeやspoofされたframeがrekeyを妨げません。rekey message 1の再送には上限が設けられ、link-dead heartbeatはrekeyを認識し、高遅延リンクで双方が同時に開始する競合は対称jitterでずらされます。`fipstop` TUIは、用意されたcontrol-socket出力に対して各viewの正確なtext gridとcellごとのstyleを検証するrender-snapshot harness上で再構築されました。新しいパッケージング対象も加わりました。OpenWrt 25以降向けの`.apk`はSDKなしで構築され、既存`.ipk`のcross-compileとインストール済みfilesystem payloadを再利用します。プロジェクトrootの`flake.nix`は、固定toolchainを使いNix/NixOS上で4つのbinary（`fips`、`fipsctl`、`fips-gateway`、`fipstop`）をsourceから構築します。
+
+### Whitenoise LinuxがデスクトップMarmotクライアントとして登場
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git)はデスクトップ向け[Marmot](/ja/topics/marmot/)クライアントです。Nostr relay上のMLS group messagingを、すべてのsecretをpassword暗号化vaultに保管するSlint UI付きの単一Rust binaryとして提供します。
+
+今週最も重要な論点は、Whitenoiseのメッセージエフェクトを親メッセージを参照する専用kind 9イベントとして運ぶ提案です。現在のwire formatはメッセージ本文末尾に`dmfx:sparkle`のようなmarkerを付加するため、この慣習を知らないrendererでは本文が汚れます。エフェクトを独立イベントへ移せばメッセージ本文を清潔に保てる一方、より広いMarmot stackが直面する設計上の問いも生じます。任意のrich featureを本文内の慣習で表すのか、sidecar eventで表すのかという問題です。
+
+### CustIDがNIP-46とNFCチャレンジフローを備えたモバイルidentity vaultとして登場
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c)は、NostrとSISTR protocol上に構築されたモバイルidentity vault、CustIDの最初の公開betaです。CustIDは複数のNostr identityをhardware-backed secure storageに保存し、他のclient向け[NIP-46](/ja/topics/nip-46/) remote signerとして動作し、NFCとQR codeを使って物理およびオンラインのaccess challengeに応答します。
+
+betaはNIP-46 signerとNFC challenge-response flowに必要な機能を備えています。zero-knowledge proofによるaccess flowは今後のmilestoneです。このリリースではアプリのバックグラウンド[NIP-65](/ja/topics/nip-65/) keep-alive layerも削除されました。以前はprofileごと、read relayごとにWebSocketを開き、clientが即座に破棄するkindまで取り込んでいました。現在バックグラウンドで維持されるのはsigning request通知を運ぶNIP-46 socketだけです。この修正により、CustIDを他clientのbunkerとしてスマートフォン上で実用的に動かせます。
+
+### mycoがFIPS mesh上でピアツーピアnsite共有を開始
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0)は6月27日に公開され、7月1日にv0.1.0へ到達しました。mycoは近くにいる人からアプリをインストールするRust製Androidアプリです。FIPS meshが運べる任意のトランスポート（UDP、TCP、Tor、Bluetooth）を通じてピアツーピアの[nsite](/ja/topics/nip-5a/)共有を行い、完全なオフライン環境でも動作します。設計はトランスポート基盤としてFIPS、payloadとしてNIP-5Aの静的Webサイトevent formatと直接組み合わされます。nsiteとして配布されたアプリはrelayやHTTPに依存せずmesh peer間を移動できます。
+
+v0.1.0はL2CAP Bluetooth radio pathを追加し、FIPSをインストールした2台のスマートフォンがネットワークなしでBLE越しにpeer接続できるようにします。peerごとのspeedtestと、アプリのCircle bottom sheetからNFCで開始する共有も追加されました。mycoは直接インストールできるようZapstoreでも公開されています。
+
+### Nostr Codex PhoneがNostr越しにローカルCodex workerを操作するモバイル画面として登場
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone)は今週、暗号化Nostr direct messageを介してローカルのCodex coding-assistant workerを操作するAndroid clientとして登場しました。複数repository session、音声文字起こし、routed worker session、Blossom media upload、任意の音声応答をサポートします。自宅でCodex workerを動かす開発者は、スマートフォンがrelayへ接続できる場所ならどこからでもrequestを送れます。
+
+このプロジェクトは#28で登場した[CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr)と直接の兄弟関係にあります。どちらもagentic coding workflowを暗号化DM付きNostrトランスポートへ載せ、ネットワークに穴を開けずスマートフォンから自宅のworkerへ到達するためのpairing・messaging layerとしてNostrを使います。ローカルagentのcontrol planeとしてNostrを使う方式は、定着したパターンになりつつあります。
+
+### Coop Mobileが初のversioned buildを公開
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1)と[v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2)が今週、Android向け[NIP-17](/ja/topics/nip-17/)暗号化direct messaging client、Coop Mobileの最初のversioned buildとして出荷されました。2つのリリースはメッセージ解析とQR処理のcrash safetyを強化し、logout時に保存データをすべて消去します。
+
+### AmethystがNIP-89対応UI、Git Repositoriesフィード、napplet Discoverセクションを構築
+
+[Amethyst](https://github.com/vitorpamplona/amethyst)のmain branchは今週、複数の新しい画面を構築しました。[Git Repositoriesフィード](https://github.com/vitorpamplona/amethyst/pull/3406)は[NIP-34](/ja/topics/nip-34/) repoを閲覧可能なAndroid timeline categoryにし、communityとauthorで絞り込めます。[smart-HTTP git browser](https://github.com/vitorpamplona/amethyst/pull/3415)も組み合わされ、アプリを離れずrepoの内容とcommitを読めます。napplet hostには[NIP-89](/ja/topics/nip-89/) handler eventと[NIP-5A](/ja/topics/nip-5a/) site eventをsourceとし、curated web app、follow中のnSiteとnappletを一覧にする[Discoverセクション](https://github.com/vitorpamplona/amethyst/pull/3409)が追加されました。ノート表示はNIP-89 tagを使い、[どのNostrアプリがeventを作成したか](https://github.com/vitorpamplona/amethyst/pull/3422)を示します。同期面では、[NIP-77 negentropy support](https://github.com/vitorpamplona/amethyst/pull/3434)がstreaming reconciliationと自動的な`created_at` windowingを導入し、relay側の結果上限を回避します。これにより大規模なローカルevent setをrelayと同期し続けるための帯域を削減します。
+
+### Buzz v0.3.38がrelay attack surfaceを強化しprovider非依存のmodel選択を追加
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38)は、persona、team、managed agent、NIP-OA owner attestationを署名済みNostr eventとして公開する際にBuzzが露出する[relay attack surface](https://github.com/block/buzz/pull/1369)を強化します。Buzz relayはteamのNostr identityと状態を記録する公開台帳であり、このリリースはBuzzが定義するwell-known event kindの入力検証とreplay protectionを強化します。またmodel選択を一般化し、新しいDatabricks AI Gateway v2 backendを含め、Buzzがadapterを持つ任意のproviderをteamが選べるようにします。
+
+### NotedeckがNIP-37 private-sync relay、NIP-52 calendar、NIP-22 commentを実装
+
+Damus teamのnative Rust desktop clientである[Notedeck](https://github.com/damus-io/notedeck)は、1週間で3つのprotocolを実装しました。private-sync relayはkind `10013`の[NIP-37](/ja/topics/nip-37/) listとして永続化され、ユーザーのprivate content relay setを公開NIP-65 outboxから分離します。`horizon` calendar paneはnostrdbから[NIP-52](/ja/topics/nip-52/) eventを読み、3 pane layoutへ再設計されました。`headway` paneはkind `1111`上の[NIP-22](/ja/topics/nip-22/) comment event modelを追加しました。これはNIP-10 reply threadingに代わる統一comment surfaceとしてNIP-22が定義するkindです。
+
+### Applesauceが連携した6.2.x更新で12サブパッケージを出荷
+
+signer、relay、wallet、content向けのmodular Nostr toolkitである[Applesauce](https://github.com/hzrd149/applesauce)は、サブパッケージ全体で連携した[6.2.xリリース](https://github.com/hzrd149/applesauce/releases)を行いました。signers packageには`nbunksec` import・export helperが加わり、[NIP-46](/ja/topics/nip-46/) bunker sessionをclient間で移動できるportable artifactとして扱います。wallet packageは[Cashu](/ja/topics/nip-60/) bindingを`@cashu/cashu-ts` v4へ更新し、proof amountは`Amount` value objectとなり、token decoding APIも変わりました。
+
+---
+
+## タグ付きリリース
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0)は、[Mostro](/ja/topics/nip-69/) P2P fiat取引ネットワークの次のprotocol iterationを導入します。[v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2)に続くリリースで、新coreを採用する[mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0)と同時に出荷されました。core repositoryでは今週3件のPRがマージされ、周辺stack（mostro daemonとMostro mobile）は共有type crateのv0.14.0へ追従します。
+
+### ngit v2.6.1
+
+[NIP-34](/ja/topics/nip-34/) repository向け標準git-over-nostr CLIである[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli)は、今週マージされた[NIP-34 GRASP-06 fork semantics](https://github.com/nostr-protocol/nips/pull/2395)を実装します。repo-state eventの`personal-fork` tagを`u` tagへ置き換える変更です。
+
+### mesh-llm v0.72.0とv0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm)は、Nostrからaddress可能なJSON-RPC surfaceの背後でopen-source LLMを動かすContextVM stackのinference componentです。[v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0)と[v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1)は、大きな単一promptにおけるbatching crashを修正し、MCP bridgeをdeprecated helperから移行しました。
+
+### Meiso v1.4.0がtask共有のMLSを置き換えるShared-Key Collaborative Listsを出荷
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0)は、従来のMLSベースtask共有をより単純なaddressable event設計で置き換えるShared-Key Collaborative Lists modelを導入します。各共有listはmemberへ配布する専用Nostr鍵を生成します。taskは`d=task-id`でkeyedされたkind `35000`のaddressable eventで、contentは[NIP-44](/ja/topics/nip-44/)により自己暗号化され、relayはtaskごとにLast-Write-Winsを適用します。この設計はclient実装の単純化とrelay levelのconflict resolutionと引き換えに、MLSのforward secrecyとpost-compromise securityを手放します。
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn)はgroup message投稿からephemeral sender pubkeyを削除し、古い再requestに対するjoin-request flowを強化する「more-private-coordinator」系統を出荷します。Cordnは[#28のCordn Ad-hoc CVM登場](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator)で取り上げたMLSベースmessaging stackで、このリリースは対応するcoordinator側の更新です。
+
+---
+
+## 未リリースの変更
+
+### diVineがローンチ後の改善として108件のPRをマージ
+
+Vineを復活させる短尺loop video client、[diVine](https://github.com/divinevideo/divine-mobile)は、ローンチ後の大規模な改善段階にあります。今週Nostrから見える変更は、`nostrconnect://`の失敗を構造化reason codeへ移行する[NIP-46](/ja/topics/nip-46/) connect flowの安定化です。
+
+### Zap Cookingがプロジェクト横断NIP-46修正とcomposer全面改修を継続
+
+[Zap Cooking](https://github.com/zapcooking/frontend)は、recipeをNostr long-form eventとして公開するNostr recipe共有clientです。今週の作業は、[#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes)で未リリース変更として取り上げたプロジェクト横断[NIP-46](/ja/topics/nip-46/)修正とcomposer全面改修を継続します。
+
+### Conduitがlisting flowとmarketplaceの正確性を強化
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono)は、buyer market、merchant portal、store builderの3アプリを含むNostr marketplace monorepoです。今週の作業は[#28のローンチ記事](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default)で取り上げたmarketplaceの正確性向上を継続し、前号のprotocol面の中心だった[NIP-99](/ja/topics/nip-99/) commerceの動きの上に構築されています。
+
+### Pollerama v1.12からv1.13.1がclient tag選択、profile tab、thread上限を追加
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls)はpollとnoteに重点を置き、web of trustによるdiscoveryを強く採用するAndroid Nostr clientです。今週Zapstoreへv1.12.0、v1.13.0、v1.13.1を出荷しました。ユーザーは作成するnoteとpollへ付けるclient tagをpreset listから選ぶか、独自の値を入力できます。深くnestしたcomment・reply chainは数levelで止まり、note pageの完全なthreadへlinkします。profile pageは既定でNotesを開き、Posts tabとConversations tabに分かれます。新しくfollowしたaccountがアプリ再起動後に消えるpersistence bugが修正され、follow buttonは進捗を表示します。
+
+### getwired.appとget-tao.appがNIP-13 confess送信flowを修正
+
+[getwired.app](https://github.com/smolgrrr/Wired)と[get-tao.app](https://github.com/smolgrrr/TAO)は、送信時のspam抑制にNIP-13 proof-of-workを加える匿名投稿flowを共有しています。[confess送信flow](https://github.com/smolgrrr/Wired/pull/57)を修正し、PoW mining中のUXを一貫させました。
+
+### nostuiがmention timeline tabを追加
+
+Rust製terminal Nostr clientの[nostui](https://github.com/akiomik/nostui)は、active pubkeyをtag付けしたkind 1 eventをTUIの専用viewに表示する[mention timeline tab](https://github.com/akiomik/nostui/pull/463)を追加しました。
+
+### HeartwoodがidentityごとのNIP-46 bunker URIとHSM mode signing bridgeを導入
+
+[Heartwood](https://github.com/forgesworn/heartwood)は、signing keyがclientへ一切届かない[NIP-46](/ja/topics/nip-46/) signerです。clientはNIP-46で小さなrelayと通信し、relayはserial frame protocolで接続済みhardware deviceと通信し、そのdeviceが署名を実行します。今週、プロジェクトは[relay-to-serial signing bridge](https://github.com/forgesworn/heartwood/pull/11)と[identityごとのbunker connection](https://github.com/forgesworn/heartwood/pull/16)を導入しました。複数identityを保持する1台のhardware deviceが、それぞれに異なるbunker URIを公開できます。
+
+### Nostterのauth・signer refactor
+
+[Nostter](https://github.com/SnowCait/nostter)は今週、[auth・signer layer](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth)を再設計し、login stateを単一signalへ移し、signer dispatchをstrategy moduleへ抽出しました。NIP-07 web extension、NIP-46 remote bunker、raw nsecが同じcode pathを共有する、明確なsigner abstractionへ向かっています。
+
+### Dart NDKがNIP-07 signerを分離しNIP-59 timestampをrandomize
+
+[Dart NDK](https://github.com/relaystr/dart_ndk)は[NIP-07](/ja/topics/nip-07/) signerをcore packageからFlutter WebViewを含む`ndk_flutter`へ移し、暗号化messageのtiming correlationを難しくするため[NIP-59 gift-wrap timestampをrandomize](https://github.com/relaystr/dart_ndk/pull/667)しました。
+
+### Milk MarketがNIP-23 storefront pageとSquare決済を追加
+
+Shopstr teamのmarketplace storefrontである[Milk Market](https://github.com/shopstr-eng/milk-market)は、sellerの[NIP-23](/ja/topics/nip-23/) long-form eventを基盤に各storefrontへblog pageを追加し、編集可能なsectionとblog settingへのdirect routeを提供しました。同じ週にseller向け代替payment processorとして[Square](https://github.com/shopstr-eng/milk-market/pull/30)を追加し、支払い済みorderのshipping labelを自動購入できるようにしました。
+
+### Calendar by FormstrがiOSアプリを出荷
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar)は今週、[PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159)をマージし、[NIP-52](/ja/topics/nip-52/) calendar clientをiOSへ持ち込みました。[PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197)はlocal timeでのcalendar date解析を修正し、[PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201)は`run-tests` labelで起動するPlaywright E2E workflowを追加します。
+
+### cagliostrがNIP-22、座標によるNIP-09、NIP-13 proof-of-workを適用
+
+Go製relay実装の[cagliostr](https://github.com/mattn/cagliostr)は今週、3つの適用経路を強化しました。受信eventへの[設定可能なNIP-13 proof-of-work](https://github.com/mattn/cagliostr/pull/7)、replaceable eventを`a` tagで削除できる[座標によるNIP-09削除](https://github.com/mattn/cagliostr/pull/8)（event idによる削除だけでは到達できません）、過去または未来へ離れすぎたtimestampのeventを拒否する[設定可能なNIP-22 timestamp上限](https://github.com/mattn/cagliostr/pull/9)です。
+
+---
+
+## 新たに追跡・発見したプロジェクト
+
+[Vanderwarker wellbeing suite](https://git.vanderwarker.family/wellbeing)は、共有publisher signing keyの下で現実世界のtelemetryをNostr eventとして公開します。5つの兄弟アプリで構成されます。[Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android)はfitness dataを`kind:30078`としてNostrへ固定するstep tracker、[Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android)は1日のスマートフォンunlock回数を公開、[Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android)は現在のmedia playbackをUser Statusとして公開、[Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android)は15分ごとにbattery level、voltage、temperatureを公開、[Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android)は日ごとのdata usageを公開します。5つすべてが6月24日から30日の間にZapstoreへ登場しました。
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9)は、RustとSlintで構築された暗号化・serverlessのlive location共有Androidアプリで、6月29日にリリースされました。[#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot)で紹介した[Marmot](/ja/topics/marmot/)ベースのlocation共有アプリ[Haven](https://github.com/mehmetefeumit/Haven-App)の兄弟ですが、トランスポート構成が異なります。ntrackでは暗号化Nostr DMがlocation updateを運び、HavenではMarmot group messageを使います。
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell)は、Nostrアプリを構築するための初期段階のapplication shell scaffoldです。今週、最初のユーザー向け文書を公開しました。
+
+[NIPs by Pollerama](https://nips.pollerama.fun)（repositoryは[abh3po/better-nips](https://github.com/abh3po/better-nips)、2026-06-29作成）は、[NostrHub](https://nostrhub.io)の`kind:30817` community-authored NIP向け新clientで、nostrhub.ioに代わるtrust-weighted surfaceとして位置づけられています。各`kind:30817` NIPは、完全なMarkdown描画と定義するevent kindを備えた共有可能な独自URL（`#/nip/<naddr>`）を持ちます。clientはFollowing、Web of Trust（follows-of-follows）、Globalの3 feedを提供し、それぞれtrust-weighted approvalまたは新着順でsortできます。approvalはkind `1985`上の[NIP-32](/ja/topics/nip-32/) labelとして、tag `["L","nostrhub"]`と`["l","approve","nostrhub"]`、対象NIP addressを指す`a` tag、`better-nips`を示す`client` tagを付けて公開されます。これはNostrHub自身が署名するeventと完全に同じ形状で、2つのclient間でapprovalに互換性があります。rankingではdirect followによるapprovalが、2次のfollows-of-followsによるapprovalより大きな重みを持ちます。
+
+signing stackは[`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer)で、[NIP-07](/ja/topics/nip-07/)、[NIP-46](/ja/topics/nip-46/) bunkerとnostrconnect、[NIP-49](/ja/topics/nip-49/) ncryptsec、[NIP-55](/ja/topics/nip-55/) Android signerを網羅するlogin modalを備え、reload時にsessionを自動で再接続します。network layerは[`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay)を通ります。これはユーザーの[NIP-65](/ja/topics/nip-65/) outboxをrelay間で分割するWeb Workerで、大規模なweb of trust setが単一relayへfan outするのを防ぎます。設計上、community NIPはNostrHub、`better-nips`、将来の別clientのどこでhostされてもprotocol levelでは対等です。rankingはmoderatorによるcurationではなくsocial graphから生まれ、[#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling)のディープダイブで扱ったNIP-32 labeling flowと直接組み合わされます。
+
+今週、2つの新しい[NIP-34](/ja/topics/nip-34/) repo clusterが登場しました。[Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git)はvideo中心のNostr clientです。[nostrapps.com cluster](wss://gitnostr.com)は3つの兄弟プロジェクトを公開します。[verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git)はdesktop向けnapp VM、[hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git)はcustomizable community client、[napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git)はHTML microapp specとruntimeです。このclusterは前号のlead storyで取り上げた[napplet](/ja/topics/nip-5d/)の動きと並行しています。
+
+---
+
+## Protocol作業とNIP更新
+
+### マージ済み: NIP-44が65,535バイトのpayload上限を撤廃
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907)は2024年9月からopenのまま、6月28日にマージされました。[NIP-44](/ja/topics/nip-44/) versioned encryption envelopeのplaintext payload上限65,535バイトを撤廃し、4 GiB（`uint32_max`）へ引き上げます。NIP-44のwire formatはpayload lengthを`uint16`でencodeし、元の仕様は相互運用のため厳密にこれを要求していました。マージされた変更はより長いlength fieldをversion byteへtag付けするため、v2実装はwire互換を保ち、v3以降の実装はより長いlengthを運べます。[NIP-17](/ja/topics/nip-17/) direct message、[NIP-59](/ja/topics/nip-59/) gift wrap、[NIP-46](/ja/topics/nip-46/) remote signer payload、その他NIP-44で暗号化したNostr messageを扱うclientは、application layerで分割せず64 KiBを超える単一eventを交換できるようになりました。
+
+### マージ済み: NIP-86に`signevent`メソッドとRelay Rolesイベントを追加
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389)は[NIP-86](/ja/topics/nip-86/) relay management JSON-RPC APIへ`signevent`メソッドを追加し、administratorがrelay自身のpubkeyでeventに署名するようrelayへ依頼できます。対になる[PR #2390](https://github.com/nostr-protocol/nips/pull/2390)はRelay Rolesイベントを定義します。relayがadministratorとmoderatorを宣言するために公開するreplaceable eventです。2つを組み合わせると、NIP-86 clientはrelayのadmin listを調べ、帯域外のtrustなしに、認証済みrequestが現在のadminから来たことを検証できます。両変更のディープダイブは後述します。
+
+### マージ済み: NIP-34がGRASP-06向け`personal-fork`を`u`へ置換
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395)は6月24日にマージされ、repo-state event（`kind:30618`）上の[NIP-34](/ja/topics/nip-34/) `personal-fork` tagを「upstream」を表す`u` tagへ置き換え、GitWorkshop suiteが実装してきたGRASP-06 fork semanticsへwire formatを合わせます。この変更により、別のfork semantics修正を提案していた[PR #2384](https://github.com/nostr-protocol/nips/pull/2384)（`NIP-34: remove maintainers to solve expiry issues`）はcloseされました。マージされた方向をngit v2.6.xが実装するため、仕様とreference CLIが一致しました。既存の`personal-fork`使用repoは引き続き相互運用でき、新規repoとngit v2.6系統は`u` tagを公開します。
+
+### マージ済み: NIP-46 client metadata（Amber出荷後にupstreamへ反映）
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381)は6月23日にマージされ、[NIP-46](/ja/topics/nip-46/) `connect` requestへ任意のclient metadataを追加しました。signer接続時にclientが名称、icon URL、homepage URLを公開できます。[Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2)は先週metadata拡張を出荷済みで（[#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata)で紹介）、今週upstream NIPが出荷済み実装へ追いつきました。
+
+### オープン: epochベースの決定論的NIP-17 wrapper key
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397)と[PR #2396](https://github.com/nostr-protocol/nips/pull/2396)は、収束しつつある2つのNIP-17 wrap key提案です。PR #2397は、[NIP-59](/ja/topics/nip-59/) gift wrapの作成に使うephemeral signing keyを、粗い時間epochに結びついたconversationごとのseedから決定論的に導出することを提案します。conversation keyを知る受信者は、購読すべきpubkeyを予測できます。現在の仕様はwrapごとに新しいrandom keyを要求するため、この予測は不可能です。PR #2396は対になる変更で、特定conversationのwrapをconversation keyそのもので署名し、wrap pubkeyがconversation identifierを兼ねるよう提案します。2件を合わせると、metadataを漏らさずfilter可能なNIP-17 conversationへの道筋になります。どちらもopenで議論中です。
+
+### オープン: NIP-59のkind 13 seal eventをrelayで拒否
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399)は、[NIP-59](/ja/topics/nip-59/) gift wrapのinner sealであるkind 13 eventがpublish requestのtop levelに現れた場合、relayが拒否すべきだと提案します。seal eventはwrap内でのみ意味を持ち、漏洩したsealはrecipient pubkeyを露出するためです。対になる[issue #2398](https://github.com/nostr-protocol/nips/issues/2398)はさらに進み、sealをephemeral kindとして再定義すべきだと主張します。NIP-01のephemeral kindはrelayに保存されないため、protocol levelで規則を強化し、relayごとのpolicyへの依存をなくせます。
+
+### オープン: NIP-29 group state
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372)は[NIP-29](/ja/topics/nip-29/)（relayベースgroup）へ明示的なgroup state semanticsを追加します。groupがopen、closed、public、private、archivedである意味と、state transitionがmember eventとどう関係するかを定義します。client固有だったsemanticsをrelay仕様へ取り込みます。
+
+### オープン: NIP-34の任意multi-maintainer support
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324)は、上で扱ったGRASP-06 fork semanticsのマージ済み[PR #2395](https://github.com/nostr-protocol/nips/pull/2395)に対するcompanion proposalです。[NIP-34](/ja/topics/nip-34/) repo announcement event（`kind:30617`）へ任意のmulti-maintainer supportを追加し、repositoryが繰り返し`maintainer` tagで複数のcanonical maintainer pubkeyを宣言できるようにします。宣言済みmaintainerの誰かが署名したpatchとissueをclientがofficialとして信頼でき、co-maintainerを持つNIP-34 repoがすべてを1つのpubkeyへ集約するか、protocol外の調整へ頼るしかなかった長年のgapを解消します。
+
+### オープン: filter向けNIP-91 AND operator（提案は未マージ）
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252)はNostr [filter](/ja/topics/nip-01/)向けAND operatorの提案で、以前closeされた[PR #1365](https://github.com/nostr-protocol/nips/pull/1365)で議論された設計を再提案します。[nostr-rs-relay](https://github.com/v0l/nostr-rs-relay)、applesauce、[Amethyst](https://github.com/vitorpamplona/amethyst)、worker-relayには既に実装がありますが、仕様PR自体はopenのままです。
+
+### クローズ: pats2satsのcommerce NIP 4件
+
+今週、Nostr上のcommerceに関する4つの提案がcloseされました。Escrow（[#2334](https://github.com/nostr-protocol/nips/pull/2334)）、Reservations（[#2335](https://github.com/nostr-protocol/nips/pull/2335)）、[NIP-99](/ja/topics/nip-99/) Marketplace Listing Extension（[#2346](https://github.com/nostr-protocol/nips/pull/2346)）、Accommodation Listing Profile（[#2333](https://github.com/nostr-protocol/nips/pull/2333)）です。同じcommerce surfaceは現在、NIP-99 marketplace listing上にorder、checkout、escrow、dispute semanticsを組み合わせるプロジェクト所有extension repository、[Gamma Market Spec](https://github.com/GammaMarkets/market-spec)へ統合されています。CompassはこのrepositoryをMarmot、Blossomと並ぶNIPs repository外のprotocol spec repoとして追跡します。今週openのPRにはclient attributionの明確化（[#11](https://github.com/GammaMarkets/market-spec/pull/11)）、product identity変更向けsupersedes tag（[#8](https://github.com/GammaMarkets/market-spec/pull/8)）、merchant review semantics（[#7](https://github.com/GammaMarkets/market-spec/pull/7)）があります。
+
+### オープン: Bitcoin identityの連携
+
+今週、Bitcoin identityをNostr identityへ結びつける2つの提案がopenされました。[NIP-352 Bitcoin Silent Payment Address](https://github.com/nostr-protocol/nips/pull/2392)と[Bitcoin-OTC Identity Linkage Proof](https://github.com/nostr-protocol/nips/pull/2401)です。
+
+---
+
+## NIPディープダイブ: NIP-86（Relay Management API）
+
+[NIP-86](/ja/topics/nip-86/)はrelay管理向けJSON-RPC interfaceを定義し、認可済みclientが標準API越しにrelayへadministrative commandを送れるようにします。単一clientでrelay固有toolを使わず、任意のNIP-86互換relayを管理できます。今週の2件の仕様マージ（[PR #2389](https://github.com/nostr-protocol/nips/pull/2389)と[PR #2390](https://github.com/nostr-protocol/nips/pull/2390)）は、relay署名eventとrelayが宣言するadministratorの間を閉じます。
+
+### トランスポート
+
+NIP-86管理requestは、relayがWebSocket接続を提供するものと同じURIへのHTTP POSTで、`Content-Type: application/nostr+json+rpc`を使います。request bodyは次の形式のJSON文書です。
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+authenticationは`Authorization` header内の[NIP-98](/ja/topics/nip-98/) HTTP auth署名eventを使います。relayはmethod実行前に、署名pubkeyがadministrator listに含まれることを検証します。relayのresponseは次の形式のJSON文書です。
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### 今週以前から存在したmethod
+
+従来のmethod setはpubkey ban（`banpubkey`、`allowpubkey`、`listbannedpubkeys`）、event ban（`banevent`、`allowevent`、`listbannedevents`）、relay metadata（`changerelayname`、`changerelaydescription`、`changerelayicon`）、許可pubkey list管理（`allowkind`、`disallowkind`、`listallowedkinds`）、relay statisticsを返す`stats` methodを扱います。標準JSON-RPC serviceに意図的に近い形状なので、clientはその上にtyped bindingを構築できます。
+
+### 今週の変更
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389)は仕様へ`signevent`メソッドを追加します。このmethodは部分event template（kind、tags、content）を引数に取り、relay自身のpubkeyを`pubkey` fieldに持つ完全なeventへ署名して返すようrelayへ依頼します。これはrelayが自身についてprotocol levelのeventを公開するための前提です。blocked pubkey announcement、relay metadata、後述する新しいRelay Roles eventはいずれもoperator管理鍵によるrelayの署名を必要としますが、多くのrelay operatorはadministrative clientにprivate keyを保持したくありません。
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390)はRelay Roles eventを定義します。relayが公開し、`signevent`を通じて自身のpubkeyで署名するparameterised replaceable event kindで、administratorとmoderatorのpubkeyを明示的なrole semantics付きで宣言します。NIP-86対応clientは追跡中の任意relayからRelay Roles eventを取得し、event tagからadmin listを構築し、帯域外trustやrelayごとの設定なしに、認証済みNIP-86 requestが現在のadminから来たことを検証できます。2つのPRがloopを閉じます。`signevent`がmechanismで、Relay Rolesがその上に構築される最初のevent kindです。
+
+### NIP-86 requestの例
+
+完全なNIP-86 `banpubkey` requestは次のようになります。
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+`Authorization` headerにはNIP-98署名eventを入れます。
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+署名pubkeyはrelayのadmin set（現在はrelay roles eventで宣言）に含まれていなければなりません。`u` tagはrelayのHTTPS URLと一致し、`payload` tagはJSON request bodyのSHA-256と一致しなければなりません。relayは次を返します。
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### 実装
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst)はAndroidにNIP-86 relay management UIを搭載しています（v1.07.0以降）。
+- 仕様を実装するreference relayには[strfry](https://github.com/hoytech/strfry)、[khatru](https://github.com/fiatjaf/khatru)、仕様の`Implementation Status` sectionからlinkされる複数の小規模実装があります。
+
+実装者が`signevent`とRelay Roles変更を取り込めば、NIP-86対応clientはrelay roles eventをrelay admin listのcanonical sourceとして扱い始めます。
+
+---
+
+## NIPディープダイブ: NIP-89（Recommended Application Handlers）
+
+[NIP-89](/ja/topics/nip-89/)は2つのparameterised replaceable event kindを定義します。`kind:31990`はapp developerが公開するapplication handler、`kind:31989`はユーザーが利用中のappについて公開するrecommendationです。両者により、clientは帯域外の調整なしに未知のevent kindを処理するapplicationを発見できます。例えばnativeでは扱えない`kind:30030` eventに遭遇したlong-form readerは、NIP-89 graphへhandlerを問い合わせ、対応する公開appへの「Open in...」flowをユーザーへ提示できます。NIP-89はcross-app routingという同じ問題に対する元来の基盤であり、本号に登場するnapplet・nappsの作業はこれをcomposableなNostr native appletへ拡張しています。
+
+### Application handler event（`kind:31990`）
+
+app developerは、appが対応するevent kindとNostr entityをappで開く方法を説明するhandler eventを1つ以上公開します。
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+`d` tagはhandlerを識別し、置き換え可能にします。各`k` tagはappが扱うevent kindを宣言します。各platform tag（`web`、`ios`、`android`など）は、呼び出し側clientがopen時に置換する[NIP-19](/ja/topics/nip-19/) encoded entityのplaceholderとして`<bech32>`を持つURL templateを示します。同じrouting patternを共有する場合、1つのhandler eventが複数の対応kindを広告できます。app discoveryをcompactに保ち、kindごとにhandler eventを1つ作る必要をなくします。
+
+### User recommendation event（`kind:31989`）
+
+ユーザーは、特定event kindに利用するappを宣言するrecommendationを公開します。
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+`d` tagはrecommendation対象のevent kindを持ちます。各`a` tagは`kind:31990` handler eventへのNIP-01 address pointerで、推奨relayとrecommendation対象platformを伴います。同じrecommendationに異なるplatform向けの複数appを列挙できます。
+
+### Client tagとprivacyのtradeoff
+
+NIP-89は、任意のpublishing appが自身の作成eventへ付けられる任意の`client` tagも定義します。
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+これによりeventを表示するclientは、そのeventが作成されたappを示し、より詳しいhandler metadataを取得し、handlerが宣言するrendering hintを尊重できます。仕様はprivacy上のcostも明記します。すべてのeventで`client` tagを発行するclientはユーザーのsoftware identityを公開し、時間の経過とともに利用patternを明らかにします。仕様はclientがユーザーへopt-outを提供することを推奨します。
+
+Amethystの[PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422)はevent表示でNIP-89の`t`、`i`、`a`、`client` tagを解析・表示し、noteを作成したappをtimeline上へ直接示します。
+
+### 実際のdiscovery flow
+
+未知のevent kindを受信したclientは次の手順を取ります。（1）ユーザーのfollow graphへ、event kindと一致する`d` tagを持つ`kind:31989` eventを問い合わせます。（2）推奨された各`a` tagを対応する`kind:31990` handler eventへ解決します。（3）現在のplatformに一致する`web`、`ios`、`android` URL templateを持つhandlerを選びます。（4）entityの`bech32` encodingをURL templateへ代入します。（5）生成したURLを「Open in...」の選択肢としてユーザーへ提示します。このflowはsocial filterを通ります。信頼できないrelayから任意のhandler eventを問い合わせると、悪意あるappへredirectされる可能性があります。そのため、公開されたすべてのhandlerを同等に信頼するより、ユーザーがfollowする人々から始める方が安全なdefaultです。
+
+### NIP-89とnapplet layer
+
+AmethystのDiscoverセクション、napplet host runtime、`client` tag表示を合わせると、Android上の完全なNIP-89 consumer surfaceになります。前号で登場したnapplet specは、NIP-89 handler eventの対象を拡張します。NostrとBlossom上でcomposableなNostr native runtimeを動かすsandboxed appletです。NIP-89がdiscovery・routing graphで、napplet runtimeはそのgraphが指せる実行対象の1つです。
+
+---
+
+*フィードバック、訂正、見落としたプロジェクトは[github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass)でissueを開くか、NIP-17 DMでnpub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923までお送りください。*

--- a/content/ko/newsletters/2026-07-01-newsletter.md
+++ b/content/ko/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+주간 Nostr 가이드 Nostr Compass에 다시 오신 것을 환영합니다.
+
+**이번 주:** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul)은 Nym mixnet 전송, 선택형 mDNS LAN 탐색, 손실 중 무중단 rekey, 데이터 plane 개편을 내놓았으며 v0.3.0과 wire 호환됩니다. [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client)는 Rust와 Slint로 만든 데스크톱 Marmot 클라이언트로 모습을 드러냈고, 메시지 효과를 전용 kind-9 이벤트로 옮기는 프로토콜 제안도 내놓았습니다. [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow)는 NIP-46 원격 signer로 동작하고 NFC로 물리적 접근 챌린지에 응답하는 하드웨어 기반 모바일 신원 vault로 출시되었습니다. [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh)는 v0.1.0의 새 BLE L2CAP 전송으로 FIPS mesh 위의 peer-to-peer nsite 공유를 시작했습니다. [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr)은 암호화 Nostr DM으로 로컬 Codex worker를 제어하는 Android 앱으로 출시되었습니다. [Amethyst의 미출시 line](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section)은 NIP-89 app-handler parsing, NIP-34용 Git Repositories feed, nSite와 napplet용 Discover section을 추가했습니다. [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments)은 한 주에 NIP-37, NIP-52, NIP-22를 구현했습니다. [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut)는 12개 sub-package release와 nbunksec NIP-46 helper 및 Cashu-ts v4 wallet upgrade를 내놓았습니다. [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing)은 addressable kind-35000 기반 Shared-Key Collaborative Lists를 출시했습니다. NIPs repository는 relay roles event, NIP-44의 65,535-byte 제한 해제, NIP-34 fork semantics, NIP-46 client metadata, NIP-86 signevent method를 포함한 PR 다섯 개를 병합했습니다. 심층 분석은 [NIP-86(Relay Management API)](#nip-deep-dive-nip-86-relay-management-api)과 [NIP-89(Recommended Application Handlers)](#nip-deep-dive-nip-89-recommended-application-handlers)를 다룹니다.
+
+---
+
+## 주요 소식
+
+### FIPS v0.4.0, Nym mixnet 전송과 mDNS 탐색 및 데이터 plane 개편
+
+[FIPS](https://github.com/jmcorgan/fips)는 중앙 인프라 없이 node가 서로를 발견하고 traffic을 routing하는 Nostr용 비공개 self-organizing peer-to-peer mesh network입니다. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0)은 Nym mixnet 전송, 선택형 mDNS LAN 탐색, 데이터 plane 개편, packet loss 중 무중단 rekey, render-snapshot harness 위에서 다시 쓴 `fipstop` TUI, hot path 밖의 observability plane, 새 OpenWrt apk 및 Nix flake 패키징 대상을 추가했습니다. 모두 v0.3.0과 wire 호환되므로 rolling upgrade 중 혼합 mesh도 상호운용됩니다. 릴리스의 중심은 peer 탐색용 새 전송 두 가지입니다. 새 [outbound Nym mixnet 전송](https://github.com/jmcorgan/fips/releases/tag/v0.4.0)은 FIPS traffic을 `nym-socks5-client` SOCKS5 proxy를 거쳐 [Nym](https://nymtech.net/) cover-traffic network에 섞어, link-level 관찰자가 어떤 mesh peer끼리 통신하는지 상관관계를 찾지 못하게 합니다. `examples/sidecar-nostr-mixnet-relay`는 별도 프로세스로 Nostr relay traffic을 같은 경로에 실어 나릅니다. 선택형 mDNS transport는 LAN에서 `_fips._udp` service record를 광고하고 탐색하므로, operator가 수동 peer 주소나 multicast seed를 설정하지 않아도 같은 로컬 네트워크의 FIPS node가 서로를 찾습니다. 기본값은 꺼짐이며 명시적으로 켜야 합니다.
+
+단일 node 처리량을 높이도록 데이터 plane도 다시 만들었습니다. peer별 encrypt와 decrypt는 이제 receive loop 밖의 전용 worker task에서 실행되므로, 바쁜 peer 하나가 전체 node의 crypto를 직렬화하지 않습니다. Linux send path는 가능한 경우 generic segmentation offload와 connected-UDP socket을 쓰고, receive hot path는 예전에 packet마다 만들던 buffer copy를 피합니다. macOS에는 v0.3.0의 Linux `recvmmsg` batching에 대응하는 `recvmsg_x` batched receive가 추가되었습니다. `fipsctl`과 `fipstop`의 전체 `show_*` 읽기 surface는 이제 control accept task가 lock-free `ArcSwap`에 게시하는 tick별 snapshot에서 응답하므로, receive loop가 바쁜 node에서도 operator 질의가 즉시 처리됩니다. counter만 반환하는 새 `show_metrics` 질의(`fipsctl stats metrics`)는 hot-path 비용 없이 Prometheus scraping을 지원합니다.
+
+FMP와 FSP session rekey는 이제 양방향 packet loss와 reordering에서도 중단되지 않습니다. inbound frame은 K-bit cutover가 pending session을 승격하기 전에 그 session으로 인증되므로 오래되거나 spoofed frame이 rekey를 망칠 수 없습니다. rekey message-1 재전송에는 상한이 생겼고, link-dead heartbeat는 rekey를 인식하며, 고지연 link의 양쪽 동시 시작 race는 symmetric jitter로 엇갈립니다. `fipstop` TUI는 미리 준비한 control-socket 출력에 대해 모든 view의 정확한 text grid와 cell별 style을 검증하는 render-snapshot harness 위에서 다시 만들어졌습니다. 패키징 대상도 추가되었습니다. OpenWrt 25+용 `.apk`는 SDK 없이 기존 `.ipk` cross-compile과 설치 filesystem payload를 재사용해 빌드되며, 프로젝트 root의 `flake.nix`는 고정 toolchain으로 네 binary(`fips`, `fipsctl`, `fips-gateway`, `fipstop`)를 Nix/NixOS에서 source부터 빌드합니다.
+
+### Whitenoise Linux, 데스크톱 Marmot 클라이언트로 등장
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git)는 데스크톱 [Marmot](/ko/topics/marmot/) 클라이언트입니다. Nostr relay 위의 MLS group messaging을 Slint UI가 있는 단일 Rust binary로 패키징하며, 모든 비밀값을 password로 암호화된 하나의 vault에 보관합니다.
+
+이번 주 가장 중요한 논의는 Whitenoise 메시지 효과를 parent message를 참조하는 전용 kind-9 이벤트로 전달하자는 제안입니다. 현재 wire format은 메시지 본문 끝에 `dmfx:sparkle` 같은 marker를 붙이므로 이 관례를 모르는 renderer에서는 본문이 오염됩니다. 효과를 별도 이벤트로 옮기면 메시지 text가 깨끗해지고, 더 넓은 Marmot stack이 마주할 설계 질문도 드러납니다. 선택적 rich feature를 inline body 관례로 담을지 sidecar event로 담을지의 문제입니다.
+
+### CustID, NIP-46과 NFC challenge flow를 갖춘 모바일 identity vault로 출시
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c)는 Nostr와 SISTR protocol 위에 만든 모바일 identity vault CustID의 첫 공개 beta입니다. CustID는 여러 Nostr identity를 hardware-backed secure storage에 보관하고, 다른 client를 위한 [NIP-46](/ko/topics/nip-46/) remote signer로 동작하며, NFC와 QR code를 통해 물리적·온라인 접근 challenge에 응답합니다.
+
+이 beta는 NIP-46 signer와 NFC challenge-response flow를 완성했으며 zero-knowledge-proof access flow는 향후 milestone으로 남았습니다. 이 릴리스는 앱의 background [NIP-65](/ko/topics/nip-65/) keep-alive layer도 제거했습니다. 기존 layer는 profile별 read relay마다 WebSocket을 열고 client가 즉시 버리는 kind까지 받아들였습니다. 이제 signing-request 알림을 전달하는 NIP-46 socket만 background에서 유지됩니다. 이 수정 덕분에 휴대폰에서 CustID를 다른 client용 bunker로 실용적으로 운영할 수 있습니다.
+
+### myco, FIPS mesh 위에서 peer-to-peer nsite 공유 시작
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0)은 6월 27일 공개되어 7월 1일 v0.1.0에 도달했습니다. myco는 주변 사람에게서 앱을 설치하는 Rust Android 앱입니다. FIPS mesh가 전달할 수 있는 모든 transport(UDP, TCP, Tor, Bluetooth)를 통해 peer-to-peer [nsite](/ko/topics/nip-5a/)를 공유하며 완전히 offline으로 작동합니다. FIPS를 transport substrate로, NIP-5A의 static-website event format을 payload로 직접 결합해 nsite로 배포된 앱이 relay나 HTTP에 의존하지 않고 mesh peer 사이를 이동하게 합니다.
+
+v0.1.0은 FIPS가 설치된 휴대폰 두 대가 네트워크 없이 BLE로 peer가 될 수 있는 L2CAP Bluetooth radio path, peer별 speedtest, 앱의 Circle bottom-sheet에서 NFC로 시작하는 공유를 추가합니다. myco는 직접 설치할 수 있도록 Zapstore에도 게시되었습니다.
+
+### Nostr Codex Phone, Nostr로 로컬 Codex worker를 다루는 모바일 control surface로 출시
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone)는 암호화 Nostr direct message로 로컬 Codex coding-assistant worker를 제어하는 Android client로 이번 주 출시되었습니다. 여러 repository session, voice transcription, routed worker session, Blossom media upload, 선택적 음성 응답을 지원하므로, 집에서 Codex worker를 실행하는 개발자는 휴대폰이 relay에 접근할 수 있는 어디서든 요청을 보낼 수 있습니다.
+
+이 프로젝트는 #28에 출시된 [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr)의 직접적인 형제입니다. 둘 다 agentic-coding workflow를 암호화 DM과 함께 Nostr transport에 올리고, network에 구멍을 뚫지 않고 휴대폰에서 집의 worker에 닿게 하는 pairing 및 messaging layer로 Nostr를 사용합니다. 로컬 agent의 control plane으로 Nostr를 쓰는 방식이 확립된 pattern이 되고 있습니다.
+
+### Coop Mobile, 첫 versioned build 게시
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1)과 [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2)는 Android용 [NIP-17](/ko/topics/nip-17/) 암호화 direct-messaging client Coop Mobile의 첫 versioned build로 이번 주 출시되었습니다. 두 릴리스는 message parsing과 QR 처리 주변의 crash safety를 강화하고 logout 때 저장된 모든 데이터를 지웁니다.
+
+### Amethyst, NIP-89 UI와 Git Repositories feed 및 napplet Discover section 구축
+
+[Amethyst](https://github.com/vitorpamplona/amethyst)의 main branch에는 이번 주 여러 새 surface가 만들어졌습니다. [Git Repositories feed](https://github.com/vitorpamplona/amethyst/pull/3406)는 [NIP-34](/ko/topics/nip-34/) repo를 community와 author로 filter할 수 있는 Android timeline category로 만들고, 앱을 떠나지 않고 repo 내용과 commit을 읽는 [smart-HTTP git browser](https://github.com/vitorpamplona/amethyst/pull/3415)와 짝을 이룹니다. napplet host에는 curated web app과 followed nSite 및 napplet을 나열하는 [Discover section](https://github.com/vitorpamplona/amethyst/pull/3409)이 생겼으며, [NIP-89](/ko/topics/nip-89/) handler event와 [NIP-5A](/ko/topics/nip-5a/) site event를 source로 씁니다. Note display는 NIP-89 tag를 통해 [어떤 Nostr 앱이 event를 작성했는지 표시](https://github.com/vitorpamplona/amethyst/pull/3422)합니다. sync 쪽에서는 streaming reconciliation과 자동 relay capability detection을 갖춘 [NIP-77 negentropy 지원](https://github.com/vitorpamplona/amethyst/pull/3434)이 들어왔습니다.
+
+### Buzz v0.3.38, relay attack surface 강화와 provider-independent model 선택
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38)은 Buzz가 persona, team, managed agent, NIP-OA owner attestation을 signed Nostr event로 게시할 때 드러나는 [relay attack surface](https://github.com/block/buzz/pull/1369)를 강화합니다. Buzz relay는 team의 Nostr identity와 상태를 담은 공개 record이며, 이 릴리스는 Buzz가 정의한 well-known event kind의 input validation과 replay protection을 강화했습니다. model 선택도 일반화되어 Buzz team이 새 Databricks AI Gateway v2 backend를 포함해 Buzz adapter가 있는 어느 provider든 지정할 수 있습니다.
+
+### Notedeck, NIP-37 private-sync relay와 NIP-52 calendar 및 NIP-22 comment 구현
+
+Damus 팀의 native Rust desktop client [Notedeck](https://github.com/damus-io/notedeck)은 한 주에 protocol 세 가지를 구현했습니다. private-sync relay는 이제 kind `10013` [NIP-37](/ko/topics/nip-37/) list로 유지되어 사용자의 private-content relay set을 public NIP-65 outbox와 분리합니다. `horizon` calendar pane은 nostrdb에서 [NIP-52](/ko/topics/nip-52/) event를 읽고 three-pane layout으로 다시 설계되었습니다. `headway` pane은 kind `1111`에 [NIP-22](/ko/topics/nip-22/) comment-event model을 추가했습니다. NIP-22가 NIP-10 reply threading을 대체하는 통합 comment surface로 정의한 kind입니다.
+
+### Applesauce, nbunksec NIP-46 session과 Cashu v4 wallet upgrade 추가
+
+signer, relay, wallet, content용 modular Nostr toolkit [Applesauce](https://github.com/hzrd149/applesauce)는 sub-package 전반에 걸쳐 [6.2.x release](https://github.com/hzrd149/applesauce/releases)를 냈습니다. signer package는 `nbunksec` import/export helper를 추가해 [NIP-46](/ko/topics/nip-46/) bunker session을 client 사이에서 옮길 수 있는 portable artifact로 다룹니다. wallet package는 [Cashu](/ko/topics/nip-60/) binding을 `@cashu/cashu-ts` v4로 올렸으며, 이 버전에서는 proof amount가 `Amount` value object가 되고 token-decoding API가 바뀝니다.
+
+---
+
+## Tagged release
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0)은 [Mostro](/ko/topics/nip-69/) P2P fiat trading network의 다음 protocol iteration을 제공합니다. [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2)에 이은 릴리스이며 새 core를 채택한 [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0)과 함께 나왔습니다. 이번 주 core repository에는 병합 PR 세 개가 들어왔고, 주변 stack(mostro daemon과 Mostro mobile)은 shared types crate v0.14.0에 맞춰집니다.
+
+### ngit v2.6.1
+
+[NIP-34](/ko/topics/nip-34/) repository용 canonical git-over-nostr CLI [ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli)은 이번 주 병합된 [NIP-34 GRASP-06 fork semantics](https://github.com/nostr-protocol/nips/pull/2395)를 구현합니다. repo-state event의 `personal-fork` tag를 `u` tag로 바꾸는 변경입니다.
+
+### mesh-llm v0.72.0 및 v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm)은 Nostr-addressable JSON-RPC surface 뒤에서 open-source LLM을 실행하는 ContextVM stack의 inference component입니다. [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0)과 [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1)은 큰 단일 prompt에서 발생하는 batching crash를 고치고 MCP bridge를 deprecated helper에서 옮겼습니다.
+
+### Meiso v1.4.0, MLS를 대체하는 Shared-Key Collaborative Lists 출시
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0)은 기존 MLS 기반 task 공유를 더 단순한 addressable-event 설계로 바꾸는 Shared-Key Collaborative Lists model을 도입합니다. 각 shared list는 member에게 배포되는 전용 Nostr key를 만들고, task는 [NIP-44](/ko/topics/nip-44/)로 self-encrypted된 content와 `d=task-id`를 가진 kind `35000` addressable event이며 relay는 task별 Last-Write-Wins를 강제합니다. 이 설계는 client 구현과 relay-level conflict resolution을 단순화하는 대신 MLS의 forward secrecy와 post-compromise security를 포기합니다.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn)는 group message 게시에서 ephemeral sender pubkey를 제거하고 stale re-request로부터 join-request flow를 강화하는 "more-private-coordinator" track을 제공합니다. Cordn은 [#28의 Cordn Ad-hoc CVM 출시](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator)에서 다룬 MLS 기반 messaging stack이며, 이번 릴리스는 이에 맞춘 coordinator 쪽 update입니다.
+
+---
+
+## 미출시 변경
+
+### diVine, 출시 후 다듬기 PR 108개 병합
+
+Vine을 되살리는 short-form looping video client [diVine](https://github.com/divinevideo/divine-mobile)은 출시 후 대규모 polish 단계에 있습니다. 이번 주 Nostr 관련 작업은 `nostrconnect://` 실패를 structured reason code로 옮기는 [NIP-46](/ko/topics/nip-46/) connect-flow 안정화입니다.
+
+### Zap Cooking, cross-project NIP-46 수정과 composer 개편 계속
+
+[Zap Cooking](https://github.com/zapcooking/frontend)은 recipe를 long-form Nostr event로 게시하는 Nostr recipe-sharing client입니다. 이번 주 작업은 [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes)에서 미출시 변경으로 다룬 cross-project [NIP-46](/ko/topics/nip-46/) 수정과 composer 개편을 이어갑니다.
+
+### Conduit, listing flow와 marketplace 정확성 강화
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono)는 buyer market, merchant portal, store builder를 아우르는 Nostr 기반 three-app marketplace monorepo입니다. 이번 주 작업은 [#28의 출시 보도](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default)에서 다룬 marketplace 정확성 강화를 계속하며, 지난 호 protocol 소식이었던 [NIP-99](/ko/topics/nip-99/) commerce 흐름을 바탕으로 합니다.
+
+### Pollerama v1.12부터 v1.13.1, client tag 선택과 profile tab 및 thread 상한 추가
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls)는 poll과 note에 초점을 두고 web-of-trust discovery를 강화한 Android Nostr client입니다. 이번 주 Zapstore에 v1.12.0, v1.13.0, v1.13.1을 출시했습니다. 사용자는 작성한 note와 poll에 붙일 client tag를 preset에서 고르거나 직접 입력할 수 있습니다. 깊게 중첩된 comment와 reply chain은 몇 단계 뒤 멈추고 note 페이지의 전체 thread로 연결됩니다. profile 페이지는 Notes로 열리며 Posts와 Conversations tab으로 나뉩니다. 새로 follow한 account가 앱 재시작 뒤 사라지는 follow persistence bug가 수정되었고 follow button은 진행 상태를 표시합니다.
+
+### getwired.app과 get-tao.app, NIP-13 confess 제출 flow 수정
+
+submit 때 spam을 억제하도록 NIP-13 proof-of-work를 추가하는 anonymous-posting flow를 공유하는 [getwired.app](https://github.com/smolgrrr/Wired)과 [get-tao.app](https://github.com/smolgrrr/TAO)은 PoW mining 중 UX가 일관되도록 [confess 제출 flow](https://github.com/smolgrrr/Wired/pull/57)를 고쳤습니다.
+
+### nostui, mention timeline tab 추가
+
+Rust로 만든 terminal Nostr client [nostui](https://github.com/akiomik/nostui)는 활성 pubkey를 tag한 kind:1 event를 TUI의 전용 view로 보여주는 [mention timeline tab](https://github.com/akiomik/nostui/pull/463)을 추가했습니다.
+
+### Heartwood, identity별 NIP-46 bunker URI와 HSM-mode signing bridge 추가
+
+[Heartwood](https://github.com/forgesworn/heartwood)는 signing key가 client에 전혀 전달되지 않는 [NIP-46](/ko/topics/nip-46/) signer입니다. client는 작은 relay에 NIP-46으로 통신하고 relay는 signature를 만드는 attached hardware device에 serial frame protocol로 통신합니다. 이번 주 프로젝트에는 [relay-to-serial signing bridge](https://github.com/forgesworn/heartwood/pull/11)와 [identity별 bunker connection](https://github.com/forgesworn/heartwood/pull/16)이 들어와, 여러 identity를 가진 hardware device 하나가 각각에 별도 bunker URI를 노출합니다.
+
+### Nostter auth 및 signer refactor
+
+[Nostter](https://github.com/SnowCait/nostter)는 이번 주 [auth와 signer layer](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth)를 다시 만들며 login 상태를 single signal로 옮기고 signer dispatch를 strategy module로 추출했습니다. 목표는 NIP-07 web extension, NIP-46 remote bunker, raw nsec이 하나의 code path를 공유하는 깔끔한 signer abstraction입니다.
+
+### Dart NDK, NIP-07 signer 분리와 NIP-59 timestamp 무작위화
+
+[Dart NDK](https://github.com/relaystr/dart_ndk)는 [NIP-07](/ko/topics/nip-07/) signer를 core package에서 Flutter WebView가 있는 `ndk_flutter`로 옮기고, 암호화 메시지의 timing correlation을 어렵게 하도록 [NIP-59 gift-wrap timestamp를 무작위화](https://github.com/relaystr/dart_ndk/pull/667)했습니다.
+
+### Milk Market, NIP-23 storefront page와 Square 결제 처리 추가
+
+Shopstr 팀의 marketplace storefront [Milk Market](https://github.com/shopstr-eng/milk-market)은 seller의 [NIP-23](/ko/topics/nip-23/) long-form event를 기반으로 한 blog 페이지를 모든 storefront에 추가하고, 편집 가능한 section과 직접 blog-setting route를 제공했습니다. 같은 주에 seller용 대체 payment processor [Square](https://github.com/shopstr-eng/milk-market/pull/30)와 결제된 order의 shipping-label 자동 구매도 추가했습니다.
+
+### Calendar by Formstr, iOS 앱 출시
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar)는 이번 주 [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159)을 병합해 [NIP-52](/ko/topics/nip-52/) calendar client를 iOS로 가져왔습니다. [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197)은 local time의 calendar-date parsing을 고치고, [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201)은 `run-tests` label로 시작되는 Playwright E2E workflow를 추가합니다.
+
+### cagliostr, NIP-22와 coordinate별 NIP-09 및 NIP-13 proof-of-work 강제
+
+Go relay 구현 [cagliostr](https://github.com/mattn/cagliostr)는 이번 주 세 enforcement path를 강화했습니다. incoming event에 [설정 가능한 NIP-13 proof-of-work](https://github.com/mattn/cagliostr/pull/7)를 적용하고, event-id 삭제만으로 닿지 않는 replaceable event를 `a` tag로 삭제하도록 [addressable coordinate별 NIP-09 삭제](https://github.com/mattn/cagliostr/pull/8)를 지원하며, 지나치게 과거나 미래 timestamp의 event를 거부하는 [설정 가능한 NIP-22 timestamp 제한](https://github.com/mattn/cagliostr/pull/9)을 추가했습니다.
+
+---
+
+## 새로 추적·발견한 프로젝트
+
+[Vanderwarker wellbeing suite](https://git.vanderwarker.family/wellbeing)는 하나의 publisher signing key로 현실 세계 telemetry를 Nostr event로 게시합니다. 다섯 sibling app으로 구성됩니다. [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android)은 fitness data를 `kind:30078`로 Nostr에 고정하는 step tracker, [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android)은 하루 phone unlock 횟수를 게시하는 앱, [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android)은 현재 media playback을 User Status로 게시하는 앱, [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android)는 15분마다 battery level, voltage, temperature를 게시하는 앱, [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android)는 일일 data usage를 게시하는 앱입니다. 다섯 앱 모두 6월 24일부터 30일 사이 Zapstore에 등장했습니다.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9)는 Rust와 Slint로 만든 암호화 serverless 실시간 위치 공유 Android 앱으로 6월 29일 출시되었습니다. [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot)에서 다룬 [Haven](https://github.com/mehmetefeumit/Haven-App) [Marmot](/ko/topics/marmot/) 기반 위치 공유 앱의 sibling이지만 transport architecture가 다릅니다. ntrack은 암호화 Nostr DM으로 위치 update를 전달하고 Haven은 Marmot group message를 사용합니다.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell)은 Nostr 앱을 만들기 위한 초기 application shell scaffold입니다. 프로젝트는 이번 주 첫 user-facing documentation을 게시했습니다.
+
+[NIPs by Pollerama](https://nips.pollerama.fun)(repository [abh3po/better-nips](https://github.com/abh3po/better-nips), 2026-06-29 생성)는 [NostrHub](https://nostrhub.io)의 `kind:30817` community-authored NIP을 위한 새 client로, nostrhub.io에 대한 trust-weighted 대체 surface입니다. 각 `kind:30817` NIP은 full Markdown rendering과 정의하는 event kind를 보여주는 공유 가능한 URL(`#/nip/<naddr>`)을 가집니다. client는 Following, Web of Trust(follows-of-follows), Global의 세 feed를 제공하며 trust-weighted approval 또는 최신순으로 정렬할 수 있습니다. approval은 kind `1985`의 [NIP-32](/ko/topics/nip-32/) label로 게시되며 tag `["L","nostrhub"]`, `["l","approve","nostrhub"]`, 대상 NIP address를 가리키는 `a` tag, `better-nips`를 알리는 `client` tag를 포함합니다. NostrHub 자체가 서명하는 event와 정확히 같은 형태라 두 client의 approval이 상호 호환됩니다. ranking에서는 direct follow의 approval이 second-degree follow보다 높은 weight를 받고, Global feed는 user의 social graph 밖 approval도 보여줍니다.
+
+signing stack은 [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer)이며 [NIP-07](/ko/topics/nip-07/), [NIP-46](/ko/topics/nip-46/) bunker와 nostrconnect, [NIP-49](/ko/topics/nip-49/) ncryptsec, [NIP-55](/ko/topics/nip-55/) Android signer를 다루는 full login modal을 제공합니다. session은 reload 때 조용히 다시 attach됩니다. network layer는 [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay)를 사용합니다. 이 Web Worker는 큰 web-of-trust set이 한 relay로 fan-out되지 않도록 사용자의 [NIP-65](/ko/topics/nip-65/) outbox를 relay별로 나눕니다. community NIP은 NostrHub, `better-nips`, 다른 미래 client 중 어디에 hosted되든 protocol 수준에서 모두 같고 ranking은 moderator curation이 아니라 social graph에서 나온다는 설계입니다. 이는 [#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling)의 deep dive가 다룬 NIP-32 labeling flow와 직접 맞물립니다.
+
+이번 주 새 [NIP-34](/ko/topics/nip-34/) repo cluster 두 개가 나타났습니다. [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git)는 video 중심 Nostr client이며, [nostrapps.com cluster](wss://gitnostr.com)는 sibling project 세 개를 게시합니다. [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git)는 desktop용 napp VM, [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git)는 customizable communities client, [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git)는 HTML microapps spec과 runtime입니다. 이 cluster는 지난 호 lead story에서 다룬 [napplet](/ko/topics/nip-5d/) 작업과 나란히 놓입니다.
+
+---
+
+## Protocol 작업과 NIP update
+
+### 병합: NIP-44, 65,535-byte payload 제한 해제
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907)은 2024-09부터 열린 채 6월 28일 병합되었습니다. [NIP-44](/ko/topics/nip-44/) versioned-encryption envelope의 plaintext payload 상한 65,535 byte를 없애고 4 GiB(`uint32_max`)까지 높입니다. NIP-44 wire format은 payload length를 `uint16`으로 encode했고 원 사양은 interop을 위해 이를 엄격히 요구했습니다. 병합된 변경은 version byte에 tag된 longer-length field를 채택해 v2 구현은 wire 호환성을 유지하고 v3+ 구현은 더 긴 길이를 전달합니다. [NIP-17](/ko/topics/nip-17/) direct message, [NIP-59](/ko/topics/nip-59/) gift wrap, [NIP-46](/ko/topics/nip-46/) remote-signer payload 또는 다른 NIP-44 암호화 Nostr message를 쓰는 client는 이제 application layer에서 나누지 않고 64 KiB보다 큰 단일 event를 교환할 수 있습니다.
+
+### 병합: NIP-86, signevent method와 Relay Roles event 추가
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389)은 [NIP-86](/ko/topics/nip-86/) relay management JSON-RPC API에 `signevent` method를 추가해 administrator가 relay의 자체 pubkey로 event를 서명하도록 요청할 수 있게 합니다. 함께 나온 [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)은 relay가 administrator와 moderator를 선언하도록 게시하는 replaceable Relay Roles event를 정의합니다. 둘을 합치면 NIP-86 client는 relay의 admin list를 조회하고 out-of-band trust 없이 인증된 request가 현재 admin에게서 왔는지 검증할 수 있습니다. 두 변경은 아래에서 심층 분석합니다.
+
+### 병합: NIP-34, GRASP-06에서 personal-fork를 `u`로 교체
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395)은 6월 24일 병합되어 [NIP-34](/ko/topics/nip-34/) repo-state event(`kind:30618`)의 `personal-fork` tag를 "upstream"을 뜻하는 `u` tag로 바꾸고, wire format을 GitWorkshop suite가 구현해 온 GRASP-06 fork semantics와 맞췄습니다. 이 변경은 다른 fork-semantics 해법을 제안한 [PR #2384](https://github.com/nostr-protocol/nips/pull/2384)(`NIP-34: remove maintainers to solve expiry issues`)를 닫습니다. 병합된 방향은 ngit v2.6.x가 구현하므로 사양과 reference CLI가 일치합니다. 기존 `personal-fork` repo도 계속 상호운용되며 새 repo와 ngit v2.6 line은 `u` tag를 게시합니다.
+
+### 병합: NIP-46 client metadata, Amber 출시 뒤 upstream 반영
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381)은 6월 23일 병합되어 [NIP-46](/ko/topics/nip-46/) `connect` request에 optional client metadata를 추가했습니다. client가 signer connect 때 이름, icon URL, homepage URL을 게시할 수 있습니다. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2)는 지난주 이 metadata extension을 출시했고 [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata)에서 다뤘습니다. 이번 주 upstream NIP이 이미 출시된 구현을 따라잡았습니다.
+
+### 공개: epoch 기반 deterministic NIP-17 wrapper key
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397)과 [PR #2396](https://github.com/nostr-protocol/nips/pull/2396)은 수렴하는 두 NIP-17 wrap-key 제안입니다. PR #2397은 [NIP-59](/ko/topics/nip-59/) gift wrap을 작성하는 ephemeral signing key를 coarse time epoch에 묶인 conversation별 seed에서 deterministically 유도해, conversation key를 아는 recipient가 subscribe할 pubkey를 예측하게 하자고 제안합니다. 현재 사양은 wrap마다 새 random key를 요구해 이 예측이 불가능합니다. PR #2396은 companion 변경으로, conversation wrap을 conversation key 자체로 서명해 wrap pubkey가 conversation identifier 역할도 하게 합니다. 둘은 metadata leakage 없이 filter 가능한 NIP-17 conversation을 만드는 경로를 정의합니다. 둘 다 열려 있고 논의 중입니다.
+
+### 공개: relay가 kind:13 seal event를 거부해야 한다는 NIP-59 제안
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399)은 [NIP-59](/ko/topics/nip-59/) gift wrap의 inner seal인 kind:13 event가 publish request의 top level에 나타나면 relay가 거부해야 한다고 제안합니다. seal event는 wrap 안에서만 의미가 있고 유출된 seal은 recipient pubkey를 노출하기 때문입니다. 함께 나온 [issue #2398](https://github.com/nostr-protocol/nips/issues/2398)은 seal을 ephemeral kind로 다시 정의하자고 더 나아갑니다. NIP-01 ephemeral kind는 relay에 저장되지 않으므로 protocol 수준에서 규칙을 강화하고 relay별 policy 의존을 없앨 수 있습니다.
+
+### 공개: NIP-29 group state
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372)은 [NIP-29](/ko/topics/nip-29/)(relay 기반 group)에 명시적 group-state semantics를 추가합니다. group이 open, closed, public, private, archived라는 뜻과 state transition이 member event와 상호작용하는 방식을 정의합니다. client별이던 의미를 relay 사양으로 끌어옵니다.
+
+### 공개: NIP-34 optional multi-maintainer 지원
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324)은 위에서 다룬 병합 [PR #2395](https://github.com/nostr-protocol/nips/pull/2395)(GRASP-06 fork semantics)의 companion 제안입니다. [NIP-34](/ko/topics/nip-34/) repo announcement event(`kind:30617`)에 optional multi-maintainer 지원을 더해 repeated `maintainer` tag로 여러 canonical maintainer pubkey를 선언하게 합니다. 선언된 maintainer가 서명한 patch와 issue는 client가 official로 신뢰합니다. 공동 maintainer가 있는 NIP-34 repo가 모든 작업을 pubkey 하나로 보내거나 off-protocol coordination에 의존해야 하던 문제를 해결합니다.
+
+### 공개: filter용 NIP-91 AND operator, 제안은 병합되지 않음
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252)는 Nostr [filter](/ko/topics/nip-01/)용 AND operator 제안으로, 이전에 닫힌 [PR #1365](https://github.com/nostr-protocol/nips/pull/1365)의 설계를 다시 엽니다. [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst), worker-relay에 이미 구현되어 있지만 spec PR 자체는 열려 있습니다.
+
+### 종료: pats2sats commerce NIP 네 개
+
+이번 주 Nostr commerce 제안 네 개가 닫혔습니다. Escrow([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations([#2335](https://github.com/nostr-protocol/nips/pull/2335)), [NIP-99](/ko/topics/nip-99/) Marketplace Listing Extension([#2346](https://github.com/nostr-protocol/nips/pull/2346)), Accommodation Listing Profile([#2333](https://github.com/nostr-protocol/nips/pull/2333))입니다. 같은 commerce surface는 이제 [Gamma Market Spec](https://github.com/GammaMarkets/market-spec)에 통합되고 있습니다. 이 project-owned extension repository는 NIP-99 marketplace listing 위에 order, checkout, escrow, dispute semantics를 조합합니다. Compass는 Marmot와 Blossom처럼 NIPs repository 밖의 protocol-spec repo로 이를 추적합니다. 이번 주 열린 PR에는 client-attribution 명확화([#11](https://github.com/GammaMarkets/market-spec/pull/11)), product-identity 변경용 supersedes tag([#8](https://github.com/GammaMarkets/market-spec/pull/8)), merchant-review semantics([#7](https://github.com/GammaMarkets/market-spec/pull/7))가 있습니다.
+
+### 공개: Bitcoin identity linkage
+
+Bitcoin identity를 Nostr identity에 연결하는 제안 두 개가 이번 주 열렸습니다. [NIP-352 Bitcoin Silent Payment Address](https://github.com/nostr-protocol/nips/pull/2392)와 [Bitcoin-OTC Identity Linkage Proof](https://github.com/nostr-protocol/nips/pull/2401)입니다.
+
+---
+
+## NIP 심층 분석: NIP-86(Relay Management API)
+
+[NIP-86](/ko/topics/nip-86/)은 relay management를 위한 JSON-RPC interface를 정의해 authorized client가 표준 API로 relay에 administrative command를 보내게 합니다. client 하나로 relay별 tooling 없이 어느 NIP-86-compatible relay든 관리할 수 있습니다. 이번 주 spec merge 두 개([PR #2389](https://github.com/nostr-protocol/nips/pull/2389), [PR #2390](https://github.com/nostr-protocol/nips/pull/2390))는 relay-signed event와 relay가 선언한 administrator 사이의 고리를 닫습니다.
+
+### Transport
+
+NIP-86 management request는 relay가 WebSocket connection을 제공하는 것과 같은 URI로 보내는 HTTP POST이며 `Content-Type: application/nostr+json+rpc`를 사용합니다. request body는 다음 형태의 JSON document입니다.
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+authentication은 `Authorization` header의 [NIP-98](/ko/topics/nip-98/) HTTP-auth signed event를 사용합니다. relay는 method를 실행하기 전에 signing pubkey가 administrator list에 있는지 검증합니다. relay response는 다음 형태의 JSON document입니다.
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### 이번 주 이전부터 있던 method
+
+기존 method set은 pubkey ban(`banpubkey`, `allowpubkey`, `listbannedpubkeys`), event ban(`banevent`, `allowevent`, `listbannedevents`), relay metadata(`changerelayname`, `changerelaydescription`, `changerelayicon`), allowed-pubkey list 관리(`allowkind`, `disallowkind`, `listallowedkinds`), relay 통계를 반환하는 `stats`를 다룹니다. client가 그 위에 typed binding을 올릴 수 있도록 표준 JSON-RPC service와 의도적으로 비슷한 형태입니다.
+
+### 이번 주 변경
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389)은 spec에 `signevent` method를 추가합니다. method는 partial event template(kind, tags, content)을 argument로 받아 relay가 자체 pubkey를 `pubkey` field에 넣어 서명한 complete event를 반환하도록 요청합니다. relay가 자기 자신에 대한 protocol-level event를 게시하기 위한 전제입니다. blocked-pubkey announcement, relay metadata, 아래의 새 Relay Roles event는 모두 operator-controlled key로 relay가 서명해야 하지만, 대부분 relay operator는 administrative client에 private key를 보관하고 싶어 하지 않습니다.
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390)은 Relay Roles event를 정의합니다. relay가 자체 pubkey로 `signevent`를 통해 서명하여 게시하는 parameterised replaceable event kind로, administrator와 moderator pubkey를 명시적 role semantics와 함께 선언합니다. NIP-86-aware client는 추적하는 relay에서 Relay Roles event를 가져와 event tag로 admin list를 만들고, out-of-band trust나 relay별 설정 없이 authenticated NIP-86 request가 현재 admin에게서 왔는지 검증할 수 있습니다. 두 PR은 함께 고리를 닫습니다. `signevent`가 mechanism이고 Relay Roles가 그 위에 만든 첫 event kind입니다.
+
+### NIP-86 request 예시
+
+완전한 NIP-86 `banpubkey` request는 다음과 같습니다.
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+`Authorization` header에는 NIP-98 signed event가 담깁니다.
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+signing pubkey는 relay의 admin set(이제 relay-roles event에 선언됨)에 있어야 하고, `u` tag는 relay의 HTTPS URL과 일치해야 하며, `payload` tag는 JSON request body의 SHA-256과 일치해야 합니다. relay는 다음을 반환합니다.
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### 구현
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst)는 Android에 NIP-86 relay management UI를 제공합니다(v1.07.0+).
+- spec을 구현한 reference relay에는 [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru), 그리고 spec의 `Implementation Status` section이 연결하는 여러 작은 구현이 있습니다.
+
+구현자들이 `signevent`와 Relay Roles 변경을 반영하면 NIP-86-aware client는 relay-roles event를 relay admin list의 canonical source로 다루기 시작할 것입니다.
+
+---
+
+## NIP 심층 분석: NIP-89(Recommended Application Handlers)
+
+[NIP-89](/ko/topics/nip-89/)는 parameterised replaceable event kind 두 개를 정의합니다. 앱 개발자가 게시하는 application handler `kind:31990`과 사용자가 쓰는 앱을 추천하는 `kind:31989`입니다. 둘을 통해 client는 out-of-band coordination 없이 모르는 event kind를 처리하는 application을 찾을 수 있습니다. native로 처리하지 못하는 `kind:30030` event를 만난 longform reader는 NIP-89 graph에서 handler를 질의하고, 해당 event를 처리하는 published app으로 사용자를 보내는 `Open in...` flow를 제공할 수 있습니다. NIP-89는 이번 호 곳곳의 napplet/napps 작업이 composable Nostr-native applet으로 확장하는 cross-app routing 문제의 원래 기반입니다.
+
+### Application handler event(`kind:31990`)
+
+app developer는 app이 지원하는 event kind와 Nostr entity를 app에서 여는 방법을 설명하는 handler event를 하나 이상 게시합니다.
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+`d` tag는 handler를 식별해 replace할 수 있게 하고, 각 `k` tag는 app이 처리하는 event kind를 선언합니다. 각 platform tag(`web`, `ios`, `android`, ...)는 호출하는 client가 open 때 대체할 [NIP-19](/ko/topics/nip-19/) encoded entity placeholder `<bech32>`가 있는 URL template를 제공합니다. 같은 routing pattern을 공유한다면 handler event 하나가 여러 지원 kind를 알릴 수 있어 app discovery를 compact하게 유지하고 kind마다 별도 handler event를 만드는 일을 피합니다.
+
+### User recommendation event(`kind:31989`)
+
+사용자는 특정 event kind에 어떤 앱을 쓰는지 선언하는 recommendation을 게시합니다.
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+`d` tag는 추천 대상 event kind를 담습니다. 각 `a` tag는 `kind:31990` handler event를 가리키는 NIP-01 address pointer이며, 추천 relay와 recommendation이 적용되는 platform을 함께 담습니다. 같은 recommendation에 platform별 여러 앱을 나열할 수 있습니다.
+
+### Client tag와 privacy tradeoff
+
+NIP-89는 event를 게시하는 앱이 작성 event에 붙일 수 있는 optional `client` tag도 정의합니다.
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+이를 통해 event를 보여주는 client는 어느 앱에서 왔는지 표시하고, 더 풍부한 handler metadata를 조회하며, handler가 선언한 rendering hint를 따를 수 있습니다. 사양은 privacy 비용도 명시합니다. 모든 event에 `client` tag를 내보내면 사용자의 software identity가 공개되고 시간이 지나며 usage pattern이 드러납니다. spec은 client가 opt-out을 제공하도록 권합니다.
+
+Amethyst의 [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422)는 event display에서 NIP-89 `t`, `i`, `a`, `client` tag를 parse하고 보여주어 timeline에서 note를 작성한 앱을 직접 드러냅니다.
+
+### 실제 discovery flow
+
+모르는 event kind를 받은 client는 다음 순서를 밟습니다. (1) 사용자의 follow graph에서 해당 event kind와 일치하는 `d` tag를 가진 `kind:31989` event를 질의합니다. (2) 추천된 각 `a` tag를 `kind:31990` handler event로 resolve합니다. (3) 현재 platform과 맞는 `web`, `ios`, `android` URL template의 handler를 고릅니다. (4) entity의 `bech32` encoding을 URL template에 대입합니다. (5) 결과 URL을 `Open in...` 선택지로 제공합니다. 이 flow는 social filter를 거칩니다. 신뢰하지 않는 relay의 임의 handler event를 질의하면 악성 앱으로 redirect될 수 있으므로, 모든 published handler를 똑같이 신뢰하는 것보다 사용자가 follow하는 사람에서 시작하는 편이 안전한 기본값입니다.
+
+### NIP-89와 napplet layer
+
+Amethyst의 Discover section, napplet-host runtime, `client`-tag display는 Android에 완전한 NIP-89 consumer surface를 함께 만듭니다. 지난 호에 출시된 napplet spec은 NIP-89 handler event가 가리킬 수 있는 대상을 확장합니다. Nostr와 Blossom 위에서 composable Nostr-native runtime을 실행하는 sandboxed applet입니다. NIP-89가 discovery 및 routing graph이고 napplet runtime은 그 graph가 가리킬 수 있는 execution target 하나입니다.
+
+---
+
+*피드백, 수정 사항, 빠뜨린 프로젝트가 있다면 [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass)에 issue를 열거나 npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923으로 NIP-17 DM을 보내주세요.*

--- a/content/nl/newsletters/2026-07-01-newsletter.md
+++ b/content/nl/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,372 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+Welkom terug bij Nostr Compass, je wekelijkse gids voor Nostr.
+
+**Deze week:** [FIPS v0.4.0](#fips-v040-levert-nym-mixnet-transport-mdns-ontdekking-en-een-vernieuwde-dataplane) levert Nym-mixnettransport, optionele mDNS-ontdekking op het LAN, ononderbroken rekeying bij pakketverlies en een vernieuwde dataplane, wire-compatible met v0.3.0. [Whitenoise Linux](#whitenoise-linux-verschijnt-als-desktopclient-voor-marmot) verschijnt als desktopclient voor Marmot in Rust en Slint, met een protocolvoorstel om berichteffecten naar een afzonderlijk kind-9-event te verplaatsen. [CustID v0.1.10-beta](#custid-verschijnt-als-mobiele-identiteitskluis-met-nip-46-en-nfc-challenge-flow) verschijnt als hardwarematig beveiligde mobiele identiteitskluis die als NIP-46-remote signer werkt en fysieke toegangsuitdagingen via NFC beantwoordt. [myco](#myco-verschijnt-met-peer-to-peer-deling-van-nsites-over-het-fips-mesh) brengt peer-to-peer-deling van nsites over het FIPS-mesh, met een nieuw BLE L2CAP-transport in v0.1.0. [Nostr Codex Phone](#nostr-codex-phone-verschijnt-als-mobiel-bedieningspaneel-voor-een-lokale-codex-worker-over-nostr) verschijnt als Android-bedieningspaneel voor een lokale Codex-codeerassistent via versleutelde Nostr-DM's. [De nog niet uitgebrachte versie van Amethyst](#amethyst-bouwt-een-nip-89-bewuste-ui-een-git-repositories-feed-en-een-discover-sectie-voor-napplets) voegt parsing van NIP-89-apphandlers, een Git Repositories-feed voor NIP-34 en een Discover-sectie voor nSites en napplets toe. [Notedeck](#notedeck-implementeert-nip-37-relays-voor-privesynchronisatie-nip-52-agendas-en-nip-22-commentaren) implementeert NIP-37, NIP-52 en NIP-22 in één week. [Applesauce](#applesauce-levert-nbunksec-nip-46-sessies-en-een-cashu-v4-walletupgrade) brengt twaalf subpackagereleases uit met nbunksec-helpers voor NIP-46 en een walletupgrade naar Cashu-ts v4. [Meiso v1.4.0](#meiso-v140-levert-collaborative-lists-met-een-gedeelde-sleutel-die-mls-voor-taakdeling-vervangen) levert Collaborative Lists met een gedeelde sleutel op adresseerbaar kind 35000. De NIPs-repository voegde vijf PR's samen, waaronder een Relay Roles-event, het schrappen van de limiet van 65.535 bytes in NIP-44, NIP-34-forksemantiek, NIP-46-clientmetadata en een NIP-86-`signevent`-methode. De deep dives behandelen [NIP-86 (Relay Management API)](#nip-deep-dive-nip-86-relay-management-api) en [NIP-89 (Recommended Application Handlers)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Topverhalen
+
+### FIPS v0.4.0 levert Nym-mixnettransport, mDNS-ontdekking en een vernieuwde dataplane
+
+[FIPS](https://github.com/jmcorgan/fips) is een privaat, zelforganiserend peer-to-peer-meshnetwerk voor Nostr waarin nodes elkaar ontdekken en verkeer routeren zonder centrale infrastructuur. [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) levert Nym-mixnettransport, optionele mDNS-ontdekking op het LAN, een vernieuwde dataplane, ononderbroken rekeying bij pakketverlies, een herschreven `fipstop`-TUI op een render-snapshot-harnas, een observability-plane buiten het hot path en nieuwe packagingtargets voor OpenWrt-apk en Nix flakes. Alles blijft wire-compatible met v0.3.0, zodat gemengde meshes tijdens een rolling upgrade samenwerken. Twee nieuwe transporten voor peerontdekking vormen de kern van de release. Een nieuw [uitgaand Nym-mixnettransport](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) routeert FIPS-verkeer via een `nym-socks5-client`-SOCKS5-proxy en mengt het in het cover-traffic-netwerk van [Nym](https://nymtech.net/), zodat waarnemers op linkniveau niet kunnen correleren welke meshpeers met elkaar praten. De map `examples/sidecar-nostr-mixnet-relay/` demonstreert een Nostr-relay die via een FIPS-link end-to-end over het mixnet bereikbaar is. Met optionele mDNS-/DNS-SD-ontdekking vinden nodes op dezelfde lokale link elkaar zonder adresconfiguratie of STUN; ze adverteren en accepteren peers via een standaard-servicerecord wanneer `node.discovery.lan.enabled: true` staat.
+
+De dataplane is herwerkt voor meer throughput per node. Encryptie en decryptie per peer draaien nu in eigen workertaken buiten de receive-loop, zodat één drukke peer de cryptografie van de hele node niet meer serialiseert. Het Linux-sendpad gebruikt waar mogelijk generic segmentation offload en een verbonden UDP-socket, het receive-hotpath vermijdt bufferkopieën die voorheen per pakket werden gemaakt en macOS krijgt `recvmsg_x` voor batched receive als tegenhanger van Linux' `recvmmsg`-batching uit v0.3.0. Het volledige `show_*`-leesoppervlak voor `fipsctl` en `fipstop` wordt nu bediend vanuit een snapshot per tick, dat de control-accept-taak in een lock-free `ArcSwap` publiceert. Daardoor worden operatorqueries snel beantwoord, ook wanneer de receive-loop van een node druk is. Een nieuwe `show_metrics`-query met alleen tellers (beschikbaar als `fipsctl stats metrics`) maakt Prometheus-scraping mogelijk zonder kosten in het hot path.
+
+Rekeying van FMP- en FSP-sessies verloopt nu in beide richtingen zonder onderbreking bij pakketverlies en herordening: inkomende frames worden tegen de wachtende sessie geauthenticeerd voordat de K-bit-cutover die sessie promoveert (zodat een oud of gespooft frame rekeying niet kan ontsporen), retransmissie van rekey-bericht 1 is begrensd, de link-dead-heartbeat houdt rekening met rekeying en races bij gelijktijdige initiatie op high-latency-links worden met symmetrische jitter gedesynchroniseerd. De `fipstop`-TUI is herbouwd op een render-snapshot-harnas dat voor elke view het exacte tekstraster en de stijl per cel controleert tegen vooraf gemaakte control-socket-output. Er komen ook nieuwe packagingtargets: een OpenWrt-`.apk` voor OpenWrt 25+ (gebouwd zonder SDK, met hergebruik van de bestaande `.ipk`-crosscompile en de payload van het geïnstalleerde bestandssysteem) en een `flake.nix` in de projectroot die alle vier binaries (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) vanuit de bron bouwt op Nix/NixOS met de vastgezette toolchain.
+
+### Whitenoise Linux verschijnt als desktopclient voor Marmot
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) is een desktopclient voor [Marmot](/nl/topics/marmot/): MLS-groepsberichten via Nostr-relays, verpakt als één Rust-binary met een Slint-UI die elk geheim in één met een wachtwoord versleutelde kluis bewaart.
+
+De belangrijkste discussie van deze week stelt voor om Whitenoise-berichteffecten te vervoeren als een afzonderlijk kind-9-event dat naar het bovenliggende bericht verwijst. Het huidige wire-formaat plakt een marker zoals `dmfx:sparkle` achter aan de berichttekst, waardoor renderers die de conventie niet kennen vervuilde tekst tonen. Effecten in een eigen event houden de berichttekst schoon en leggen een ontwerpvraag bloot waarmee de bredere Marmot-stack te maken krijgt: inline-conventies in de body of sidecar-events voor optionele rijke functies.
+
+### CustID verschijnt als mobiele identiteitskluis met NIP-46 en NFC-challenge-flow
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) is de eerste publieke bèta van CustID, een mobiele identiteitskluis op Nostr en het SISTR-protocol. CustID bewaart meerdere Nostr-identiteiten in hardwarematig beveiligde opslag, werkt voor andere clients als [NIP-46](/nl/topics/nip-46/)-remote signer en beantwoordt fysieke en online toegangsuitdagingen via NFC en QR-codes.
+
+De bèta is volledig voor de NIP-46-signer en de NFC-challenge-response-flow; toegangsflows met zero-knowledge proofs blijven een toekomstige mijlpaal. Deze release verwijdert ook de [NIP-65](/nl/topics/nip-65/)-keep-alive-laag op de achtergrond. Die opende per profiel en per leesrelay een WebSocket en nam kinds in die de client meteen weggooide. Alleen de NIP-46-sockets met meldingen van ondertekeningsverzoeken blijven nu op de achtergrond actief. Daardoor is CustID op een telefoon bruikbaar als bunker voor andere clients.
+
+### myco verschijnt met peer-to-peer-deling van nsites over het FIPS-mesh
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) opende deze week op 27 juni en bereikte v0.1.0 op 1 juli. myco is een Android-app in Rust die apps installeert van mensen in je omgeving: peer-to-peer-deling van [nsites](/nl/topics/nip-5a/) over een FIPS-mesh, via elk transport dat het mesh kan dragen (UDP, TCP, Tor, Bluetooth) en volledig offline. Het ontwerp koppelt FIPS als transportlaag rechtstreeks aan het eventformaat voor statische websites van NIP-5A als payload. Daardoor kan een als nsite gedistribueerde app tussen meshpeers bewegen zonder afhankelijk te zijn van relays of HTTP.
+
+v0.1.0 voegt een L2CAP-radiopad via Bluetooth toe, zodat twee telefoons met FIPS via BLE kunnen peeren zonder netwerk. Ook komen er een speedtest per peer en door NFC geactiveerd delen vanuit de Circle-bottom-sheet van de app. myco staat eveneens op Zapstore voor rechtstreekse installatie.
+
+### Nostr Codex Phone verschijnt als mobiel bedieningspaneel voor een lokale Codex-worker over Nostr
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) verschijnt deze week als Android-client die een lokale Codex-worker voor codeerassistentie bestuurt via versleutelde directe berichten over Nostr. De app ondersteunt meerdere repositorysessies, spraaktranscriptie, gerouteerde workersessies, Blossom-mediauploads en optionele gesproken antwoorden. Zo kan een ontwikkelaar met een Codex-worker thuis vanaf een telefoon opdrachten versturen zodra die telefoon toegang tot een relay heeft.
+
+Het project is een directe tegenhanger van [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), dat in #28 verscheen. Beide plaatsen agentic-coding-workflows op Nostr-transport met versleutelde DM's en gebruiken Nostr als koppelings- en berichtenlaag waarmee een telefoon een worker thuis bereikt zonder gaten in het netwerk te openen. Nostr als control-plane voor lokale agents wordt een herkenbaar patroon.
+
+### Coop Mobile publiceert zijn eerste versiegenummerde builds
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) en [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) verschenen deze week als de eerste versiegenummerde builds van Coop Mobile, een Android-client voor versleutelde directe berichten via [NIP-17](/nl/topics/nip-17/). De twee releases verbeteren de crashbestendigheid bij het parsen van berichten en verwerken van QR-codes en wissen bij uitloggen alle opgeslagen gegevens.
+
+### Amethyst bouwt een NIP-89-bewuste UI, een Git Repositories-feed en een Discover-sectie voor napplets
+
+De main-branch van [Amethyst](https://github.com/vitorpamplona/amethyst) bouwde deze week meerdere nieuwe oppervlakken uit. Een [Git Repositories-feed](https://github.com/vitorpamplona/amethyst/pull/3406) verandert [NIP-34](/nl/topics/nip-34/)-repo's in een doorbladerbare Android-tijdlijn, filterbaar op community en auteur, naast een [smart-HTTP-gitbrowser](https://github.com/vitorpamplona/amethyst/pull/3415) die repository-inhoud en commits leest zonder de app te verlaten. De napplet-host kreeg een [Discover-sectie](https://github.com/vitorpamplona/amethyst/pull/3409) met gecureerde webapps, gevolgde nSites en napplets, afkomstig uit [NIP-89](/nl/topics/nip-89/)-handlerevents en [NIP-5A](/nl/topics/nip-5a/)-site-events. De weergave van notes [toont nu welke Nostr-app een event schreef](https://github.com/vitorpamplona/amethyst/pull/3422) via NIP-89-tags. Voor synchronisatie komt [NIP-77-negentropy-ondersteuning](https://github.com/vitorpamplona/amethyst/pull/3434) met streaming reconciliation en automatische `created_at`-vensters om resultaatlimieten van relays te omzeilen. Dat vermindert de bandbreedte die nodig is om grote lokale eventsets met een relay te synchroniseren.
+
+### Buzz v0.3.38 verhardt het relay-aanvalsoppervlak en voegt provideronafhankelijke modelkeuze toe
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) verhardt het [relay-aanvalsoppervlak](https://github.com/block/buzz/pull/1369) dat Buzz blootstelt wanneer het persona's, teams, beheerde agents en NIP-OA-owner attestations als ondertekende Nostr-events publiceert. Een Buzz-relay is een openbaar register van de Nostr-identiteiten en toestand van een team; deze release scherpt de invoervalidatie en replaybescherming aan voor de bekende eventkinds die Buzz definieert. De release veralgemeniseert ook de modelkeuze, zodat een Buzz-team elke provider kan gebruiken waarvoor Buzz een adapter heeft, waaronder een nieuwe Databricks AI Gateway v2-backend.
+
+### Notedeck implementeert NIP-37-relays voor privésynchronisatie, NIP-52-agenda's en NIP-22-commentaren
+
+[Notedeck](https://github.com/damus-io/notedeck), de native Rust-desktopclient van het Damus-team, implementeerde in één week drie protocollen. Relays voor privésynchronisatie worden nu opgeslagen als een kind `10013`-[NIP-37](/nl/topics/nip-37/)-lijst, los van de publieke NIP-65-outbox van de gebruiker. Het agendapaneel `horizon` leest [NIP-52](/nl/topics/nip-52/)-events uit nostrdb en kreeg een herontwerp met drie panelen. Het paneel `headway` voegde een [NIP-22](/nl/topics/nip-22/)-model voor commentaarevents toe op kind `1111`, het kind dat NIP-22 definieert voor het uniforme commentaaroppervlak dat reply-threading uit NIP-10 vervangt.
+
+
+
+### Applesauce levert nbunksec-NIP-46-sessies en een Cashu v4-walletupgrade
+
+[Applesauce](https://github.com/hzrd149/applesauce), de modulaire Nostr-toolkit voor signers, relays, wallets en content, bracht een gecoördineerde [6.2.x-release](https://github.com/hzrd149/applesauce/releases) uit voor zijn subpackages. Het signerpackage kreeg helpers voor het importeren en exporteren van `nbunksec`, waarmee een [NIP-46](/nl/topics/nip-46/)-bunkersessie een verplaatsbaar artefact wordt dat tussen clients kan worden overgezet. Het walletpackage vernieuwde zijn [Cashu](/nl/topics/nip-60/)-bindings naar `@cashu/cashu-ts` v4, waarin proofbedragen `Amount`-value objects worden en de API voor tokendecodering verandert.
+
+---
+
+## Releases met tags
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) levert de volgende protocoliteratie voor het [Mostro](/nl/topics/nip-69/)-netwerk voor peer-to-peerhandel in fiatgeld. De release volgt op [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) en verschijnt naast [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), dat de nieuwe core overneemt. Deze week werden drie PR's in de core-repository samengevoegd; de omliggende stack (mostro daemon en Mostro mobile) volgt v0.14.0 van de gedeelde types-crate.
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), de canonieke git-over-Nostr-CLI voor [NIP-34](/nl/topics/nip-34/)-repositories, implementeert de deze week samengevoegde [NIP-34 GRASP-06-forksemantiek](https://github.com/nostr-protocol/nips/pull/2395), die de `personal-fork`-tag op repo-state-events vervangt door een `u`-tag.
+
+### mesh-llm v0.72.0 en v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm), het inference-onderdeel van de ContextVM-stack dat opensource-LLM's achter een via Nostr adresseerbaar JSON-RPC-oppervlak draait, bracht [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) en [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1) uit met een oplossing voor een batchingcrash bij grote afzonderlijke prompts en een migratie van de MCP-bridge weg van verouderde helpers.
+
+### Meiso v1.4.0 levert Collaborative Lists met een gedeelde sleutel die MLS voor taakdeling vervangen
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) introduceert een model van Collaborative Lists met een gedeelde sleutel, dat de eerdere taakdeling op basis van MLS vervangt door een eenvoudiger ontwerp met adresseerbare events. Elke gedeelde lijst maakt een eigen Nostr-sleutel die onder leden wordt verspreid. Taken zijn adresseerbare events op kind `35000`, geïdentificeerd met `d=task-id`, met via [NIP-44](/nl/topics/nip-44/) zelfversleutelde content. Relays dwingen Last-Write-Wins per taak af. Het ontwerp levert de forward secrecy en post-compromise security van MLS in voor een eenvoudiger clientimplementatie en conflictoplossing op relayniveau.
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) levert een "more-private-coordinator"-traject dat tijdelijke pubkeys van afzenders uit het publiceren van groepsberichten verwijdert en de flow voor joinverzoeken verhardt tegen verouderde herhaalde verzoeken. Cordn is de op MLS gebaseerde berichtenstack uit [de lancering van Cordn Ad-hoc CVM in #28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); deze release is de bijbehorende update aan de coördinatorzijde.
+
+---
+
+## Nog niet uitgebrachte wijzigingen
+
+### diVine verwerkt 108 samengevoegde PR's met verbeteringen na de lancering
+
+[diVine](https://github.com/divinevideo/divine-mobile), de client voor korte loopingvideo's die Vine terugbrengt, zit in een intensieve verbeteringsronde na de lancering. Het voor Nostr zichtbare werk van deze week is een stabiliteitspass voor de [NIP-46](/nl/topics/nip-46/)-connectflow die fouten van `nostrconnect://` omzet in gestructureerde redencodes.
+
+### Zap Cooking zet de projectoverschrijdende NIP-46-fix en herbouw van de composer voort
+
+[Zap Cooking](https://github.com/zapcooking/frontend) is een Nostr-client voor het delen van recepten, waarbij recepten als longform-events op Nostr worden gepubliceerd. Het werk van deze week zet de projectoverschrijdende [NIP-46](/nl/topics/nip-46/)-fix en herbouw van de composer voort die in [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes) als nog niet uitgebracht zijn beschreven.
+
+### Conduit verhardt de flow voor listings en de correctheid van de marktplaats
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) is een marktplaats-monorepo op Nostr met drie apps: de kopersmarkt, het handelaarsportaal en de winkelbouwer. Het werk van deze week zet de verbeteringen aan de correctheid van de marktplaats voort die in [de lanceringsdekking van #28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default) aan bod kwamen, voortbouwend op de [NIP-99](/nl/topics/nip-99/)-handelsgolf die vorig nummer het protocolverhaal vormde.
+
+### Pollerama v1.12 tot en met v1.13.1 voegen keuze van clienttag, profieltabbladen en threadlimieten toe
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls), een Android-Nostr-client voor polls en notes met een sterke web-of-trust-ontdekkingslaag, bracht deze week v1.12.0, v1.13.0 en v1.13.1 uit op Zapstore. Gebruikers kunnen nu kiezen welke clienttag aan hun notes en polls wordt toegevoegd, uit een vooraf ingestelde lijst of met een eigen invoer. Diep geneste commentaar- en antwoordketens stoppen nu na enkele niveaus en linken naar de volledige thread op de notepagina. Profielpagina's openen standaard op Notes, onderverdeeld in een tabblad Posts en een tabblad Conversations. Een persistentiefout waarbij nieuw gevolgde accounts na een herstart verdwenen is opgelost en volgknoppen tonen nu voortgang.
+
+### getwired.app en get-tao.app repareren de NIP-13-flow voor confess-inzendingen
+
+[getwired.app](https://github.com/smolgrrr/Wired) en [get-tao.app](https://github.com/smolgrrr/TAO) delen een flow voor anoniem publiceren die bij het inzenden NIP-13-proof-of-work toevoegt om spam te onderdrukken. Ze repareerden de [flow voor confess-inzendingen](https://github.com/smolgrrr/Wired/pull/57), zodat de UX tijdens PoW-mining samenhangend is.
+
+### nostui voegt een tijdlijntabblad voor vermeldingen toe
+
+[nostui](https://github.com/akiomik/nostui), een terminalclient voor Nostr in Rust, voegde een [tijdlijntabblad voor vermeldingen](https://github.com/akiomik/nostui/pull/463) toe dat kind-1-events die de actieve pubkey taggen in een afzonderlijke TUI-view toont.
+
+### Heartwood krijgt NIP-46-bunker-URI's per identiteit en een ondertekeningsbridge in HSM-modus
+
+[Heartwood](https://github.com/forgesworn/heartwood) is een [NIP-46](/nl/topics/nip-46/)-signer waarbij de ondertekeningssleutel nooit bij de client terechtkomt: de client spreekt NIP-46 met een kleine relay en de relay spreekt een serieel frameprotocol met een aangesloten hardwareapparaat dat de handtekening uitvoert. Deze week kreeg het project een [ondertekeningsbridge van relay naar seriële verbinding](https://github.com/forgesworn/heartwood/pull/11) en [bunkerverbindingen per identiteit](https://github.com/forgesworn/heartwood/pull/16), zodat één hardwareapparaat met meerdere identiteiten voor elke identiteit een afzonderlijke bunker-URI aanbiedt.
+
+### Nostter vernieuwt authenticatie en signers
+
+[Nostter](https://github.com/SnowCait/nostter) vernieuwde deze week zijn [authenticatie- en signerlaag](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth): de loginstatus verhuisde naar één signal en signer-dispatch werd opgesplitst in strategiemodules. Het doel is een heldere signerabstractie waarin de NIP-07-webextensie, NIP-46-remote bunker en raw nsec hetzelfde codepad delen.
+
+### Dart NDK splitst de NIP-07-signer af en randomiseert NIP-59-tijdstempels
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) verplaatste zijn [NIP-07](/nl/topics/nip-07/)-signer uit het corepackage naar `ndk_flutter` (waar de Flutter WebView zich bevindt) en [randomiseerde de NIP-59-tijdstempels van gift wraps](https://github.com/relaystr/dart_ndk/pull/667) om correlatie van versleutelde berichten op basis van timing te bemoeilijken.
+
+### Milk Market voegt NIP-23-winkelpagina's en betalingsverwerking via Square toe
+
+[Milk Market](https://github.com/shopstr-eng/milk-market), de marktplaatswinkel van het Shopstr-team, gaf elke winkel een blogpagina op basis van de [NIP-23](/nl/topics/nip-23/)-longform-events van de verkoper, met bewerkbare secties en een rechtstreekse route naar de bloginstellingen. In dezelfde week kwamen [Square](https://github.com/shopstr-eng/milk-market/pull/30) als alternatieve betalingsverwerker voor verkopers en automatische aankoop van verzendlabels voor betaalde bestellingen erbij.
+
+### Calendar by Formstr brengt een iOS-app uit
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) voegde deze week [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159) samen en bracht daarmee de [NIP-52](/nl/topics/nip-52/)-agendaclient naar iOS. [PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) repareert het parsen van kalenderdatums in lokale tijd en [PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) voegt een Playwright-E2E-workflow toe die door een `run-tests`-label wordt geactiveerd.
+
+### cagliostr handhaaft NIP-22, NIP-09 per coördinaat en NIP-13-proof-of-work
+
+[cagliostr](https://github.com/mattn/cagliostr), een relayimplementatie in Go, scherpte deze week drie handhavingspaden aan: [configureerbare NIP-13-proof-of-work](https://github.com/mattn/cagliostr/pull/7) voor inkomende events, [NIP-09-verwijdering per adresseerbare coördinaat](https://github.com/mattn/cagliostr/pull/8), zodat vervangbare events via hun `a`-tag kunnen worden verwijderd (wat verwijdering per event-id niet kan bereiken), en [configureerbare NIP-22-limieten voor tijdstempels](https://github.com/mattn/cagliostr/pull/9) die events met een tijdstempel te ver in het verleden of de toekomst weigeren.
+
+---
+
+## Nieuw gevolgd en ontdekt
+
+De [wellbeing-suite van Vanderwarker](https://git.vanderwarker.family/wellbeing) publiceert telemetrie uit de fysieke wereld als Nostr-events onder één gedeelde ondertekeningssleutel van de publisher. De suite bestaat uit vijf zusterapps: [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) is een stappenteller die fitnessgegevens als `kind:30078` aan Nostr verankert; [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) publiceert dagelijks hoe vaak een telefoon is ontgrendeld; [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) publiceert de huidige mediaweergave als User Status; [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) publiceert elke vijftien minuten batterijniveau, spanning en temperatuur; en [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) publiceert dagelijks het dataverbruik. Alle vijf verschenen tussen 24 en 30 juni op Zapstore.
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) is een versleutelde, serverloze Android-app voor live locatiedeling, gebouwd in Rust en Slint en uitgebracht op 29 juni. Het is een tegenhanger van [Haven](https://github.com/mehmetefeumit/Haven-App), de op [Marmot](/nl/topics/marmot/) gebaseerde app voor locatiedeling uit [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), maar met een andere transportarchitectuur: versleutelde Nostr-DM's vervoeren de locatie-updates, terwijl Haven Marmot-groepsberichten gebruikt.
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) is een applicatieshell in een vroeg stadium voor het bouwen van Nostr-apps. Het project publiceerde deze week zijn eerste gebruikersdocumentatie.
+
+[NIPs by Pollerama](https://nips.pollerama.fun) (repository [abh3po/better-nips](https://github.com/abh3po/better-nips), aangemaakt op 2026-06-29) is een nieuwe client voor de door de community geschreven `kind:30817`-NIPs van [NostrHub](https://nostrhub.io), bedoeld als op vertrouwen gewogen alternatief voor nostrhub.io. Elke `kind:30817`-NIP heeft een eigen deelbare URL (`#/nip/<naddr>`) met volledige Markdown-weergave en de eventkinds die de NIP definieert. De client biedt drie feeds: Following, Web of Trust (gevolgden van gevolgden) en Global. Elke feed kan worden gesorteerd op op vertrouwen gewogen goedkeuringen of op nieuwste. Goedkeuringen worden gepubliceerd als [NIP-32](/nl/topics/nip-32/)-labels op kind `1985`, met tags `["L","nostrhub"]` en `["l","approve","nostrhub"]`, plus een `a`-tag die naar het doeladres van de NIP wijst en een `client`-tag die `better-nips` vermeldt. Dat is exact de eventvorm die NostrHub zelf ondertekent, zodat goedkeuringen tussen beide clients compatibel zijn. Een goedkeuring van een direct gevolgd account weegt in de rangschikking zwaarder dan een goedkeuring van een tweede graad.
+
+De signerstack is [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer), met een volledige loginmodal voor [NIP-07](/nl/topics/nip-07/), [NIP-46](/nl/topics/nip-46/)-bunker en nostrconnect, [NIP-49](/nl/topics/nip-49/)-ncryptsec en [NIP-55](/nl/topics/nip-55/)-Android-signer. Sessies worden bij herladen stil opnieuw gekoppeld. De netwerklaag draait via [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), een Web Worker die de [NIP-65](/nl/topics/nip-65/)-outbox van de gebruiker over relays verdeelt, zodat een grote web-of-trust-set niet naar één relay uitwaaiert. Het ontwerp stelt dat community-NIPs, ongeacht of ze bij NostrHub, in `better-nips` of bij toekomstige clients staan, op protocolniveau gelijk zijn; de rangschikking komt uit de sociale grafiek, niet uit moderatie. Dat sluit rechtstreeks aan op de NIP-32-labelingflow uit de deep dive in [#25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling).
+
+Deze week verschenen twee nieuwe clusters van [NIP-34](/nl/topics/nip-34/)-repo's. [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) is een videogerichte Nostr-client. Een [nostrapps.com-cluster](wss://gitnostr.com) publiceert drie zusterprojecten: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git) (een napp-VM voor desktop), [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git) (een aanpasbare communityclient) en [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git) (een specificatie en runtime voor HTML-microapps). Het cluster loopt parallel aan het [napplet](/nl/topics/nip-5d/)-werk uit het topverhaal van het vorige nummer.
+
+---
+
+## Protocolwerk en NIP-updates
+
+### Samengevoegd: NIP-44 schrapt de payloadlimiet van 65.535 bytes
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907) werd op 28 juni samengevoegd nadat hij sinds 2024-09 openstond. De wijziging schrapt de bovengrens van 65.535 bytes voor de plaintext-payload van een [NIP-44](/nl/topics/nip-44/)-envelope met versiegebonden versleuteling en verhoogt die naar 4 GiB (`uint32_max`). NIP-44 codeert de payloadlengte als een `uint16` in het wire-formaat, wat de oorspronkelijke specificatie strikt vereiste voor interoperabiliteit. De samengevoegde wijziging gebruikt een langer lengteveld dat in de versiebyte wordt gemarkeerd, zodat v2-implementaties wire-compatible blijven en v3+-implementaties de langere lengte dragen. Clients die NIP-44 gebruiken voor directe berichten via [NIP-17](/nl/topics/nip-17/), gift wraps via [NIP-59](/nl/topics/nip-59/), payloads voor remote signers via [NIP-46](/nl/topics/nip-46/) of andere via NIP-44 versleutelde Nostr-berichten, kunnen nu afzonderlijke events groter dan 64 KiB uitwisselen zonder ze op applicatieniveau te splitsen.
+
+### Samengevoegd: NIP-86 krijgt een `signevent`-methode en een Relay Roles-event
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) voegt een `signevent`-methode toe aan de JSON-RPC-API voor relaybeheer van [NIP-86](/nl/topics/nip-86/), waarmee een beheerder de relay kan vragen een event met de eigen pubkey van de relay te ondertekenen. De bijbehorende [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) definieert een Relay Roles-event: een vervangbaar event dat een relay publiceert om zijn beheerders en moderators bekend te maken. Samen laten ze NIP-86-clients de beheerderslijst van een relay inspecteren en zonder out-of-band-vertrouwen controleren of een geauthenticeerd verzoek van een huidige beheerder kwam. Hieronder volgt een deep dive over beide wijzigingen.
+
+### Samengevoegd: NIP-34 vervangt `personal-fork` door `u` voor GRASP-06
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395) werd op 24 juni samengevoegd en vervangt de `personal-fork`-tag van [NIP-34](/nl/topics/nip-34/) op repo-state-events (`kind:30618`) door een `u`-tag (voor "upstream"). Daarmee sluit het wire-formaat aan op de GRASP-06-forksemantiek die de GitWorkshop-suite implementeert. De wijziging sluit [PR #2384](https://github.com/nostr-protocol/nips/pull/2384) (`NIP-34: remove maintainers to solve expiry issues`), die een andere oplossing voor forksemantiek voorstelde. ngit v2.6.x implementeert de samengevoegde richting, zodat de samengevoegde specificatie en de referentie-CLI nu overeenkomen. Bestaande repo's met `personal-fork` blijven interoperabel; nieuwe repo's en ngit v2.6 publiceren de `u`-tag.
+
+### Samengevoegd: NIP-46-clientmetadata, nu upstream nadat Amber die al leverde
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381) werd op 23 juni samengevoegd en voegt optionele clientmetadata toe aan het `connect`-verzoek van [NIP-46](/nl/topics/nip-46/). Een client kan bij het verbinden met de signer zijn naam, een icoon-URL en een homepage-URL publiceren. [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) leverde de metadata-uitbreiding vorige week al (behandeld in [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata)); deze week haalt de upstream-NIP de bestaande implementatie in.
+
+### Open: deterministische NIP-17-wrappersleutels per epoch
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397) en [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) behandelen twee naar elkaar toegroeiende voorstellen voor NIP-17-wrapsleutels. PR #2397 stelt voor om de tijdelijke ondertekeningssleutel voor een [NIP-59](/nl/topics/nip-59/)-gift wrap deterministisch af te leiden uit een seed per gesprek die aan een grove tijdsepoch is gekoppeld. Een ontvanger die de gesprekssleutel kent, kan dan voorspellen op welke pubkeys die zich moet abonneren. De huidige specificatie vereist voor elke wrap een nieuwe willekeurige sleutel, waardoor die voorspelling onmogelijk is. PR #2396 is de bijbehorende wijziging: wraps voor een bepaald gesprek zouden rechtstreeks met de gesprekssleutel moeten worden ondertekend, zodat de pubkey van de wrap ook als gespreksidentifier dient. Samen vormen ze een route naar filterbare NIP-17-gesprekken zonder metadatalekken. Beide voorstellen staan open en worden besproken.
+
+### Open: NIP-59 moet kind-13-seal-events bij de relay weigeren
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399) stelt voor dat relays kind-13-events, de binnenste seal van een [NIP-59](/nl/topics/nip-59/)-gift wrap, weigeren wanneer ze op het hoogste niveau van een publicatieverzoek verschijnen. Een seal-event is alleen zinvol binnen een wrap en een gelekte seal onthult de pubkey van de ontvanger. Het bijbehorende [issue #2398](https://github.com/nostr-protocol/nips/issues/2398) gaat verder en stelt dat de seal opnieuw moet worden gedefinieerd als tijdelijk kind (tijdelijke kinds van NIP-01 worden niet door relays opgeslagen). Dat zou de regel op protocolniveau afdwingen en de afhankelijkheid van beleid per relay wegnemen.
+
+### Open: groepstoestanden in NIP-29
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372) voegt expliciete semantiek voor groepstoestanden toe aan [NIP-29](/nl/topics/nip-29/) (relay-gebaseerde groepen). Het voorstel definieert wanneer een groep open, gesloten, openbaar, privé of gearchiveerd is en hoe toestandsveranderingen met lidgebeurtenissen omgaan. Daarmee verhuist semantiek die tot nu toe clientspecifiek was naar de relayspecificatie.
+
+### Open: optionele ondersteuning voor meerdere maintainers in NIP-34
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324) hoort bij de samengevoegde [PR #2395](https://github.com/nostr-protocol/nips/pull/2395) over de hierboven behandelde GRASP-06-forksemantiek. PR #2324 voegt optionele ondersteuning voor meerdere maintainers toe aan repository-announcement-events van [NIP-34](/nl/topics/nip-34/) (`kind:30617`). Een repository kan zo via herhaalde `maintainer`-tags meer dan één canonieke maintainer-pubkey opgeven. Clients vertrouwen patches en issues die door een van de opgegeven maintainers zijn ondertekend dan als officieel. Dat vult het lang bestaande hiaat waarbij NIP-34-repo's met co-maintainers alles via één pubkey moeten leiden of terugvallen op coördinatie buiten het protocol.
+
+### Open: AND-operator voor filters in NIP-91; het voorstel is niet samengevoegd
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252) is het voorstel voor een AND-operator voor Nostr-[filters](/nl/topics/nip-01/) en heropent een ontwerp dat eerder in de gesloten [PR #1365](https://github.com/nostr-protocol/nips/pull/1365) is besproken. Er bestaan al implementaties in [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), applesauce, [Amethyst](https://github.com/vitorpamplona/amethyst) en worker-relay, maar de PR voor de specificatie staat nog open.
+
+### Gesloten: vier handels-NIPs van pats2sats
+
+Vier voorstellen voor handel op Nostr zijn deze week gesloten: Escrow ([#2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([#2335](https://github.com/nostr-protocol/nips/pull/2335)), een Marketplace Listing Extension voor [NIP-99](/nl/topics/nip-99/) ([#2346](https://github.com/nostr-protocol/nips/pull/2346)) en een Accommodation Listing Profile ([#2333](https://github.com/nostr-protocol/nips/pull/2333)). Hetzelfde handelsoppervlak wordt nu geconsolideerd in de [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), een uitbreidingsrepository van het project zelf die boven op NIP-99-marktplaatsvermeldingen orders, checkout, escrow en geschilsemantiek samenstelt. Compass volgt deze repository nu naast Marmot en Blossom als protocolspecificatierepository buiten de NIPs-repository. Open PR's daar omvatten deze week verduidelijking van client attribution ([#11](https://github.com/GammaMarkets/market-spec/pull/11)), een `supersedes`-tag voor wijzigingen aan productidentiteit ([#8](https://github.com/GammaMarkets/market-spec/pull/8)) en semantiek voor beoordelingen van handelaars ([#7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Open: koppeling van Bitcoin-identiteiten
+
+Deze week zijn twee voorstellen geopend om Bitcoin-identiteiten aan Nostr-identiteiten te koppelen: een [NIP-352 Bitcoin Silent Payment Address](https://github.com/nostr-protocol/nips/pull/2392) en een [Bitcoin-OTC Identity Linkage Proof](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## NIP Deep Dive: NIP-86 (Relay Management API)
+
+[NIP-86](/nl/topics/nip-86/) definieert een JSON-RPC-interface voor relaybeheer, waarmee geautoriseerde clients via een gestandaardiseerde API administratieve opdrachten naar relays sturen. Eén client kan elke NIP-86-compatibele relay beheren zonder gereedschap per relay. Twee deze week samengevoegde specificatiewijzigingen ([PR #2389](https://github.com/nostr-protocol/nips/pull/2389) en [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)) sluiten de kring tussen door relays ondertekende events en door relays bekendgemaakte beheerders.
+
+### Het transport
+
+Een NIP-86-beheerverzoek is een HTTP-POST naar dezelfde URI waarop de relay WebSocket-verbindingen aanbiedt, met `Content-Type: application/nostr+json+rpc`. De body van het verzoek is een JSON-document in deze vorm:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+Authenticatie gebruikt een via HTTP-auth ondertekend event van [NIP-98](/nl/topics/nip-98/) in de `Authorization`-header. De relay controleert of de ondertekenende pubkey op zijn beheerderslijst staat voordat de methode wordt uitgevoerd. Het antwoord van de relay is een JSON-document in deze vorm:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### De methoden die vóór deze week bestonden
+
+De bestaande methodeset dekt bans van pubkeys (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), bans van events (`banevent`, `allowevent`, `listbannedevents`), relaymetadata (`changerelayname`, `changerelaydescription`, `changerelayicon`), beheer van de lijst met toegestane kinds (`allowkind`, `disallowkind`, `listallowedkinds`) en een methode `stats` die relaystatistieken teruggeeft. De vorm ligt bewust dicht bij een standaard-JSON-RPC-service, zodat een client er typed bindings bovenop kan leggen.
+
+### Wat deze week veranderde
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) voegt een `signevent`-methode aan de specificatie toe. De methode neemt een gedeeltelijke eventtemplate (kind, tags, content) als argument en vraagt de relay een volledig event te ondertekenen en terug te geven, met de eigen pubkey van de relay in het veld `pubkey`. Dit is de voorwaarde waaronder een relay events op protocolniveau over zichzelf kan publiceren: aankondigingen van geblokkeerde pubkeys, relaymetadata en het nieuwe Relay Roles-event hieronder moeten allemaal door de relay met de sleutel van de operator worden ondertekend. De meeste relayoperators willen echter geen privésleutel in hun administratieve client bewaren.
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390) definieert een Relay Roles-event: een geparametriseerd vervangbaar eventkind dat een relay publiceert, met de eigen pubkey ondertekend via `signevent`, om de pubkeys van zijn beheerders en moderators met expliciete rolsemantiek bekend te maken. Een NIP-86-bewuste client kan het Relay Roles-event van elke gevolgde relay ophalen, de beheerderslijst uit de eventtags opbouwen en zonder out-of-band-vertrouwen of configuratie per relay controleren of een geauthenticeerd NIP-86-verzoek van een huidige beheerder kwam. De twee PR's sluiten samen de kring: `signevent` is het mechanisme en Relay Roles is het eerste eventkind dat erop voortbouwt.
+
+### Voorbeeld van een NIP-86-verzoek
+
+Een volledig NIP-86-`banpubkey`-verzoek ziet er zo uit:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+met een `Authorization`-header die een door NIP-98 ondertekend event bevat:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+De ondertekenende pubkey moet in de beheerdersset van de relay staan, die nu in het Relay Roles-event wordt bekendgemaakt; de `u`-tag moet met de HTTPS-URL van de relay overeenkomen; de `payload`-tag moet overeenkomen met de SHA-256 van de JSON-body van het verzoek. De relay antwoordt:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementaties
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) levert op Android een UI voor NIP-86-relaybeheer (v1.07.0+).
+- Referentierelays die de specificatie implementeren zijn onder meer [strfry](https://github.com/hoytech/strfry), [khatru](https://github.com/fiatjaf/khatru) en enkele kleinere implementaties waarnaar de specificatie in `Implementation Status` verwijst.
+
+NIP-86-bewuste clients zullen het Relay Roles-event als canonieke bron voor de beheerderslijst van een relay gaan behandelen zodra implementeerders de wijzigingen aan `signevent` en Relay Roles overnemen.
+
+---
+
+## NIP Deep Dive: NIP-89 (Recommended Application Handlers)
+
+[NIP-89](/nl/topics/nip-89/) definieert twee geparametriseerde vervangbare eventkinds: `kind:31990` (de applicatiehandler die een appontwikkelaar publiceert) en `kind:31989` (de aanbeveling die een gebruiker publiceert voor een gebruikte app). Samen laten ze clients zonder out-of-band-coördinatie applicaties ontdekken die een onbekend eventkind verwerken. Een longform-lezer die een `kind:30030`-event tegenkomt dat hij niet native ondersteunt, kan de NIP-89-grafiek naar handlers doorzoeken en de gebruiker een `Open in...`-flow naar een gepubliceerde app aanbieden. NIP-89 is de oorspronkelijke infrastructuur voor hetzelfde routeringsprobleem tussen apps dat het napplet-/napps-werk in dit nummer nu uitbreidt naar samenstelbare, Nostr-native applets.
+
+### Het applicatiehandlerevent (`kind:31990`)
+
+Een appontwikkelaar publiceert een of meer handlerevents die beschrijven welke eventkinds de app ondersteunt en hoe een Nostr-entiteit in de app wordt geopend:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+De `d`-tag identificeert de handler, zodat die kan worden vervangen. Elke `k`-tag vermeldt een eventkind dat de app verwerkt en elke platformtag (`web`, `ios`, `android`, ...) geeft een URL-template waarin `<bech32>` de placeholder is voor een via [NIP-19](/nl/topics/nip-19/) gecodeerde entiteit die de aanroepende client bij het openen invult. Eén handlerevent kan meerdere ondersteunde kinds adverteren als ze hetzelfde routeringspatroon delen. Dat houdt appontdekking compact en voorkomt één handlerevent per kind.
+
+### Het aanbevelingsevent van de gebruiker (`kind:31989`)
+
+Een gebruiker publiceert een aanbeveling die vermeldt welke apps die voor een bepaald eventkind gebruikt:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+De `d`-tag bevat het aanbevolen eventkind. Elke `a`-tag is een NIP-01-adresverwijzing naar een `kind:31990`-handlerevent, met de voorgestelde relay en het platform waarop de aanbeveling van toepassing is. Dezelfde aanbeveling kan meerdere apps voor verschillende platforms vermelden.
+
+### De clienttag en de privacyafweging
+
+NIP-89 definieert ook een optionele `client`-tag die elke publicerende app aan zelf geschreven events kan toevoegen:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Hierdoor kan elke client die het event toont ook de app van herkomst tonen, rijkere handlermetadata opzoeken en door de handler opgegeven renderhints respecteren. De specificatie benoemt ook expliciet de privacykosten: een client die op elk event een `client`-tag plaatst, publiceert welke software de gebruiker inzet en onthult daarmee na verloop van tijd gebruikspatronen. De specificatie adviseert clients gebruikers een opt-out te geven.
+
+[PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) van Amethyst parset en toont de NIP-89-tags `t`, `i`, `a` en `client` bij de eventweergave, zodat direct in de tijdlijn zichtbaar wordt welke app een note schreef.
+
+### Hoe de ontdekkingsflow in de praktijk verloopt
+
+Een client die een onbekend eventkind ontvangt, doorloopt de volgende stappen. (1) Doorzoek de volgrafiek van de gebruiker naar `kind:31989`-events met een `d`-tag die met het eventkind overeenkomt. (2) Los elke aanbevolen `a`-tag op naar het bijbehorende `kind:31990`-handlerevent. (3) Kies de handler waarvan de URL-template voor `web`, `ios` of `android` bij het huidige platform past. (4) Vul de `bech32`-codering van de entiteit in de URL-template in. (5) Bied de resulterende URL aan als keuze voor `Open in...`. De flow wordt sociaal gefilterd: een client die willekeurige handlerevents van onvertrouwde relays opvraagt, kan gebruikers naar schadelijke apps doorsturen. Beginnen bij mensen die de gebruiker volgt, is daarom veiliger dan elke gepubliceerde handler even betrouwbaar te behandelen.
+
+### NIP-89 en de nappletlaag
+
+De Discover-sectie, napplet-host-runtime en weergave van `client`-tags in Amethyst vormen samen een volledig NIP-89-consumentenoppervlak op Android. De nappletspecificatie uit het vorige nummer breidt uit waarnaar die NIP-89-handlerevents kunnen verwijzen: sandboxed applets die een samenstelbare, Nostr-native runtime op Nostr en Blossom draaien. NIP-89 is de grafiek voor ontdekking en routering; de napplet-runtime is een uitvoeringsdoel waarnaar die grafiek kan wijzen.
+
+---
+
+*Feedback, correcties en projecten die we hebben gemist: open een issue op [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) of bereik ons via een NIP-17-DM op npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/pt/newsletters/2026-07-01-newsletter.md
+++ b/content/pt/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+Bem-vindos de volta ao Nostr Compass, seu guia semanal do Nostr.
+
+**Esta semana:** o [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) traz transporte pela mixnet Nym, descoberta opt-in na LAN via mDNS, troca de chaves sem interrupções sob perda de pacotes e uma reformulação do plano de dados, mantendo compatibilidade de rede com a v0.3.0. O [Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) surge como cliente Marmot para desktop em Rust e Slint, acompanhado de uma proposta de protocolo para mover efeitos de mensagens para um evento kind 9 dedicado. O [CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) é lançado como um cofre móvel de identidades respaldado por hardware, que atua como assinador remoto NIP-46 e responde a desafios de acesso físico via NFC. O [myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) estreia o compartilhamento ponto a ponto de nsites pela malha FIPS, com um novo transporte BLE L2CAP na v0.1.0. O [Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) é lançado como uma superfície de controle Android para um assistente de programação Codex local por DMs criptografadas do Nostr. A [linha ainda não lançada do Amethyst](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) adiciona parsing de handlers de aplicativos NIP-89, um feed de repositórios Git para NIP-34 e uma seção Discover para nSites e napplets. O [Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) implementa NIP-37, NIP-52 e NIP-22 em uma semana. O [Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) lança 12 versões de subpacotes, com auxiliares nbunksec para NIP-46 e atualização da carteira para Cashu-ts v4. O [Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) traz listas colaborativas de chave compartilhada em eventos endereçáveis kind 35000. O repositório de NIPs incorporou cinco PRs, entre eles um evento de funções de relay, a remoção do limite de 65.535 bytes do NIP-44, semântica de forks do NIP-34, metadados de cliente NIP-46 e o método `signevent` do NIP-86. Os mergulhos profundos abordam o [NIP-86 (API de gerenciamento de relays)](#nip-deep-dive-nip-86-relay-management-api) e o [NIP-89 (handlers de aplicativos recomendados)](#nip-deep-dive-nip-89-recommended-application-handlers).
+
+---
+
+## Histórias principais
+
+### FIPS v0.4.0 traz transporte pela mixnet Nym, descoberta mDNS e uma reformulação do plano de dados {#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul}
+
+O [FIPS](https://github.com/jmcorgan/fips) é uma rede mesh ponto a ponto privada e auto-organizável para o Nostr, na qual os nós descobrem uns aos outros e roteiam tráfego sem infraestrutura central. O [FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) incorpora um transporte pela mixnet Nym, descoberta opt-in na LAN via mDNS, uma reformulação do plano de dados, troca de chaves sem interrupções sob perda de pacotes, uma TUI `fipstop` reescrita sobre um harness de snapshots de renderização, um plano de observabilidade fora do caminho crítico e novos alvos de empacotamento apk para OpenWrt e flake para Nix. Tudo mantém compatibilidade de rede com a v0.3.0, para que malhas com versões mistas interoperem durante uma atualização gradual. Dois novos transportes para descoberta de peers sustentam o lançamento. Um novo [transporte de saída pela mixnet Nym](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) roteia o tráfego FIPS por um proxy SOCKS5 `nym-socks5-client`, misturando-o à rede de tráfego de cobertura da [Nym](https://nymtech.net/) para impedir que observadores no nível do link correlacionem quais peers da malha estão se comunicando. Um diretório `examples/sidecar-nostr-mixnet-relay/` demonstra um relay Nostr acessível por um link FIPS pareado de ponta a ponta através da mixnet. A descoberta opt-in na LAN via mDNS/DNS-SD permite que nós no mesmo link local se encontrem sem configurar endereços nem usar STUN, anunciando e adotando peers por um registro de serviço padrão quando `node.discovery.lan.enabled: true`.
+
+O plano de dados foi reformulado para aumentar a vazão de um único nó. A criptografia e a descriptografia por peer agora rodam em workers dedicados fora do loop de recebimento, para que um peer ocupado não serialize a criptografia de todo o nó. No Linux, o caminho de envio usa generic segmentation offload e, quando disponível, um socket UDP conectado; o caminho crítico de recebimento evita as cópias de buffer antes realizadas para cada pacote; e o macOS ganha recebimento em lote com `recvmsg_x`, espelhando o lote `recvmmsg` do Linux introduzido na v0.3.0. Toda a superfície de leitura `show_*` do `fipsctl` e do `fipstop` agora é atendida por um snapshot por tick, publicado em um `ArcSwap` lock-free pela tarefa que aceita conexões de controle. Assim, consultas do operador respondem rapidamente mesmo quando o loop de recebimento está ocupado. Uma nova consulta `show_metrics`, apenas de contadores e exposta como `fipsctl stats metrics`, permite coleta pelo Prometheus sem custo no caminho crítico.
+
+A troca de chaves das sessões FMP e FSP agora ocorre sem interrupções sob perda e reordenação de pacotes nas duas direções: frames recebidos são autenticados contra a sessão pendente antes que a transição pelo bit K a promova, impedindo que um frame antigo ou falsificado atrapalhe a troca; a retransmissão da mensagem 1 da troca de chaves é limitada; o heartbeat que detecta link inativo considera a troca; e corridas de iniciação dupla em links de alta latência são dessincronizadas com jitter simétrico. A TUI `fipstop` foi reconstruída sobre um harness de snapshots de renderização que valida o grid de texto exato e o estilo de cada célula de todas as telas contra saídas predefinidas do socket de controle. Novos alvos de empacotamento acompanham o lançamento: um `.apk` para OpenWrt 25 ou posterior, criado sem SDK ao reutilizar a compilação cruzada `.ipk` e o payload do sistema de arquivos instalado já existentes, e um `flake.nix` na raiz do projeto que compila os quatro binários (`fips`, `fipsctl`, `fips-gateway`, `fipstop`) a partir do código-fonte no Nix/NixOS com a toolchain fixada.
+
+### Whitenoise Linux surge como cliente Marmot para desktop {#whitenoise-linux-surfaces-as-a-desktop-marmot-client}
+
+O [Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) é um cliente [Marmot](/pt/topics/marmot/) para desktop: mensagens de grupo MLS sobre relays Nostr, empacotadas em um único binário Rust com uma interface Slint que mantém todos os segredos em um cofre criptografado por senha.
+
+A discussão mais relevante desta semana propõe transportar os efeitos de mensagens do Whitenoise em um evento kind 9 dedicado que referencia a mensagem original. O formato de rede atual acrescenta um marcador como `dmfx:sparkle` ao final do corpo da mensagem, poluindo o texto para qualquer renderizador que desconheça essa convenção. Mover os efeitos para eventos próprios mantém limpo o texto das mensagens e abre uma questão de design que todo o ecossistema Marmot terá de enfrentar: convenções embutidas no corpo ou eventos sidecar para recursos avançados opcionais.
+
+### CustID é lançado como cofre móvel de identidades com NIP-46 e fluxo de desafios via NFC {#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow}
+
+O [CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) é a primeira beta pública do CustID, um cofre móvel de identidades baseado no Nostr e no protocolo SISTR. O CustID armazena várias identidades Nostr em armazenamento seguro respaldado por hardware, atua como assinador remoto [NIP-46](/pt/topics/nip-46/) para outros clientes e responde a desafios de acesso físicos e on-line por NFC e códigos QR.
+
+A beta tem todos os recursos previstos para o assinador NIP-46 e o fluxo de desafio e resposta via NFC; os fluxos de acesso com provas de conhecimento zero continuam como objetivo futuro. Este lançamento também remove a camada de keep-alive [NIP-65](/pt/topics/nip-65/) em segundo plano do aplicativo, que abria um WebSocket por perfil para cada relay de leitura e recebia kinds descartados imediatamente pelo cliente. Agora, somente os sockets NIP-46 que transportam notificações de solicitações de assinatura permanecem ativos em segundo plano, correção que viabiliza usar o CustID como bunker para outros clientes em um celular.
+
+### myco lança compartilhamento ponto a ponto de nsites pela malha FIPS {#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh}
+
+O [myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) foi aberto em 27 de junho e chegou à v0.1.0 em 1º de julho. O myco é um aplicativo Android em Rust que instala aplicativos recebidos de pessoas próximas: compartilhamento ponto a ponto de [nsites](/pt/topics/nip-5a/) por uma malha FIPS, usando qualquer transporte aceito pela malha (UDP, TCP, Tor, Bluetooth) e funcionando totalmente off-line. O design combina diretamente o FIPS como base de transporte com o formato de evento de sites estáticos do NIP-5A como payload, permitindo que um aplicativo distribuído como nsite passe entre peers da malha sem depender de relays nem HTTP.
+
+A v0.1.0 adiciona um caminho de rádio Bluetooth L2CAP para que dois celulares com FIPS instalado possam se parear por BLE sem nenhuma rede, além de um teste de velocidade por peer e compartilhamento acionado por NFC na bottom sheet Circle do aplicativo. O myco também está publicado no Zapstore para instalação direta.
+
+### Nostr Codex Phone é lançado como superfície de controle móvel para um worker Codex local pelo Nostr {#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr}
+
+O [Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) é lançado nesta semana como cliente Android que controla um worker local do assistente de programação Codex por mensagens diretas criptografadas do Nostr. O aplicativo aceita várias sessões de repositório, transcrição de voz, sessões roteadas do worker, uploads de mídia para Blossom e respostas faladas opcionais. Assim, quem executa um worker Codex em casa pode enviar solicitações pelo celular em qualquer lugar onde tenha acesso a relays.
+
+O projeto é irmão direto do [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr), lançado na edição nº 28. Ambos colocam fluxos de programação agêntica sobre o transporte Nostr com DMs criptografadas e tratam o Nostr como a camada de pareamento e mensagens que permite a um celular alcançar um worker doméstico sem abrir portas na rede. O uso do Nostr como plano de controle para agentes locais está se tornando um padrão consolidado.
+
+### Coop Mobile publica suas primeiras compilações versionadas
+
+O [Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) e a [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) foram lançados nesta semana como as primeiras compilações versionadas do Coop Mobile, um cliente Android de mensagens diretas criptografadas [NIP-17](/pt/topics/nip-17/). Os dois lançamentos melhoram a segurança contra crashes no parsing de mensagens e no tratamento de códigos QR, além de apagar todos os dados armazenados ao sair da conta.
+
+### Amethyst cria interface compatível com NIP-89, feed de repositórios Git e seção Discover para napplets {#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section}
+
+A branch principal do [Amethyst](https://github.com/vitorpamplona/amethyst) criou várias superfícies novas nesta semana. Um [feed de repositórios Git](https://github.com/vitorpamplona/amethyst/pull/3406) transforma repositórios [NIP-34](/pt/topics/nip-34/) em uma categoria navegável da timeline do Android, filtrável por comunidade e autor, acompanhada de um [navegador git smart-HTTP](https://github.com/vitorpamplona/amethyst/pull/3415) que lê o conteúdo e os commits dos repositórios sem sair do aplicativo. O host de napplets ganhou uma [seção Discover](https://github.com/vitorpamplona/amethyst/pull/3409) que lista aplicativos web selecionados, além de nSites e napplets seguidos, com base em eventos de handlers [NIP-89](/pt/topics/nip-89/) e eventos de sites [NIP-5A](/pt/topics/nip-5a/). A exibição de notas agora [revela qual aplicativo Nostr criou um evento](https://github.com/vitorpamplona/amethyst/pull/3422) por meio de tags NIP-89. Na sincronização, o [suporte à negentropy do NIP-77](https://github.com/vitorpamplona/amethyst/pull/3434) traz reconciliação por streaming e janelas automáticas por `created_at` para contornar limites de resultados impostos pelos relays, reduzindo a largura de banda necessária para manter grandes conjuntos locais de eventos sincronizados com um relay.
+
+### Buzz v0.3.38 reforça a superfície de ataque dos relays e adiciona seleção de modelos independente de provedor
+
+O [Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) reforça a [superfície de ataque dos relays](https://github.com/block/buzz/pull/1369) exposta quando o Buzz publica personas, equipes, agentes gerenciados e atestados de proprietário NIP-OA como eventos Nostr assinados. Um relay do Buzz é um registro público das identidades Nostr da equipe e de seu estado; este lançamento endurece a validação de entradas e a proteção contra replay nos kinds de evento conhecidos definidos pelo Buzz. O lançamento também generaliza a seleção de modelos, permitindo que uma equipe do Buzz use qualquer provedor para o qual existam adaptadores, inclusive um novo backend Databricks AI Gateway v2.
+
+### Notedeck implementa relays de sincronização privada NIP-37, calendário NIP-52 e comentários NIP-22 {#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments}
+
+O [Notedeck](https://github.com/damus-io/notedeck), cliente desktop nativo em Rust da equipe do Damus, implementou três protocolos em uma semana. Os relays de sincronização privada agora persistem em uma lista [NIP-37](/pt/topics/nip-37/) kind `10013`, separando o conjunto de relays de conteúdo privado do usuário de sua outbox pública NIP-65. O painel de calendário `horizon` lê eventos [NIP-52](/pt/topics/nip-52/) do nostrdb e recebeu um novo layout de três painéis. O painel `headway` adicionou um modelo de eventos de comentário [NIP-22](/pt/topics/nip-22/) no kind `1111`, definido pelo NIP-22 para a superfície unificada de comentários que substitui o encadeamento de respostas NIP-10.
+
+### Applesauce incorpora sessões NIP-46 nbunksec e atualiza carteira para Cashu v4 {#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut}
+
+O [Applesauce](https://github.com/hzrd149/applesauce), toolkit modular do Nostr para assinadores, relays, carteiras e conteúdo, fez um [lançamento coordenado da série 6.2.x](https://github.com/hzrd149/applesauce/releases) entre seus subpacotes. O pacote de assinadores ganhou auxiliares para importar e exportar `nbunksec`, tratando uma sessão de bunker [NIP-46](/pt/topics/nip-46/) como artefato portátil que pode ser transferido entre clientes. O pacote de carteira atualizou seus bindings de [Cashu](/pt/topics/nip-60/) para o `@cashu/cashu-ts` v4, no qual valores de proofs se tornam objetos de valor `Amount` e a API de decodificação de tokens muda.
+
+---
+
+## Lançamentos com tag
+
+### mostro-core v0.14.0
+
+O [mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) traz a próxima iteração do protocolo da rede P2P de negociação fiduciária [Mostro](/pt/topics/nip-69/). O lançamento sucede a [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2) e chega junto com o [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0), que adota o novo core. Três PRs foram incorporados ao repositório do core nesta semana; o restante da stack, o daemon mostro e o Mostro mobile, acompanha a v0.14.0 do crate de tipos compartilhados.
+
+### ngit v2.6.1
+
+O [ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli), CLI canônico de git sobre Nostr para repositórios [NIP-34](/pt/topics/nip-34/), implementa a [semântica de forks GRASP-06 do NIP-34](https://github.com/nostr-protocol/nips/pull/2395), incorporada nesta semana, que substitui a tag `personal-fork` por uma tag `u` nos eventos de estado de repositório.
+
+### mesh-llm v0.72.0 e v0.72.1
+
+O [mesh-llm](https://github.com/Mesh-LLM/mesh-llm), componente de inferência da stack ContextVM que executa LLMs de código aberto por uma superfície JSON-RPC endereçável pelo Nostr, lançou as versões [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) e [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1), com uma correção para crash de batching em prompts individuais grandes e a migração da ponte MCP para longe de auxiliares obsoletos.
+
+### Meiso v1.4.0 traz listas colaborativas de chave compartilhada que substituem MLS no compartilhamento de tarefas {#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing}
+
+O [Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) apresenta um modelo de listas colaborativas de chave compartilhada que substitui o compartilhamento de tarefas anterior do projeto, baseado em MLS, por um design mais simples de eventos endereçáveis. Cada lista compartilhada gera uma chave Nostr dedicada, distribuída aos membros; as tarefas são eventos endereçáveis kind `35000`, identificados por `d=task-id`, com conteúdo autoencriptado por [NIP-44](/pt/topics/nip-44/); e os relays aplicam Last-Write-Wins por tarefa. O design abre mão do forward secrecy e da segurança pós-comprometimento do MLS em troca de uma implementação de cliente mais simples e resolução de conflitos no nível do relay.
+
+### Cordn 0.3.2
+
+O [Cordn 0.3.2](https://github.com/Cordn-msg/cordn) traz uma linha “more-private-coordinator” que remove pubkeys efêmeras dos remetentes da publicação de mensagens em grupo e reforça o fluxo de solicitações de entrada contra novas solicitações antigas. O Cordn é a stack de mensagens baseada em MLS abordada no [lançamento do Cordn Ad-hoc CVM na edição nº 28](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator); este lançamento é a atualização correspondente no lado do coordenador.
+
+---
+
+## Alterações ainda não lançadas
+
+### diVine incorpora 108 PRs de aprimoramentos pós-lançamento
+
+O [diVine](https://github.com/divinevideo/divine-mobile), cliente de vídeos curtos em loop que resgata o Vine, está em uma intensa onda de aprimoramentos pós-lançamento. O trabalho visível no Nostr nesta semana é uma rodada de estabilidade do fluxo de conexão [NIP-46](/pt/topics/nip-46/) que migra falhas de `nostrconnect://` para códigos de motivo estruturados.
+
+### Zap Cooking prossegue com a correção NIP-46 entre projetos e a reformulação do compositor
+
+O [Zap Cooking](https://github.com/zapcooking/frontend) é um cliente de compartilhamento de receitas no Nostr, no qual as receitas são publicadas como eventos Nostr de formato longo. O trabalho desta semana continua a correção [NIP-46](/pt/topics/nip-46/) entre projetos e a reformulação do compositor abordadas como ainda não lançadas na [edição nº 28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes).
+
+### Conduit reforça o fluxo de anúncios e a correção do marketplace
+
+O [Conduit](https://github.com/Conduit-BTC/conduit-mono) é um monorepo de marketplace com três aplicativos sobre o Nostr, cobrindo o mercado de compradores, o portal de comerciantes e o construtor de lojas. O trabalho desta semana dá continuidade ao esforço de correção do marketplace abordado na [cobertura do lançamento da edição nº 28](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default), apoiando-se na onda de comércio [NIP-99](/pt/topics/nip-99/) que foi a história de protocolo da edição anterior.
+
+### Pollerama v1.12 a v1.13.1 adicionam escolha da tag de cliente, abas de perfil e limites de threads
+
+O [Pollerama](https://github.com/formstr-hq/nostr-polls), cliente Android do Nostr concentrado em enquetes e notas, com uma forte camada de descoberta por web of trust, lançou as versões v1.12.0, v1.13.0 e v1.13.1 no Zapstore nesta semana. Agora os usuários podem escolher qual tag de cliente acompanha as notas e enquetes que criam, selecionando-a em uma lista predefinida ou informando uma própria. Cadeias muito aninhadas de comentários e respostas passam a parar após alguns níveis e oferecem um link para a thread completa na página da nota. As páginas de perfil abrem por padrão em Notes, divididas nas abas Posts e Conversations. Foi corrigido um bug de persistência em que contas recém-seguidas desapareciam após reiniciar o aplicativo, e os botões de seguir agora exibem progresso.
+
+### getwired.app e get-tao.app corrigem o fluxo de envio de confissões NIP-13
+
+O [getwired.app](https://github.com/smolgrrr/Wired) e o [get-tao.app](https://github.com/smolgrrr/TAO), que compartilham um fluxo de publicação anônima que adiciona proof-of-work NIP-13 para conter spam no envio, corrigiram o [fluxo de envio de confissões](https://github.com/smolgrrr/Wired/pull/57) para tornar coerente a experiência durante a mineração do PoW.
+
+### nostui adiciona uma aba de timeline de menções
+
+O [nostui](https://github.com/akiomik/nostui), cliente de terminal do Nostr em Rust, adicionou uma [aba de timeline de menções](https://github.com/akiomik/nostui/pull/463) que apresenta, em uma tela própria da TUI, eventos kind 1 que marcam a pubkey ativa.
+
+### Heartwood incorpora URIs de bunker NIP-46 por identidade e uma ponte de assinatura em modo HSM
+
+O [Heartwood](https://github.com/forgesworn/heartwood) é um assinador [NIP-46](/pt/topics/nip-46/) em que a chave de assinatura jamais chega ao cliente: o cliente fala NIP-46 com um pequeno relay, e o relay usa um protocolo de frames seriais para se comunicar com um dispositivo de hardware conectado que executa a assinatura. Nesta semana, o projeto incorporou uma [ponte de assinatura do relay para a porta serial](https://github.com/forgesworn/heartwood/pull/11) e [conexões de bunker por identidade](https://github.com/forgesworn/heartwood/pull/16), de modo que um único dispositivo de hardware com várias identidades exponha uma URI de bunker distinta para cada uma.
+
+### Refatoração de autenticação e assinadores do Nostter
+
+O [Nostter](https://github.com/SnowCait/nostter) reformulou sua [camada de autenticação e assinadores](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth) nesta semana, movendo o estado de login para um único signal e extraindo o despacho do assinador para módulos de estratégia. O caminho aponta para uma abstração limpa de assinadores em que a extensão web NIP-07, o bunker remoto NIP-46 e um nsec bruto compartilham um único fluxo de código.
+
+### Dart NDK extrai o assinador NIP-07 e randomiza timestamps NIP-59
+
+O [Dart NDK](https://github.com/relaystr/dart_ndk) moveu seu assinador [NIP-07](/pt/topics/nip-07/) para fora do pacote core e para o `ndk_flutter`, onde fica a WebView do Flutter, e [randomizou os timestamps de gift wraps NIP-59](https://github.com/relaystr/dart_ndk/pull/667) para reforçar a proteção de mensagens criptografadas contra correlação temporal.
+
+### Milk Market adiciona páginas de loja NIP-23 e processamento de pagamentos pela Square
+
+O [Milk Market](https://github.com/shopstr-eng/milk-market), vitrine de marketplace da equipe do Shopstr, deu a cada loja uma página de blog baseada nos eventos de formato longo [NIP-23](/pt/topics/nip-23/) do vendedor, com seções editáveis e uma rota direta para as configurações do blog. Na mesma semana, adicionou a [Square](https://github.com/shopstr-eng/milk-market/pull/30) como processador de pagamentos alternativo para vendedores e a compra automática de etiquetas de envio para pedidos pagos.
+
+### Calendar by Formstr lança aplicativo para iOS
+
+O [Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) incorporou o [PR nº 159, IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159), nesta semana, levando o cliente de calendário [NIP-52](/pt/topics/nip-52/) ao iOS. O [PR nº 197](https://github.com/formstr-hq/nostr-calendar/pull/197) corrige o parsing de datas do calendário no horário local, e o [PR nº 201](https://github.com/formstr-hq/nostr-calendar/pull/201) adiciona um fluxo E2E do Playwright acionado por uma label `run-tests`.
+
+### cagliostr aplica NIP-22, NIP-09 por coordenada e proof-of-work NIP-13
+
+O [cagliostr](https://github.com/mattn/cagliostr), implementação de relay em Go, reforçou três caminhos de aplicação nesta semana: [proof-of-work NIP-13 configurável](https://github.com/mattn/cagliostr/pull/7) em eventos recebidos, [exclusão NIP-09 por coordenada endereçável](https://github.com/mattn/cagliostr/pull/8), para que eventos substituíveis possam ser apagados por sua tag `a`, algo que a exclusão apenas por id de evento não alcança, e [limites configuráveis de timestamp NIP-22](https://github.com/mattn/cagliostr/pull/9), que rejeitam eventos com data muito distante no passado ou no futuro.
+
+---
+
+## Novos projetos acompanhados e descobertos
+
+A [suíte de bem-estar Vanderwarker](https://git.vanderwarker.family/wellbeing) publica telemetria do mundo físico como eventos Nostr sob uma chave de assinatura compartilhada do publicador. Ela reúne cinco aplicativos irmãos: o [Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) é um contador de passos que ancora dados de atividade física no Nostr como `kind:30078`; o [Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) publica diariamente quantas vezes o celular foi desbloqueado; o [Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) publica a mídia em reprodução como User Status; o [Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) publica nível, tensão e temperatura da bateria a cada 15 minutos; e o [Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) publica o uso diário de dados. Os cinco apareceram no Zapstore entre 24 e 30 de junho.
+
+O [ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) é um aplicativo Android criptografado e sem servidor para compartilhamento de localização ao vivo, criado em Rust e Slint e lançado em 29 de junho. É irmão do [Haven](https://github.com/mehmetefeumit/Haven-App), aplicativo de localização baseado em [Marmot](/pt/topics/marmot/) abordado na [edição nº 28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot), mas usa outra arquitetura de transporte: DMs Nostr criptografadas carregam as atualizações de localização, enquanto o Haven usa mensagens de grupo Marmot.
+
+O [NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) é um scaffold inicial de shell para criar aplicativos Nostr. O projeto publicou sua primeira documentação voltada ao usuário nesta semana.
+
+O [NIPs by Pollerama](https://nips.pollerama.fun), cujo repositório [abh3po/better-nips](https://github.com/abh3po/better-nips) foi criado em 29 de junho de 2026, é um novo cliente para NIPs `kind:30817` escritos pela comunidade do [NostrHub](https://nostrhub.io), apresentado como uma superfície alternativa ao nostrhub.io ponderada por confiança. Cada NIP `kind:30817` tem sua própria URL compartilhável (`#/nip/<naddr>`), com renderização completa de Markdown e os kinds de evento que define. O cliente oferece três feeds, Following, Web of Trust, com pessoas seguidas pelas pessoas seguidas, e Global, cada um ordenável por aprovações ponderadas por confiança ou pelos itens mais recentes. As aprovações são publicadas como labels [NIP-32](/pt/topics/nip-32/) no kind `1985`, com as tags `["L","nostrhub"]` e `["l","approve","nostrhub"]`, além de uma tag `a` apontando para o endereço do NIP-alvo e uma tag `client` que anuncia `better-nips`. Esse é exatamente o formato de evento assinado pelo próprio NostrHub, portanto as aprovações são compatíveis entre os dois clientes. A aprovação de alguém seguido diretamente tem mais peso no ranking do que a aprovação de segundo grau de alguém seguido por uma pessoa seguida.
+
+A stack de assinatura usa [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer), com um modal de login completo que cobre extensão web [NIP-07](/pt/topics/nip-07/), bunker e nostrconnect [NIP-46](/pt/topics/nip-46/), ncryptsec [NIP-49](/pt/topics/nip-49/) e assinador Android [NIP-55](/pt/topics/nip-55/); as sessões são reconectadas silenciosamente ao recarregar. A camada de rede passa por [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay), um Web Worker que distribui a outbox [NIP-65](/pt/topics/nip-65/) do usuário entre relays para que um grande conjunto da web of trust não se espalhe para um único relay. A posição de design é que NIPs comunitários, sejam hospedados no NostrHub, no `better-nips` ou em futuros clientes, são equivalentes no nível do protocolo; o ranking vem do grafo social, não da curadoria de moderadores. Isso se alinha diretamente ao fluxo de labels NIP-32 abordado pelo mergulho profundo da [edição nº 25](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling).
+
+Dois novos clusters de repositórios [NIP-34](/pt/topics/nip-34/) surgiram nesta semana. O [Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) é um cliente Nostr voltado a vídeo; um [cluster nostrapps.com](wss://gitnostr.com) publica três projetos irmãos: [verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git), uma VM de napps para desktop; [hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git), cliente de comunidades personalizável; e [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git), especificação e runtime de microaplicativos HTML. O cluster se posiciona em paralelo ao trabalho de [napplets](/pt/topics/nip-5d/) abordado na história principal da edição anterior.
+
+---
+
+## Trabalho de protocolo e atualizações de NIPs
+
+### Incorporado: NIP-44 remove o limite de payload de 65.535 bytes
+
+O [PR nº 1907](https://github.com/nostr-protocol/nips/pull/1907) foi incorporado em 28 de junho, após permanecer aberto desde setembro de 2024. A alteração remove o limite superior de 65.535 bytes do payload em texto simples de um envelope de criptografia versionada [NIP-44](/pt/topics/nip-44/), elevando-o para 4 GiB (`uint32_max`). O NIP-44 codifica o tamanho do payload como `uint16` no formato de rede, exigência estrita da especificação original para interoperabilidade; a alteração incorporada adota um campo de comprimento maior indicado no byte de versão, para que implementações v2 mantenham a compatibilidade de rede e implementações v3 ou posteriores carreguem o comprimento maior. Clientes que usam NIP-44 para mensagens diretas [NIP-17](/pt/topics/nip-17/), gift wraps [NIP-59](/pt/topics/nip-59/), payloads de assinadores remotos [NIP-46](/pt/topics/nip-46/) ou qualquer outra mensagem Nostr criptografada por NIP-44 agora podem trocar eventos individuais maiores que 64 KiB sem dividi-los na camada de aplicação.
+
+### Incorporado: NIP-86 ganha método signevent e evento Relay Roles
+
+O [PR nº 2389](https://github.com/nostr-protocol/nips/pull/2389) adiciona um método `signevent` à API JSON-RPC de gerenciamento de relays [NIP-86](/pt/topics/nip-86/), permitindo que um administrador peça ao relay que assine um evento com a pubkey do próprio relay. O [PR nº 2390](https://github.com/nostr-protocol/nips/pull/2390) complementar define um evento Relay Roles: evento substituível publicado por um relay para declarar seus administradores e moderadores. Juntos, eles permitem que clientes NIP-86 consultem a lista de administradores de um relay e verifiquem que uma solicitação autenticada veio de um administrador atual, sem confiança fora do protocolo. O mergulho profundo abaixo aborda as duas alterações.
+
+### Incorporado: NIP-34 substitui personal-fork por `u` no GRASP-06
+
+O [PR nº 2395](https://github.com/nostr-protocol/nips/pull/2395) foi incorporado em 24 de junho e substitui a tag `personal-fork` do [NIP-34](/pt/topics/nip-34/) em eventos de estado de repositório (`kind:30618`) por uma tag `u`, de “upstream”, alinhando o formato de rede à semântica de forks GRASP-06 implementada pela suíte GitWorkshop. A mudança encerra o [PR nº 2384](https://github.com/nostr-protocol/nips/pull/2384), `NIP-34: remove maintainers to solve expiry issues`, que propunha outra correção para a semântica de forks. A direção incorporada é a implementada pelo ngit v2.6.x, portanto a especificação e o CLI de referência agora estão alinhados. Repositórios existentes que usam `personal-fork` continuam interoperáveis; repositórios novos e a linha ngit v2.6 publicam a tag `u`.
+
+### Incorporado: metadados de cliente NIP-46, agora upstream após a implementação pelo Amber
+
+O [PR nº 2381](https://github.com/nostr-protocol/nips/pull/2381) foi incorporado em 23 de junho e adiciona metadados opcionais do cliente à solicitação `connect` do [NIP-46](/pt/topics/nip-46/), permitindo que o cliente publique seu nome, a URL de um ícone e a URL de uma página inicial no momento da conexão com o assinador. O [Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) implementou a extensão de metadados na semana passada, como abordado na [edição nº 28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata); nesta semana, o NIP upstream alcança a implementação já distribuída.
+
+### Aberto: chaves wrapper NIP-17 determinísticas por época
+
+O [PR nº 2397](https://github.com/nostr-protocol/nips/pull/2397) e o [PR nº 2396](https://github.com/nostr-protocol/nips/pull/2396) abordam duas propostas convergentes de chaves para wraps NIP-17. O PR nº 2397 propõe derivar de forma determinística a chave de assinatura efêmera usada para criar um gift wrap [NIP-59](/pt/topics/nip-59/) a partir de uma seed por conversa vinculada a uma época temporal ampla, permitindo que quem conhece a chave da conversa preveja quais pubkeys deve assinar. A especificação atual exige uma chave aleatória nova por wrap, tornando impossível essa previsão. O PR nº 2396 é a alteração complementar: wraps de uma conversa deveriam ser assinados diretamente com a chave da conversa, para que a pubkey do wrap também funcione como identificador da conversa. Juntos, eles definem um caminho para conversas NIP-17 filtráveis sem vazamento de metadados. Ambos continuam abertos e em discussão.
+
+### Aberto: NIP-59 deve rejeitar eventos seal kind 13 no relay
+
+O [PR nº 2399](https://github.com/nostr-protocol/nips/pull/2399) propõe que relays rejeitem eventos kind 13, o seal interno de um gift wrap [NIP-59](/pt/topics/nip-59/), quando apareçam no nível superior de uma solicitação de publicação, pois um evento seal só faz sentido dentro de um wrap e seu vazamento expõe a pubkey do destinatário. A [issue nº 2398](https://github.com/nostr-protocol/nips/issues/2398) complementar vai além e defende que o seal seja redefinido como kind efêmero, já que kinds efêmeros NIP-01 não são armazenados pelos relays. Isso reforçaria a regra no nível do protocolo e eliminaria a dependência da política de cada relay.
+
+### Aberto: estados de grupos NIP-29
+
+O [PR nº 2372](https://github.com/nostr-protocol/nips/pull/2372) adiciona semântica explícita de estados de grupo ao [NIP-29](/pt/topics/nip-29/), sobre grupos baseados em relays, definindo o que significa um grupo estar aberto, fechado, público, privado ou arquivado e como as transições de estado interagem com eventos de membros. A proposta leva para a especificação dos relays uma semântica que antes era específica de cada cliente.
+
+### Aberto: suporte opcional a vários mantenedores no NIP-34
+
+O [PR nº 2324](https://github.com/nostr-protocol/nips/pull/2324) é a proposta complementar ao [PR nº 2395](https://github.com/nostr-protocol/nips/pull/2395), sobre a semântica de forks GRASP-06 abordada acima. O PR nº 2324 adiciona suporte opcional a vários mantenedores nos eventos de anúncio de repositórios [NIP-34](/pt/topics/nip-34/) (`kind:30617`), permitindo que um repositório declare mais de uma pubkey canônica de mantenedor por meio de tags `maintainer` repetidas. Patches e issues assinados por qualquer mantenedor declarado passam a ser aceitos pelos clientes como oficiais, resolvendo a antiga lacuna em que repositórios NIP-34 com vários mantenedores precisavam encaminhar tudo por uma única pubkey ou recorrer a coordenação fora do protocolo.
+
+### Aberto: operador AND do NIP-91 para filtros, proposta ainda não incorporada
+
+O [PR nº 2252](https://github.com/nostr-protocol/nips/pull/2252) é a proposta do operador AND para [filtros](/pt/topics/nip-01/) do Nostr, retomando um design discutido anteriormente no [PR nº 1365](https://github.com/nostr-protocol/nips/pull/1365), já encerrado. Já existem implementações no [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay), no applesauce, no [Amethyst](https://github.com/vitorpamplona/amethyst) e no worker-relay, mas o PR da especificação continua aberto.
+
+### Encerradas: quatro NIPs de comércio da pats2sats
+
+Quatro propostas de comércio sobre o Nostr foram encerradas nesta semana: Escrow ([nº 2334](https://github.com/nostr-protocol/nips/pull/2334)), Reservations ([nº 2335](https://github.com/nostr-protocol/nips/pull/2335)), uma extensão de anúncios de marketplace [NIP-99](/pt/topics/nip-99/) ([nº 2346](https://github.com/nostr-protocol/nips/pull/2346)) e um perfil para anúncios de hospedagem ([nº 2333](https://github.com/nostr-protocol/nips/pull/2333)). A mesma superfície de comércio agora está sendo consolidada na [Gamma Market Spec](https://github.com/GammaMarkets/market-spec), repositório de extensões do projeto que se compõe sobre anúncios de marketplace NIP-99 com semântica de pedidos, checkout, escrow e disputas. O Compass agora acompanha esse repositório junto com Marmot e Blossom como repositório de especificação de protocolo externo ao próprio repositório de NIPs. Os PRs abertos nesta semana incluem um esclarecimento sobre atribuição de clientes ([nº 11](https://github.com/GammaMarkets/market-spec/pull/11)), uma tag supersedes para alterações de identidade de produtos ([nº 8](https://github.com/GammaMarkets/market-spec/pull/8)) e semântica de avaliações de comerciantes ([nº 7](https://github.com/GammaMarkets/market-spec/pull/7)).
+
+### Aberto: vinculação de identidades Bitcoin
+
+Duas propostas foram abertas nesta semana para vincular identidades Bitcoin a identidades Nostr: um [endereço de Silent Payments do Bitcoin NIP-352](https://github.com/nostr-protocol/nips/pull/2392) e uma [prova de vinculação de identidade Bitcoin-OTC](https://github.com/nostr-protocol/nips/pull/2401).
+
+---
+
+## Mergulho profundo em NIPs: NIP-86 (API de gerenciamento de relays) {#nip-deep-dive-nip-86-relay-management-api}
+
+O [NIP-86](/pt/topics/nip-86/) define uma interface JSON-RPC para gerenciamento de relays, permitindo que clientes autorizados enviem comandos administrativos a relays por uma API padronizada. Um único cliente pode gerenciar qualquer relay compatível com NIP-86 sem ferramentas específicas de cada relay. Duas alterações da especificação incorporadas nesta semana, o [PR nº 2389](https://github.com/nostr-protocol/nips/pull/2389) e o [PR nº 2390](https://github.com/nostr-protocol/nips/pull/2390), fecham o ciclo entre eventos assinados por relays e administradores declarados por relays.
+
+### O transporte
+
+Uma solicitação de gerenciamento NIP-86 é um HTTP POST enviado à mesma URI em que o relay oferece conexões WebSocket, com `Content-Type: application/nostr+json+rpc`. O corpo da solicitação é um documento JSON no seguinte formato:
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+A autenticação usa um evento assinado de autenticação HTTP [NIP-98](/pt/topics/nip-98/) no header `Authorization`. O relay verifica se a pubkey de assinatura consta em sua lista de administradores antes de executar o método. A resposta do relay é um documento JSON no seguinte formato:
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### Os métodos que já existiam antes desta semana
+
+O conjunto anterior de métodos abrange banimentos de pubkeys (`banpubkey`, `allowpubkey`, `listbannedpubkeys`), banimentos de eventos (`banevent`, `allowevent`, `listbannedevents`), metadados do relay (`changerelayname`, `changerelaydescription`, `changerelayicon`), gerenciamento da lista de kinds permitidos (`allowkind`, `disallowkind`, `listallowedkinds`) e um método `stats` que retorna estatísticas do relay. O formato é intencionalmente próximo de um serviço JSON-RPC padrão, para que um cliente possa criar bindings tipados sobre ele.
+
+### O que mudou nesta semana
+
+O [PR nº 2389](https://github.com/nostr-protocol/nips/pull/2389) adiciona um método `signevent` à especificação. O método recebe como argumento um template parcial de evento, com kind, tags e content, e pede que o relay assine e devolva um evento completo com a pubkey do próprio relay no campo `pubkey`. Essa é a condição necessária para um relay publicar eventos de protocolo sobre si mesmo: anúncios de pubkeys bloqueadas, metadados do relay e o novo evento Relay Roles abaixo exigem que o relay assine com sua chave controlada pelo operador, mas a maioria dos operadores não quer manter uma chave privada no cliente administrativo.
+
+O [PR nº 2390](https://github.com/nostr-protocol/nips/pull/2390) define um evento Relay Roles: kind de evento substituível parametrizado que um relay publica, assinado com sua própria pubkey por meio de `signevent`, para declarar as pubkeys de seus administradores e moderadores com semântica explícita de funções. Um cliente compatível com NIP-86 pode buscar o evento Relay Roles em qualquer relay acompanhado, montar a lista de administradores com as tags do evento e validar que uma solicitação NIP-86 autenticada veio de um administrador atual sem confiança fora do protocolo nem configuração por relay. Juntos, os dois PRs fecham o ciclo: `signevent` é o mecanismo e Relay Roles é o primeiro kind de evento construído sobre ele.
+
+### Exemplo de solicitação NIP-86
+
+Uma solicitação NIP-86 `banpubkey` completa tem o seguinte formato:
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+com um header `Authorization` contendo um evento assinado NIP-98:
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+A pubkey de assinatura precisa constar no conjunto de administradores do relay, agora declarado no evento Relay Roles; a tag `u` precisa corresponder à URL HTTPS do relay; e a tag `payload` precisa corresponder ao SHA-256 do corpo JSON da solicitação. O relay devolve:
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### Implementações
+
+- O [Amethyst](https://github.com/vitorpamplona/amethyst) oferece uma interface de gerenciamento de relays NIP-86 no Android, a partir da v1.07.0.
+- Entre os relays de referência que implementam a especificação estão o [strfry](https://github.com/hoytech/strfry), o [khatru](https://github.com/fiatjaf/khatru) e várias implementações menores ligadas pela seção `Implementation Status` da especificação.
+
+Clientes compatíveis com NIP-86 começarão a tratar o evento Relay Roles como fonte canônica da lista de administradores de um relay quando as implementações adotarem as alterações `signevent` e Relay Roles.
+
+---
+
+## Mergulho profundo em NIPs: NIP-89 (handlers de aplicativos recomendados) {#nip-deep-dive-nip-89-recommended-application-handlers}
+
+O [NIP-89](/pt/topics/nip-89/) define dois kinds de eventos substituíveis parametrizados: `kind:31990`, o handler de aplicativo publicado pelo desenvolvedor, e `kind:31989`, a recomendação que um usuário publica para um aplicativo usado por ele. Juntos, eles permitem que clientes descubram aplicativos capazes de lidar com um kind de evento desconhecido sem coordenação fora do protocolo: ao encontrar um evento `kind:30030` sem suporte nativo, um leitor de formato longo pode consultar o grafo NIP-89 em busca de handlers e oferecer ao usuário um fluxo `Open in...` para um aplicativo publicado que dê suporte ao evento. O NIP-89 é a infraestrutura original para o mesmo problema de roteamento entre aplicativos que o trabalho em napplets e napps presente nesta edição agora estende para applets Nostr nativos e componíveis.
+
+### O evento de handler de aplicativo (`kind:31990`)
+
+O desenvolvedor de um aplicativo publica um ou mais eventos de handler descrevendo quais kinds de eventos o aplicativo aceita e como abrir uma entidade Nostr nele:
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+A tag `d` identifica o handler, permitindo sua substituição; cada tag `k` declara um kind de evento aceito pelo aplicativo; e cada tag de plataforma (`web`, `ios`, `android`, ...) fornece um template de URL em que `<bech32>` serve de placeholder para uma entidade codificada conforme o [NIP-19](/pt/topics/nip-19/), substituída pelo cliente chamador no momento da abertura. Um evento de handler pode anunciar vários kinds aceitos quando todos compartilham o mesmo padrão de roteamento, mantendo compacta a descoberta de aplicativos e evitando um evento de handler para cada kind.
+
+### O evento de recomendação do usuário (`kind:31989`)
+
+Um usuário publica uma recomendação que declara quais aplicativos usa para determinado kind de evento:
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+A tag `d` contém o kind de evento recomendado. Cada tag `a` é um ponteiro de endereço NIP-01 para um evento de handler `kind:31990`, acompanhado do relay sugerido e da plataforma à qual a recomendação se aplica. Uma mesma recomendação pode listar vários aplicativos para plataformas distintas.
+
+### A tag client e o tradeoff de privacidade
+
+O NIP-89 também define uma tag `client` opcional que qualquer aplicativo publicador pode anexar aos eventos criados por ele:
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+Assim, qualquer cliente que exiba o evento pode apresentar o aplicativo de origem, consultar metadados mais ricos do handler e respeitar sugestões de renderização declaradas pelo handler. A especificação também aponta explicitamente o custo de privacidade: um cliente que emite uma tag `client` em todos os eventos publica a identidade do software usado e, com o tempo, revela padrões de uso. A especificação recomenda que os clientes permitam desativá-la.
+
+O [PR nº 3422](https://github.com/vitorpamplona/amethyst/pull/3422) do Amethyst faz parsing e exibe tags NIP-89 `t`, `i`, `a` e `client` nos eventos, revelando diretamente na timeline qual aplicativo criou uma nota.
+
+### Como funciona o fluxo de descoberta na prática
+
+Um cliente que recebe um kind de evento desconhecido segue estas etapas. (1) Consulta o grafo de pessoas seguidas pelo usuário em busca de eventos `kind:31989` cuja tag `d` corresponda ao kind do evento. (2) Resolve cada tag `a` recomendada para seu evento de handler `kind:31990`. (3) Escolhe o handler cujo template de URL `web`, `ios` ou `android` corresponda à plataforma atual. (4) Substitui no template a codificação `bech32` da entidade. (5) Oferece ao usuário a URL resultante como opção `Open in...`. O fluxo é filtrado socialmente: um cliente que consulte eventos de handler arbitrários em relays não confiáveis pode acabar redirecionando usuários para aplicativos maliciosos, portanto começar por pessoas seguidas pelo usuário é um padrão mais seguro do que tratar todos os handlers publicados como igualmente confiáveis.
+
+### NIP-89 e a camada de napplets
+
+A seção Discover, o runtime do host de napplets e a exibição de tags `client` do Amethyst formam, juntos, uma superfície consumidora completa do NIP-89 no Android. A especificação de napplets, lançada na edição anterior, amplia o que esses eventos de handler NIP-89 podem apontar: applets em sandbox que executam um runtime Nostr nativo e componível sobre Nostr e Blossom. O NIP-89 é o grafo de descoberta e roteamento; o runtime de napplets é um dos alvos de execução para os quais ele pode apontar.
+
+---
+
+*Feedback, correções e projetos que deixamos passar: abra uma issue em [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) ou fale conosco por DM NIP-17 no npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.*

--- a/content/zh/newsletters/2026-07-01-newsletter.md
+++ b/content/zh/newsletters/2026-07-01-newsletter.md
@@ -1,0 +1,370 @@
+---
+title: 'Nostr Compass #29'
+date: 2026-07-01
+publishDate: 2026-07-01
+translationOf: /en/newsletters/2026-07-01-newsletter.md
+translationDate: 2026-07-01
+draft: false
+type: newsletters
+---
+
+欢迎回到 Nostr Compass，您的 Nostr 每周指南。
+
+**本周：** [FIPS v0.4.0](#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul) 带来 Nym mixnet 传输、可选的 mDNS 局域网发现、丢包下无中断换钥与数据平面重构，并与 v0.3.0 线缆兼容。[Whitenoise Linux](#whitenoise-linux-surfaces-as-a-desktop-marmot-client) 以 Rust 与 Slint 编写的桌面 Marmot 客户端亮相，并提出把消息效果移至专用 kind-9 event 的协议提案。[CustID v0.1.10-beta](#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow) 作为硬件保护的移动身份保险库发布，可充当 NIP-46 远程签名器，并通过 NFC 回应实体访问挑战。[myco](#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh) 在 FIPS mesh 上推出点对点 nsite 分享，v0.1.0 新增 BLE L2CAP 传输。[Nostr Codex Phone](#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr) 作为 Android 控制端发布，通过加密 Nostr 私信操控本地 Codex 编程助手。[Amethyst 的未发布分支](#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section) 新增 NIP-89 应用处理器解析、面向 NIP-34 的 Git Repositories 信息流，以及用于 nSite 与 napplet 的 Discover 区域。[Notedeck](#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments) 一周内落地 NIP-37、NIP-52 与 NIP-22。[Applesauce](#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut) 协同发布 12 个子包版本，加入 nbunksec NIP-46 辅助函数并把钱包升级至 Cashu-ts v4。[Meiso v1.4.0](#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing) 在可寻址 kind-35000 上发布 Shared-Key Collaborative Lists。NIPs 仓库合并五个 PR，包括 Relay Roles event、移除 NIP-44 的 65,535 字节限制、NIP-34 分叉语义、NIP-46 客户端元数据与 NIP-86 `signevent` 方法。深度解析涵盖 [NIP-86（中继管理 API）](#nip-deep-dive-nip-86-relay-management-api)与 [NIP-89（推荐应用处理器）](#nip-deep-dive-nip-89-recommended-application-handlers)。
+
+---
+
+## 头条新闻
+
+### FIPS v0.4.0 带来 Nym mixnet 传输、mDNS 发现与数据平面重构 {#fips-v040-ships-nym-mixnet-transport-mdns-discovery-and-a-data-plane-overhaul}
+
+[FIPS](https://github.com/jmcorgan/fips) 是面向 Nostr 的私密、自组织点对点 mesh，节点无需中心基础设施即可相互发现并路由流量。[FIPS v0.4.0](https://github.com/jmcorgan/fips/releases/tag/v0.4.0) 加入 Nym mixnet 传输、可选的 mDNS 局域网发现、数据平面重构、丢包下无中断换钥、基于渲染快照测试框架重写的 `fipstop` TUI、移出热路径的可观测性平面，以及新的 OpenWrt apk 与 Nix flake 打包目标；全部与 v0.3.0 线缆兼容，混合版本 mesh 可在滚动升级期间互操作。本次发布以两种新的 peer 发现传输为核心。新的[出站 Nym mixnet 传输](https://github.com/jmcorgan/fips/releases/tag/v0.4.0)通过 `nym-socks5-client` SOCKS5 代理路由 FIPS 流量，把流量混入 [Nym](https://nymtech.net/) 掩护流量网络，使链路层观察者无法关联哪些 mesh peer 正在通信；`examples/sidecar-nostr-mixnet-relay/` 目录则演示一个经 FIPS 链路、端到端跨越 mixnet 抵达的 Nostr 中继。可选的 mDNS / DNS-SD 局域网发现允许同一本地链路上的节点无需地址配置或 STUN 即可相互找到，并在 `node.discovery.lan.enabled: true` 时通过标准服务记录公告与采纳 peer。
+
+数据平面经过重构，可提高单节点吞吐量。每个 peer 的加密与解密现由接收循环之外的专用 worker task 执行，因此一个繁忙 peer 不会串行阻塞整个节点的密码学处理。Linux 发送路径在可用时采用通用分段卸载和已连接 UDP socket，接收热路径避免此前每包发生的缓冲区复制；macOS 新增 `recvmsg_x` 批量接收，与 v0.3.0 中 Linux 的 `recvmmsg` 批处理对应。`fipsctl` 与 `fipstop` 的整个 `show_*` 读取面现在从每 tick 快照提供数据；控制接受 task 将快照发布到无锁 `ArcSwap`，所以即使节点接收循环繁忙，运营者查询也能及时得到响应。新的纯计数器 `show_metrics` 查询（以 `fipsctl stats metrics` 暴露）支持 Prometheus 抓取，且不增加热路径成本。
+
+FMP 与 FSP session 换钥现在双向承受丢包与乱序而不中断：入站 frame 会先针对待定 session 认证，再由 K-bit 切换提升它（因此陈旧或伪造 frame 无法破坏换钥）；换钥 message-1 的重传有明确上限；链路死亡 heartbeat 感知换钥；高延迟链路上的双向同时发起竞争则通过对称抖动错开。`fipstop` TUI 基于渲染快照测试框架重建，用预设控制 socket 输出断言每个视图的精确文字网格与逐 cell 样式。同时新增打包目标：面向 OpenWrt 25+ 的 OpenWrt `.apk`（无需 SDK 构建，复用现有 `.ipk` 交叉编译与已安装文件系统载荷），以及项目根目录的 `flake.nix`，通过固定工具链在 Nix/NixOS 上从源码构建四个二进制文件（`fips`、`fipsctl`、`fips-gateway`、`fipstop`）。
+
+### Whitenoise Linux 作为桌面 Marmot 客户端亮相 {#whitenoise-linux-surfaces-as-a-desktop-marmot-client}
+
+[Whitenoise Linux](https://relay.ngit.dev/npub1ven4zk8xxw873876gx8y9g9l9fazkye9qnwnglcptgvfwxmygscqsxddfh/darkmatter-linux.git) 是桌面 [Marmot](/zh/topics/marmot/) 客户端：通过 Nostr 中继承载 MLS 群组消息，打包为单个 Rust 二进制文件，使用 Slint UI，并把所有秘密保存在一个由密码加密的保险库中。
+
+本周最重要的讨论提议把 Whitenoise 消息效果放入引用父消息的专用 kind-9 event。目前线缆格式会在消息正文末尾附加 `dmfx:sparkle` 一类标记，任何不理解此约定的渲染器都会显示被污染的文本。把效果移入独立 event 可保持消息文字干净，同时也提出整个 Marmot 栈都将面对的设计选择：可选富媒体功能应采用正文内约定，还是 sidecar event。
+
+### CustID 作为带 NIP-46 与 NFC 挑战流程的移动身份保险库发布 {#custid-launches-as-a-mobile-identity-vault-with-nip-46-and-nfc-challenge-flow}
+
+[CustID v0.1.10-beta](https://zapstore.dev/apps/naddr1qq9rzqtdwfshxwf0wccsygqv94d2qg37755z67q9yjz6q60lcejldsc3ttak83333gjqgyvf3aqpsgqqqyf6w24n0c) 是 CustID 的首个公开 beta。CustID 是基于 Nostr 与 SISTR 协议的移动身份保险库，在硬件保护的安全存储中保存多个 Nostr 身份，可作为其他客户端的 [NIP-46](/zh/topics/nip-46/) 远程签名器，并通过 NFC 与二维码回应实体及在线访问挑战。
+
+此 beta 已完整提供 NIP-46 签名器与 NFC challenge-response 流程；零知识证明访问流程仍是未来里程碑。该版本还移除了应用后台的 [NIP-65](/zh/topics/nip-65/) keep-alive 层。旧层会为每个资料的每个读取中继打开一个 WebSocket，并摄取客户端随即丢弃的 kind。现在后台只保留承载签名请求通知的 NIP-46 socket，这项修复让手机把 CustID 作为其他客户端的 bunker 运行变得可行。
+
+### myco 在 FIPS mesh 上推出点对点 nsite 分享 {#myco-launches-peer-to-peer-nsite-sharing-over-the-fips-mesh}
+
+[myco v0.1.0](https://github.com/Origami74/myco/releases/tag/v0.1.0) 于 6 月 27 日开放，并在 7 月 1 日达到 v0.1.0。myco 是一款 Rust Android 应用，可从身边的人安装应用：它在 FIPS mesh 上点对点分享 [nsite](/zh/topics/nip-5a/)，可使用 mesh 承载的任何传输（UDP、TCP、Tor、Bluetooth），并可完全离线工作。设计直接把 FIPS 作为传输底座，把 NIP-5A 的静态网站 event 格式作为载荷，使以 nsite 分发的应用无需依赖中继或 HTTP，即可在 mesh peer 之间移动。
+
+v0.1.0 新增 L2CAP Bluetooth 无线电路径，让两部装有 FIPS 的手机无需任何网络即可通过 BLE 建立 peer；还加入逐 peer speedtest，以及从应用 Circle bottom-sheet 由 NFC 触发的分享。myco 也已发布到 Zapstore，可直接安装。
+
+### Nostr Codex Phone 作为通过 Nostr 操控本地 Codex worker 的移动控制端发布 {#nostr-codex-phone-launches-as-a-mobile-control-surface-for-a-local-codex-worker-over-nostr}
+
+[Nostr Codex Phone v0.1.122](https://github.com/tidley/nostr-codex-phone) 本周发布。这款 Android 客户端通过加密 Nostr 私信控制本地 Codex 编程助手 worker。应用支持多个仓库 session、语音转录、路由式 worker session、Blossom 媒体上传与可选语音回答，因此开发者在家运行的 Codex worker 可从任何能连接中继的手机接收指令。
+
+该项目与 #28 中发布的 [CodeDeck](/en/newsletters/2026-06-24-newsletter/#codedeck-remote-agentic-coding-over-nostr) 直接同属一类。二者都以加密私信把代理式编程工作流放到 Nostr 传输之上，也都把 Nostr 作为配对与消息层，让手机无需在网络上打洞即可触达家中的 worker。以 Nostr 作为本地 agent 控制平面正成为稳定模式。
+
+### Coop Mobile 发布首批带版本的构建
+
+[Coop Mobile v0.2.1](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.1) 与 [v0.2.2](https://git.reya.su/reya/coop-mobile/releases/tag/v0.2.2) 本周发布，是 Coop Mobile 首批带版本的构建。Coop Mobile 是 Android [NIP-17](/zh/topics/nip-17/) 加密私信客户端。两个版本提高消息解析与二维码处理的崩溃安全性，并在登出时清除所有已存数据。
+
+### Amethyst 构建感知 NIP-89 的 UI、Git Repositories 信息流与 napplet Discover 区域 {#amethyst-builds-nip-89-aware-ui-a-git-repositories-feed-and-a-napplet-browser-discover-section}
+
+[Amethyst](https://github.com/vitorpamplona/amethyst) 主分支本周构建多个新界面。[Git Repositories 信息流](https://github.com/vitorpamplona/amethyst/pull/3406)把 [NIP-34](/zh/topics/nip-34/) 仓库变成可浏览的 Android 时间线类别，可按社区与作者筛选；配套的 [smart-HTTP git 浏览器](https://github.com/vitorpamplona/amethyst/pull/3415)无需离开应用即可读取仓库内容与 commit。napplet host 新增 [Discover 区域](https://github.com/vitorpamplona/amethyst/pull/3409)，列出策展 web 应用以及用户关注的 nSite 与 napplet，数据来自 [NIP-89](/zh/topics/nip-89/) handler event 和 [NIP-5A](/zh/topics/nip-5a/) site event。笔记显示现通过 NIP-89 tag [揭示 event 由哪个 Nostr 应用创作](https://github.com/vitorpamplona/amethyst/pull/3422)。同步方面，[NIP-77 negentropy 支持](https://github.com/vitorpamplona/amethyst/pull/3434)加入流式 reconciliation，并自动划分 `created_at` 窗口以绕过中继端结果上限，减少大型本地 event 集合与中继保持同步所需带宽。
+
+### Buzz v0.3.38 加固中继攻击面并加入与提供方无关的模型选择
+
+[Buzz v0.3.38](https://github.com/block/buzz/releases/tag/v0.3.38) 加固 Buzz 在把 persona、team、托管 agent 与 NIP-OA owner attestation 作为已签名 Nostr event 发布时暴露的[中继攻击面](https://github.com/block/buzz/pull/1369)。Buzz 中继是团队 Nostr 身份及其状态的公开记录，本版收紧 Buzz 定义的 well-known event kind 的输入校验与 replay 防护。该版本也泛化模型选择，使 Buzz team 可指向任何已有适配器的提供方，包括新的 Databricks AI Gateway v2 后端。
+
+### Notedeck 落地 NIP-37 私密同步中继、NIP-52 日历与 NIP-22 评论 {#notedeck-implements-nip-37-private-sync-relays-nip-52-calendar-and-nip-22-comments}
+
+[Notedeck](https://github.com/damus-io/notedeck) 是 Damus 团队的原生 Rust 桌面客户端，一周内落地三项协议。私密同步中继现作为 kind `10013` [NIP-37](/zh/topics/nip-37/) 列表持久化，把用户的私密内容中继集合与公开 NIP-65 outbox 分离。`horizon` 日历窗格从 nostrdb 读取 [NIP-52](/zh/topics/nip-52/) event，并获得三栏布局改版。`headway` 窗格加入基于 kind `1111` 的 [NIP-22](/zh/topics/nip-22/) comment-event 模型；NIP-22 把该 kind 定义为取代 NIP-10 回复串联的统一评论界面。
+
+### Applesauce 加入 nbunksec NIP-46 session 与 Cashu v4 钱包升级 {#applesauce-ships-12-sub-packages-in-a-coordinated-62x-cut}
+
+[Applesauce](https://github.com/hzrd149/applesauce) 是面向签名器、中继、钱包与内容的模块化 Nostr 工具包，其子包协同发布 [6.2.x 版本](https://github.com/hzrd149/applesauce/releases)。signers 包新增 `nbunksec` 导入与导出辅助函数，把 [NIP-46](/zh/topics/nip-46/) bunker session 当作可在客户端之间迁移的便携工件。wallet 包把 [Cashu](/zh/topics/nip-60/) 绑定升级至 `@cashu/cashu-ts` v4，其中 proof amount 变成 `Amount` value object，token decoding API 也有所变化。
+
+---
+
+## 版本发布
+
+### mostro-core v0.14.0
+
+[mostro-core v0.14.0](https://github.com/MostroP2P/mostro-core/releases/tag/v0.14.0) 为 [Mostro](/zh/topics/nip-69/) 点对点法币交易网络带来下一轮协议迭代。该版本接续 [v0.13.2](https://github.com/MostroP2P/mostro-core/releases/tag/v0.13.2)，并与采用新核心的 [mostro-cli v0.16.0](https://github.com/MostroP2P/mostro-cli/releases/tag/v0.16.0) 同期发布。核心仓库本周合并三个 PR；外围栈（mostro daemon 与 Mostro mobile）则跟随共享类型 crate 的 v0.14.0。
+
+### ngit v2.6.1
+
+[ngit v2.6.1](https://github.com/DanConwayDev/ngit-cli) 是面向 [NIP-34](/zh/topics/nip-34/) 仓库的权威 git-over-nostr CLI，它实现本周合并的 [NIP-34 GRASP-06 分叉语义](https://github.com/nostr-protocol/nips/pull/2395)：在 repo-state event 上用 `u` tag 取代 `personal-fork` tag。
+
+### mesh-llm v0.72.0 与 v0.72.1
+
+[mesh-llm](https://github.com/Mesh-LLM/mesh-llm) 是 ContextVM 栈的推理组件，在可由 Nostr 寻址的 JSON-RPC 界面背后运行开源 LLM。项目发布 [v0.72.0](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.0) 与 [v0.72.1](https://github.com/Mesh-LLM/mesh-llm/releases/tag/v0.72.1)，修复大型单 prompt 的 batching 崩溃，并把 MCP bridge 从弃用辅助函数迁出。
+
+### Meiso v1.4.0 发布 Shared-Key Collaborative Lists，取代 MLS 任务共享 {#meiso-v140-ships-shared-key-collaborative-lists-that-replace-mls-for-task-sharing}
+
+[Meiso v1.4.0](https://github.com/higedamc/meiso/releases/tag/v1.4.0) 引入 Shared-Key Collaborative Lists 模型，以更简单的可寻址 event 设计取代项目此前基于 MLS 的任务共享。每个共享列表生成一个分发给成员的专用 Nostr key；任务是 kind `35000` 上以 `d=task-id` 为键的可寻址 event，content 通过 [NIP-44](/zh/topics/nip-44/) 自我加密，中继则对每项任务执行 Last-Write-Wins。该设计放弃 MLS 的前向保密与入侵后安全性，换取更简单的客户端实现及中继层冲突解析。
+
+### Cordn 0.3.2
+
+[Cordn 0.3.2](https://github.com/Cordn-msg/cordn) 发布“more-private-coordinator”路线，从群组消息发布中移除临时发送者 pubkey，并加固加入请求流程，防止陈旧请求重复出现。Cordn 是 [#28 的 Cordn Ad-hoc CVM 发布报道](/en/newsletters/2026-06-24-newsletter/#cordn-ad-hoc-cvm-a-browser-based-mls-coordinator)所介绍的 MLS 消息栈；本版是对应的 coordinator 端更新。
+
+---
+
+## 未发布的变更
+
+### diVine 推进 108 个已合并 PR 的发布后打磨
+
+[diVine](https://github.com/divinevideo/divine-mobile) 是让 Vine 回归的短循环视频客户端，目前正进行密集的发布后打磨。本周可在 Nostr 层看到的工作是 [NIP-46](/zh/topics/nip-46/) 连接流程稳定性改进，把 `nostrconnect://` 失败迁移到结构化 reason code。
+
+### Zap Cooking 延续跨项目 NIP-46 修复与 composer 重构
+
+[Zap Cooking](https://github.com/zapcooking/frontend) 是 Nostr 食谱分享客户端，食谱以长文 Nostr event 发布。本周工作延续跨项目 [NIP-46](/zh/topics/nip-46/) 修复与 composer 重构，此前已在 [#28](/en/newsletters/2026-06-24-newsletter/#unreleased-changes) 作为未发布变更报道。
+
+### Conduit 加固商品发布流程与市场正确性
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) 是 Nostr 上含买家市场、商户门户与商店构建器三个应用的市场 monorepo。本周工作延续 [#28 发布报道](/en/newsletters/2026-06-24-newsletter/#conduit-hardens-the-marketplace-mvp-and-switches-to-its-public-relay-by-default)中的市场正确性推进，并建立在上一期协议侧主题 [NIP-99](/zh/topics/nip-99/) 商务工作之上。
+
+### Pollerama v1.12 至 v1.13.1 加入 client-tag 选择、资料标签页与线程层级上限
+
+[Pollerama](https://github.com/formstr-hq/nostr-polls) 是专注投票与笔记、并具备强 web-of-trust 发现层的 Android Nostr 客户端，本周在 Zapstore 发布 v1.12.0、v1.13.0 与 v1.13.1。用户现可选择附在自己笔记和投票上的 client tag，可从预设列表选择或自行输入。深度嵌套的评论与回复链在数层后停止，并链接到笔记页面上的完整线程。资料页面默认打开 Notes，并拆分为 Posts 与 Conversations 标签页。新关注账户在应用重启后消失的持久化 bug 已修复，关注按钮也会显示进度。
+
+### getwired.app 与 get-tao.app 修复 NIP-13 confess 提交流程
+
+[getwired.app](https://github.com/smolgrrr/Wired) 与 [get-tao.app](https://github.com/smolgrrr/TAO) 共用匿名发帖流程，在提交时加入 NIP-13 proof-of-work 以抑制垃圾信息。二者修复了 [confess 提交流程](https://github.com/smolgrrr/Wired/pull/57)，使 PoW 挖掘期间的 UX 保持连贯。
+
+### nostui 加入提及时间线标签页
+
+[nostui](https://github.com/akiomik/nostui) 是 Rust 编写的终端 Nostr 客户端，新增[提及时间线标签页](https://github.com/akiomik/nostui/pull/463)，在 TUI 中以专用视图显示标记当前 pubkey 的 kind:1 event。
+
+### Heartwood 落地逐身份 NIP-46 bunker URI 与 HSM 模式签名桥
+
+[Heartwood](https://github.com/forgesworn/heartwood) 是 [NIP-46](/zh/topics/nip-46/) 签名器，签名 key 完全不会到达客户端：客户端通过 NIP-46 与小型中继通信，中继再通过 serial frame 协议与执行签名的外接硬件设备通信。本周项目落地[中继至串口签名桥](https://github.com/forgesworn/heartwood/pull/11)及[逐身份 bunker 连接](https://github.com/forgesworn/heartwood/pull/16)，使一个持有多个身份的硬件设备能为每个身份暴露不同 bunker URI。
+
+### Nostter 认证与签名器重构
+
+[Nostter](https://github.com/SnowCait/nostter) 本周重构[认证与签名器层](https://github.com/SnowCait/nostter/pulls?q=is%3Amerged+auth)，把登录状态移至单一 signal，并将签名器 dispatch 抽取为 strategy module。目标是形成干净的签名器抽象，让 NIP-07 web extension、NIP-46 远程 bunker 与原始 nsec 共用一条代码路径。
+
+### Dart NDK 抽取 NIP-07 签名器并随机化 NIP-59 时间戳
+
+[Dart NDK](https://github.com/relaystr/dart_ndk) 把 [NIP-07](/zh/topics/nip-07/) 签名器从 core 包移到 `ndk_flutter`（Flutter WebView 所在处），并[随机化 NIP-59 gift-wrap 时间戳](https://github.com/relaystr/dart_ndk/pull/667)，提高加密消息抵抗时序关联的能力。
+
+### Milk Market 加入 NIP-23 店面页面与 Square 支付处理
+
+[Milk Market](https://github.com/shopstr-eng/milk-market) 是 Shopstr 团队的市场店面，为每个店面加入由卖家 [NIP-23](/zh/topics/nip-23/) 长文 event 支撑的博客页面，带可编辑区块与直达博客设置的路由。同一周还加入 [Square](https://github.com/shopstr-eng/milk-market/pull/30) 作为卖家的替代支付处理商，并为已付款订单自动购买运输标签。
+
+### Calendar by Formstr 发布 iOS 应用
+
+[Calendar by Formstr](https://github.com/formstr-hq/nostr-calendar) 本周合并 [PR #159 IOS App](https://github.com/formstr-hq/nostr-calendar/pull/159)，把 [NIP-52](/zh/topics/nip-52/) 日历客户端带到 iOS。[PR #197](https://github.com/formstr-hq/nostr-calendar/pull/197) 修复本地时区下的日历日期解析，[PR #201](https://github.com/formstr-hq/nostr-calendar/pull/201) 则新增由 `run-tests` label 触发的 Playwright E2E workflow。
+
+### cagliostr 执行 NIP-22、按坐标执行 NIP-09，并加入 NIP-13 proof-of-work
+
+[cagliostr](https://github.com/mattn/cagliostr) 是 Go 中继实现，本周收紧三条执行路径：对入站 event 施加[可配置的 NIP-13 proof-of-work](https://github.com/mattn/cagliostr/pull/7)；[按可寻址坐标执行 NIP-09 删除](https://github.com/mattn/cagliostr/pull/8)，使可替换 event 可通过 `a` tag 删除（仅按 event id 删除无法触达）；以及[可配置的 NIP-22 时间戳限制](https://github.com/mattn/cagliostr/pull/9)，拒绝时间戳距离当前过远的 event。
+
+---
+
+## 新纳入追踪与发现的项目
+
+[Vanderwarker wellbeing 套件](https://git.vanderwarker.family/wellbeing)以共用发布者签名 key 把现实世界遥测数据发布为 Nostr event。它包含五款同属一个系列的应用：[Holy Fit](https://git.vanderwarker.family/wellbeing/holyfit-android) 是计步器，以 `kind:30078` 把健身数据锚定到 Nostr；[Nunlock](https://git.vanderwarker.family/wellbeing/nunlock-android) 发布每日手机解锁次数；[Saint Stream](https://git.vanderwarker.family/wellbeing/saintstream-android) 把当前媒体播放发布为 User Status；[Sister Charge](https://git.vanderwarker.family/wellbeing/sistercharge-android) 每 15 分钟发布电量、电压与温度；[Cellibacy](https://git.vanderwarker.family/wellbeing/cellibacy-android) 发布每日数据用量。五款应用均在 6 月 24 日至 30 日间出现在 Zapstore。
+
+[ntrack v0.1.9](https://github.com/f321x/ntrack/releases/tag/v0.1.9) 是以 Rust 与 Slint 构建的加密、无服务器 Android 实时位置分享应用，于 6 月 29 日发布。它与 [Haven](https://github.com/mehmetefeumit/Haven-App) 这款基于 [Marmot](/zh/topics/marmot/) 的位置分享器同属一类，后者曾由 [#28](/en/newsletters/2026-06-24-newsletter/#haven-launches-private-location-sharing-on-marmot) 报道，但二者传输架构不同：ntrack 通过加密 Nostr 私信承载位置更新，Haven 则使用 Marmot 群组消息。
+
+[NostrAppShell](https://git.nostrdev.com/stuff/NostrAppShell) 是用于构建 Nostr 应用的早期 application shell scaffold。项目本周首次发布面向用户的文档。
+
+[NIPs by Pollerama](https://nips.pollerama.fun)（仓库 [abh3po/better-nips](https://github.com/abh3po/better-nips)，创建于 2026-06-29）是面向 [NostrHub](https://nostrhub.io) `kind:30817` 社区编写 NIP 的新客户端，定位为以信任权重排序、替代 nostrhub.io 的界面。每份 `kind:30817` NIP 都有自己的可分享 URL（`#/nip/<naddr>`），可完整渲染 Markdown 并列出其定义的 event kind。客户端提供 Following、Web of Trust（关注者所关注的人）与 Global 三类信息流，每类均可按信任加权批准或最新时间排序。批准以 [NIP-32](/zh/topics/nip-32/) label 发布在 kind `1985` 上，带 tag `["L","nostrhub"]`、`["l","approve","nostrhub"]`、指向目标 NIP 地址的 `a` tag，以及公告 `better-nips` 的 `client` tag。这与 NostrHub 自身签名的 event 形状完全一致，因此两个客户端的批准相互兼容。直接关注者的批准在排序中比二度关注者的批准权重更高。
+
+签名栈使用 [`@formstr/signer`](https://www.npmjs.com/package/@formstr/signer)，完整登录 modal 涵盖 [NIP-07](/zh/topics/nip-07/)、[NIP-46](/zh/topics/nip-46/) bunker 与 nostrconnect、[NIP-49](/zh/topics/nip-49/) ncryptsec，以及 [NIP-55](/zh/topics/nip-55/) Android signer，session 会在重载后静默重新连接。网络层通过 [`@formstr/local-relay`](https://www.npmjs.com/package/@formstr/local-relay) 运行；该 Web Worker 将用户 [NIP-65](/zh/topics/nip-65/) outbox 分配到各中继，使大型 web-of-trust 集合不会扇出到单个中继。其设计立场是，社区 NIP（无论托管于 NostrHub、`better-nips` 还是未来其他客户端）在协议层都完全平等；排序来自社交图谱，而非管理员策展。这与 [#25 深度解析](/en/newsletters/2026-06-03-newsletter/#nip-deep-dive-nip-32-labeling)所介绍的 NIP-32 labeling 流程直接配合。
+
+本周出现两个新的 [NIP-34](/zh/topics/nip-34/) 仓库集群。[Vidstr](https://git.shakespeare.diy/npub14rg4vrt2v374q95ezeeydu3hkdhmzglcj950mggacap4x0lv0gyq04wun7/vidstr.git) 是视频类 Nostr 客户端；一个 [nostrapps.com 集群](wss://gitnostr.com)发布三个同系列项目：[verdana](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/verdana.git)（桌面 napp VM）、[hallway](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/hallway.git)（可定制社区客户端）与 [napps](https://gitnostr.com/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6/napps.git)（HTML microapps 规范与 runtime）。该集群与上期头条报道的 [napplet](/zh/topics/nip-5d/) 工作并行。
+
+---
+
+## 协议工作与 NIP 更新
+
+### 已合并：NIP-44 解除 65,535 字节载荷限制
+
+[PR #1907](https://github.com/nostr-protocol/nips/pull/1907) 自 2024-09 开放后，于 6 月 28 日合并。该变更移除 [NIP-44](/zh/topics/nip-44/) 版本化加密 envelope 的明文载荷 65,535 字节上限，提高到 4 GiB（`uint32_max`）。NIP-44 在线缆格式中以 `uint16` 编码载荷长度，原规范为互操作性严格要求这一点；合并后的变更采用标入 version byte 的更长长度字段，使 v2 实现保持线缆兼容，而 v3+ 实现可携带更长长度。使用 NIP-44 的客户端现可交换大于 64 KiB 的单个 event，无需在应用层拆分；适用场景包括 [NIP-17](/zh/topics/nip-17/) 私信、[NIP-59](/zh/topics/nip-59/) gift wrap、[NIP-46](/zh/topics/nip-46/) 远程签名器载荷及其他 NIP-44 加密 Nostr 消息。
+
+### 已合并：NIP-86 获得 `signevent` 方法与 Relay Roles event
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) 为 [NIP-86](/zh/topics/nip-86/) 中继管理 JSON-RPC API 新增 `signevent` 方法，使管理员可要求中继以自身 pubkey 签署 event。配套的 [PR #2390](https://github.com/nostr-protocol/nips/pull/2390) 定义 Relay Roles event：中继发布的可替换 event，用于声明管理员与版主。二者结合后，NIP-86 客户端可以读取中继管理员列表，并验证已认证请求是否来自当前管理员，无需带外信任。下文将深度解析两项变更。
+
+### 已合并：NIP-34 以 `u` 取代 `personal-fork`，对齐 GRASP-06
+
+[PR #2395](https://github.com/nostr-protocol/nips/pull/2395) 于 6 月 24 日合并，把 [NIP-34](/zh/topics/nip-34/) repo-state event（`kind:30618`）上的 `personal-fork` tag 替换为代表“upstream”的 `u` tag，使线缆格式对齐 GitWorkshop 套件一直实现的 GRASP-06 分叉语义。该变更关闭提出另一种分叉语义修复的 [PR #2384](https://github.com/nostr-protocol/nips/pull/2384)（`NIP-34: remove maintainers to solve expiry issues`）。合并方向由 ngit v2.6.x 实现，因此规范与参考 CLI 现已对齐。使用 `personal-fork` 的既有仓库仍能互操作；新仓库与 ngit v2.6 系列则发布 `u` tag。
+
+### 已合并：NIP-46 客户端元数据（Amber 发货后现已进入上游）
+
+[PR #2381](https://github.com/nostr-protocol/nips/pull/2381) 于 6 月 23 日合并，为 [NIP-46](/zh/topics/nip-46/) `connect` 请求增加可选客户端元数据，使客户端在连接签名器时可发布名称、图标 URL 与主页 URL。[Amber v6.2.2](https://github.com/greenart7c3/Amber/releases/tag/v6.2.2) 上周已发布该元数据扩展（见 [#28](/en/newsletters/2026-06-24-newsletter/#amber-v622-implements-nip-46-client-metadata)）；本周上游 NIP 跟上已发货实现。
+
+### 开放：基于 epoch 的确定性 NIP-17 wrapper key
+
+[PR #2397](https://github.com/nostr-protocol/nips/pull/2397) 与 [PR #2396](https://github.com/nostr-protocol/nips/pull/2396) 涵盖两个趋同的 NIP-17 wrap-key 提案。PR #2397 提议从绑定粗粒度时间 epoch 的逐会话 seed，确定性派生用于创作 [NIP-59](/zh/topics/nip-59/) gift wrap 的临时签名 key，使知晓会话 key 的接收方能预测应订阅哪些 pubkey。当前规范要求每个 wrap 使用全新随机 key，无法进行这种预测。PR #2396 是配套变更：给定会话的 wrap 应直接由会话 key 签名，使 wrap pubkey 同时成为会话标识符。二者共同定义可筛选 NIP-17 会话且不泄露元数据的路径。目前都仍开放讨论。
+
+### 开放：NIP-59 应要求中继拒绝 kind:13 seal event
+
+[PR #2399](https://github.com/nostr-protocol/nips/pull/2399) 提议中继在 kind:13 event（[NIP-59](/zh/topics/nip-59/) gift wrap 的内层 seal）作为发布请求顶层对象出现时予以拒绝，因为 seal event 只有置于 wrap 内才有意义，泄漏的 seal 会暴露接收方 pubkey。配套的 [issue #2398](https://github.com/nostr-protocol/nips/issues/2398) 更进一步，主张把 seal 重新定义为临时 kind（NIP-01 的临时 kind 不由中继存储），从协议层加固规则并消除对逐中继策略的依赖。
+
+### 开放：NIP-29 群组状态
+
+[PR #2372](https://github.com/nostr-protocol/nips/pull/2372) 为 [NIP-29](/zh/topics/nip-29/)（基于中继的群组）增加明确群组状态语义，定义群组为开放、关闭、公开、私密或归档时的含义，以及状态转换如何与成员 event 互动。提案把此前由各客户端自行定义的语义纳入中继规范。
+
+### 开放：NIP-34 可选多维护者支持
+
+[PR #2324](https://github.com/nostr-protocol/nips/pull/2324) 是已合并 [PR #2395](https://github.com/nostr-protocol/nips/pull/2395)（上文介绍的 GRASP-06 分叉语义）的配套提案。PR #2324 为 [NIP-34](/zh/topics/nip-34/) repo announcement event（`kind:30617`）增加可选多维护者支持，使仓库可通过重复 `maintainer` tag 声明多个权威维护者 pubkey。客户端随后会把任何已声明维护者签署的 patch 与 issue 信任为官方内容，解决 NIP-34 多维护者仓库长期以来必须让所有内容经一个 pubkey 发布，或退回协议外协调的问题。
+
+### 开放：NIP-91 filter 的 AND 运算符（提案仍开放，尚未合并）
+
+[PR #2252](https://github.com/nostr-protocol/nips/pull/2252) 是 Nostr [filter](/zh/topics/nip-01/) 的 AND 运算符提案，重新开启此前已关闭 [PR #1365](https://github.com/nostr-protocol/nips/pull/1365) 首次讨论的设计。实现已存在于 [nostr-rs-relay](https://github.com/v0l/nostr-rs-relay)、applesauce、[Amethyst](https://github.com/vitorpamplona/amethyst) 与 worker-relay，但规范 PR 本身仍开放。
+
+### 已关闭：四份 pats2sats 商务 NIP
+
+本周关闭四份 Nostr 商务提案：Escrow（[#2334](https://github.com/nostr-protocol/nips/pull/2334)）、Reservations（[#2335](https://github.com/nostr-protocol/nips/pull/2335)）、[NIP-99](/zh/topics/nip-99/) Marketplace Listing Extension（[#2346](https://github.com/nostr-protocol/nips/pull/2346)）与 Accommodation Listing Profile（[#2333](https://github.com/nostr-protocol/nips/pull/2333)）。同一商务界面现正整合到 [Gamma Market Spec](https://github.com/GammaMarkets/market-spec)。这个由项目持有的扩展仓库构建在 NIP-99 市场商品 event 之上，组合订单、结账、托管与争议语义。Compass 现在像追踪 Marmot 与 Blossom 一样，追踪这个位于 NIPs 仓库外部的协议规范仓库。本周其中开放的 PR 包括客户端归属说明（[#11](https://github.com/GammaMarkets/market-spec/pull/11)）、用于商品身份变更的 supersedes tag（[#8](https://github.com/GammaMarkets/market-spec/pull/8)），以及商家评价语义（[#7](https://github.com/GammaMarkets/market-spec/pull/7)）。
+
+### 开放：Bitcoin 身份关联
+
+本周开放两项把 Bitcoin 身份关联到 Nostr 身份的提案：[NIP-352 Bitcoin Silent Payment Address](https://github.com/nostr-protocol/nips/pull/2392) 与 [Bitcoin-OTC Identity Linkage Proof](https://github.com/nostr-protocol/nips/pull/2401)。
+
+---
+
+## NIP 深度解析：NIP-86（中继管理 API） {#nip-deep-dive-nip-86-relay-management-api}
+
+[NIP-86](/zh/topics/nip-86/) 定义中继管理 JSON-RPC 接口，使获授权客户端能通过标准化 API 向中继发送管理命令。单个客户端无需逐中继专用工具，即可管理任何兼容 NIP-86 的中继。本周合并的两项规范变更（[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) 与 [PR #2390](https://github.com/nostr-protocol/nips/pull/2390)）闭合中继签名 event 与中继声明管理员之间的链路。
+
+### 传输
+
+NIP-86 管理请求是发送到中继提供 WebSocket 连接的同一 URI 的 HTTP POST，`Content-Type: application/nostr+json+rpc`。请求正文是以下形式的 JSON 文档：
+
+```json
+{
+  "method": "<method-name>",
+  "params": [<arg1>, <arg2>, ...]
+}
+```
+
+认证使用 `Authorization` header 中的 [NIP-98](/zh/topics/nip-98/) HTTP 认证签名 event。中继会先验证签名 pubkey 位于管理员列表中，再执行方法。中继响应是以下形式的 JSON 文档：
+
+```json
+{
+  "result": <return-value>,
+  "error": "<error-string-if-any>"
+}
+```
+
+### 本周之前已有的方法
+
+既有方法集涵盖 pubkey 封禁（`banpubkey`、`allowpubkey`、`listbannedpubkeys`）、event 封禁（`banevent`、`allowevent`、`listbannedevents`）、中继元数据（`changerelayname`、`changerelaydescription`、`changerelayicon`）、允许的 pubkey 列表管理（`allowkind`、`disallowkind`、`listallowedkinds`），以及返回中继统计的 `stats` 方法。其形状刻意接近标准 JSON-RPC 服务，使客户端能在其上构建类型化绑定。
+
+### 本周的变化
+
+[PR #2389](https://github.com/nostr-protocol/nips/pull/2389) 为规范增加 `signevent` 方法。该方法接受部分 event 模板（kind、tag、content）作为参数，要求中继签名并返回完整 event，其 `pubkey` 字段使用中继自身 pubkey。这是中继发布自身协议层 event 的前提：被封 pubkey 公告、中继元数据及下文新的 Relay Roles event 都要求中继以运营者控制的 key 签名，但多数中继运营者不愿在管理客户端内持有私钥。
+
+[PR #2390](https://github.com/nostr-protocol/nips/pull/2390) 定义 Relay Roles event：由中继发布的参数化可替换 event kind（通过 `signevent` 以自身 pubkey 签名），用带明确角色语义的方式声明管理员与版主 pubkey。感知 NIP-86 的客户端可从任何已追踪中继抓取 Relay Roles event，从 event tag 构建管理员列表，并验证已认证 NIP-86 请求来自当前管理员，无需带外信任或逐中继配置。两个 PR 合在一起闭合链路：`signevent` 是机制，Relay Roles 是其上的首个 event kind。
+
+### NIP-86 请求示例
+
+完整的 NIP-86 `banpubkey` 请求如下：
+
+```json
+{
+  "method": "banpubkey",
+  "params": [
+    "<64-char-hex-pubkey-to-ban>",
+    "spam"
+  ]
+}
+```
+
+其 `Authorization` header 携带一个 NIP-98 签名 event：
+
+```json
+{
+  "id": "5e1c2f9e1d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
+  "pubkey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "created_at": 1782824400,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://relay.example.com/"],
+    ["method", "POST"],
+    ["payload", "<sha256-of-request-body>"]
+  ],
+  "content": "",
+  "sig": "f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100f1e2d3c4b5a697887766554433221100ffeeddccbbaa99887766554433221100"
+}
+```
+
+签名 pubkey 必须位于中继管理员集合中（现在由 Relay Roles event 声明）；`u` tag 必须匹配中继 HTTPS URL；`payload` tag 必须匹配 JSON 请求正文的 SHA-256。中继返回：
+
+```json
+{
+  "result": true,
+  "error": null
+}
+```
+
+### 实现
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst) 在 Android 上提供 NIP-86 中继管理 UI（v1.07.0+）。
+- 实现该规范的参考中继包括 [strfry](https://github.com/hoytech/strfry)、[khatru](https://github.com/fiatjaf/khatru)，以及规范 `Implementation Status` 区域链接的若干较小实现。
+
+实现者采纳 `signevent` 与 Relay Roles 变更后，感知 NIP-86 的客户端将开始把 Relay Roles event 当作中继管理员列表的权威来源。
+
+---
+
+## NIP 深度解析：NIP-89（推荐应用处理器） {#nip-deep-dive-nip-89-recommended-application-handlers}
+
+[NIP-89](/zh/topics/nip-89/) 定义两种参数化可替换 event kind：`kind:31990`（应用开发者发布的 application handler）与 `kind:31989`（用户为自己使用的应用发布的推荐）。二者使客户端无需带外协调即可发现可处理未知 event kind 的应用：当长文阅读器遇到自身无法原生处理的 `kind:30030` event 时，可以查询 NIP-89 图谱中的 handler，并为用户提供指向已发布应用的 `Open in...` 流程。NIP-89 是这一跨应用路由问题的原始基础设施，本期出现的 napplet/napps 工作正把它扩展至可组合的 Nostr 原生 applet。
+
+### Application handler event（`kind:31990`）
+
+应用开发者发布一个或多个 handler event，描述应用支持哪些 event kind，以及如何在应用中打开 Nostr 实体：
+
+```json
+{
+  "id": "8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
+  "pubkey": "c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+  "created_at": 1782824400,
+  "kind": 31990,
+  "tags": [
+    ["d", "longform-reader-v1"],
+    ["k", "30023"],
+    ["k", "30024"],
+    ["web", "https://reader.example.com/a/<bech32>", "naddr"],
+    ["ios", "longformreader://open/<bech32>"],
+    ["android", "longformreader://open/<bech32>"]
+  ],
+  "content": "{\"name\": \"Longform Reader\", \"picture\": \"https://reader.example.com/icon.png\", \"about\": \"A native reader for NIP-23 longform.\"}",
+  "sig": "1f2e3d4c5b6a798877665544332211000ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa9988776655443322110a"
+}
+```
+
+`d` tag 标识 handler（使其可被替换），每个 `k` tag 声明应用处理的一种 event kind，每个平台 tag（`web`、`ios`、`android` 等）给出 URL 模板，其中 `<bech32>` 是调用客户端打开时替换的 [NIP-19](/zh/topics/nip-19/) 编码实体占位符。若多个受支持 kind 共享相同路由模式，一个 handler event 可以公告多个 kind，使应用发现保持紧凑，避免每种 kind 各需一个 handler event。
+
+### 用户推荐 event（`kind:31989`）
+
+用户发布推荐，声明自己针对某种 event kind 使用哪些应用：
+
+```json
+{
+  "id": "9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
+  "pubkey": "d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "created_at": 1782824500,
+  "kind": 31989,
+  "tags": [
+    ["d", "30023"],
+    ["a", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com", "web"],
+    ["a", "31990:e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6:reader-pro", "wss://relay.example.com", "ios"]
+  ],
+  "content": "",
+  "sig": "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6"
+}
+```
+
+`d` tag 携带被推荐的 event kind。每个 `a` tag 都是指向 `kind:31990` handler event 的 NIP-01 address pointer，同时给出建议中继及推荐适用的平台。同一推荐可以列出不同平台的多个应用。
+
+### Client tag 与隐私权衡
+
+NIP-89 还定义可选的 `client` tag，任何发布应用都可将其附在自己创作的 event 上：
+
+```
+["client", "Longform Reader", "31990:c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2:longform-reader-v1", "wss://relay.example.com"]
+```
+
+这使显示 event 的客户端可以展示 event 来自哪个应用、查找更丰富的 handler 元数据，并遵守 handler 声明的渲染提示。规范也明确指出隐私成本：若客户端在每个 event 上都发出 `client` tag，就会公开用户的软件身份，长期下来会泄露使用模式。规范建议客户端允许用户选择退出。
+
+Amethyst 的 [PR #3422](https://github.com/vitorpamplona/amethyst/pull/3422) 解析并显示 event 上的 NIP-89 `t`、`i`、`a` 与 `client` tag，直接在时间线中展示笔记由哪个应用创作。
+
+### 实际发现流程
+
+收到未知 event kind 的客户端依次执行以下步骤：（1）在用户关注图谱中查询 `d` tag 与目标 event kind 匹配的 `kind:31989` event。（2）把每个推荐的 `a` tag 解析到其 `kind:31990` handler event。（3）选择 `web`、`ios` 或 `android` URL 模板与当前平台匹配的 handler。（4）将实体的 `bech32` 编码代入 URL 模板。（5）向用户提供所得 URL 作为 `Open in...` 选项。该流程经过社交过滤：若客户端从不可信中继查询任意 handler event，可能会把用户重定向到恶意应用；因此从用户关注的人开始，比把所有已发布 handler 视为同等可信更安全。
+
+### NIP-89 与 napplet 层
+
+Amethyst 的 Discover 区域、napplet-host runtime 与 `client` tag 显示共同在 Android 上构成完整的 NIP-89 消费界面。上期发布的 napplet 规范扩展这些 NIP-89 handler event 可以指向的目标：在 Nostr 与 Blossom 上运行可组合 Nostr 原生 runtime 的 sandboxed applet。NIP-89 是发现与路由图谱；napplet runtime 是它可以指向的一种执行目标。
+
+---
+
+*反馈、勘误或我们遗漏的项目：请在 [github.com/andotherstuff/nostr-compass](https://github.com/andotherstuff/nostr-compass) 提交 issue，或通过 NIP-17 私信联系 npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923。*


### PR DESCRIPTION
Translations for Newsletter #29 (2026-07-01).

Languages: es, pt, de, fr, it, ja, ko, nl, zh

Generated and verified by `scripts/translate.sh`: every language passes the encoding, link-leak, and native-script checks, and all referenced topic pages are present.