### PR TITLE
Fix discovery: persist baselines, name every release, gate triage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,11 +135,48 @@ The NIP-34 tracker (`data/nip34_tracked.yml`) MUST only track repositories whose
 
 The owner sweep runs on the public-only core REST listing (`users/<owner>/repos?sort=pushed&type=public`), not the search API, because one search per owner would exhaust the 30-per-minute search budget. Owners past `OWNER_SIBLING_OWNER_LIMIT` and owner listings that exceed the bounded page walk are named in `source_errors`, never dropped quietly. A dedicated owner-sibling seen set lets every sibling receive one owner-provenance review even if an older query had already baselined it, while preventing repeated candidates in overlapping weekly windows.
 
-The script writes `data/app_discovery/discovery_YYYY-MM-DD.json`, excludes canonical repo/website/name matches already in `data/projects.yml`, and persists `seen_repos.json` so the weekly active-repository query does not repeat its baseline forever. Every GitHub result requires explicit Nostr plus application/tooling metadata; libraries and SDKs do not qualify on those labels alone. NIP-89 records require a stable `d` identifier, supported non-DVM kinds, and usable identity/location evidence. Zapstore listings require a stable app ID, canonical location, and an explicit Nostr protocol surface. Relay events are signature-verified, relay and source provenance is retained, unsafe URLs are rejected, GitHub truncation/incomplete-result warnings and partial source failures are reported, and independent records merge only when their canonical repository or website matches.
+The script writes `data/app_discovery/discovery_YYYY-MM-DD.json`, excludes canonical repo/website/name matches already in `data/projects.yml`, and persists `seen_repos.json` so the weekly active-repository query does not repeat its baseline forever.
+
+**Discovery baseline state lives outside the worktree (CRITICAL).** `seen_repos.json` and Zapstore's `publishers_seen.yml` resolve under `COMPASS_STATE_DIR` (default `/opt/data/compass-state/`), not under `data/`. They must, because `data/app_discovery/` and `data/zapstore_releases/` are gitignored and every issue runs in a fresh worktree from `origin/main`: for months the baselines never existed at run time. The consequences ran in both directions and both destroyed signal.
+
+- Zapstore's fresh-install guard fired every week, flagging every release `first_run: true` / `new_app: false`. Newsletter #37 discarded 622 Nostr-relevant releases this way, including `com.formstr.mail` (Nail's own listing) and Mostro Mobile v1.4.0.
+- App discovery's `first_run` fired every week, so nothing deduped against a baseline. The #37 fetch produced 603 candidates including 561 owner-siblings; the very next run, with the state file present, produced 14 candidates including 10 owner-siblings. Same window, 43× less noise.
+
+Run `python3 scripts/migrate_discovery_state.py` after adding a worktree or moving state; it takes the union across every worktree, because each accumulated a different partial baseline (five worktrees held five, from 6 to 778 repositories). Union is the safe direction: it can only suppress a stale "new" flag, never invent one. Never point these files back inside `data/`.
+
+Every GitHub result requires explicit Nostr plus application/tooling metadata; libraries and SDKs do not qualify on those labels alone. NIP-89 records require a stable `d` identifier, supported non-DVM kinds, and usable identity/location evidence. Zapstore listings require a stable app ID, canonical location, and an explicit Nostr protocol surface. Relay events are signature-verified, relay and source provenance is retained, unsafe URLs are rejected, GitHub truncation/incomplete-result warnings and partial source failures are reported, and independent records merge only when their canonical repository or website matches.
 
 Relay multiplicity is transport-availability evidence only: `relay_status: multi-relay` does not confirm reputation, ownership, or product legitimacy, and every candidate's `evidence_status` remains `unconfirmed` pending Triage. NIP-89 `latest`/`next` kind 35128 nsite references are retained as optional corroboration pointers, not fetched as a broad discovery source. Kind 31989 recommendations are intentionally excluded because Compass has no explicit trusted-author/follow-graph set; a global recommendation sweep would be sybil-prone and could never be a standalone approval signal.
 
 Every output row remains `candidate-only; never auto-add to projects.yml`. Forge topics and descriptions are self-asserted. A signed kind 31990 or 32267 event proves only that a key published the descriptor. Triage must open the product and repository, verify concrete Nostr relay behavior, establish canonical ownership, apply the per-item Nostr-surface gate, and record a GREEN/MAYBE/SKIP reason. Cross-source agreement raises confidence but does not replace verification.
+
+### Every discovered release must be named and triaged (CRITICAL)
+
+Stage 3 reads the Stage 2 summary, not the raw JSON. While that summary carried only aggregates, a release could exist in the data and in no downstream artifact. Newsletter #37 lost `formstr-hq/nail` v0.1.0 exactly this way: the release was in `updates_*.json` with a full changelog, its app was in the Zapstore feed as `com.formstr.mail`, Nail had been introduced in #36 the week before, and it was named in none of `fetch_2026-08-26.md`, `triage_2026-08-26.md`, `selection_review_2026-08-26.md`, or the published issue. Two independent discovery sources caught it and the aggregate summary hid both.
+
+Two artifacts now close that loop, and `scripts/fetch_all.sh` builds the first automatically:
+
+```bash
+# Written by fetch_all.sh; names every release in the window.
+data/newsletter_workspace/release_digest_<date>.md
+data/project_updates/release_digest_<date>.json
+
+# Blocking gate; run before the Triage gate passes.
+python3 scripts/check_triage_coverage.py \
+  --digest data/project_updates/release_digest_<date>.json \
+  --triage data/newsletter_workspace/triage_<date>.md \
+  --also data/newsletter_workspace/selection_review_<date>.md
+```
+
+The digest ranks by signal rather than alphabetically. Three flags lead:
+
+- **FOLLOW-UP** — the project was covered within the last 21 days and has now shipped a release. The reader already met it and the release is the payoff. This is the Nail shape, and it ranks first.
+- **POSSIBLE-FIRST-RELEASE** — a `0.x` tag with few releases in window. A debut is inherently newsworthy and was previously ranked no differently from a patch bump. It is a review hint, never a claim in prose: verify the release history before calling anything a first release.
+- **NEVER-COVERED** — no prior mention in any published issue, so there is no back-reference to lean on.
+
+The gate fails when a flagged release is named nowhere. **Skipping a release is a legitimate editorial choice; skipping it silently is not.** Record the skip and the reason in triage and the gate passes. Run against #37's real artifacts the gate reports 23 untriaged high-signal releases, Nail first, alongside Zeus v13.2.0, Marmot MDK v0.9.15, Chama v6.0.1 and diVine 1.0.22.
+
+A project-family mention does not satisfy a specific release. #37 discussed Marmot's same-account-enrollment spec PR five times and never mentioned MDK v0.9.14/v0.9.15 shipping, so the gate still flags MDK. Name the repo or the tag to record the decision.
 
 ### Pre-intake link-queue enrichment (CRITICAL)
 

--- a/scripts/build_release_digest.py
+++ b/scripts/build_release_digest.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Enumerate every release and Zapstore listing in the window, by name.
+
+WHY THIS EXISTS
+---------------
+Stage 2's summary reported only aggregates. `fetch_2026-08-26.md` said
+"100 releases, 905 merged PRs, 146 active repos of 713 fetched" and never named
+a single release. Stage 3 reads that summary, so anything not named in it is
+invisible unless a human opens the raw JSON.
+
+Nail shipped v0.1.0 on 2026-08-23, inside Newsletter #37's window. It was in
+`updates_*.json` with a full changelog, it was in the Zapstore feed as
+`com.formstr.mail`, and it appeared in **no** downstream artifact: not
+`fetch_2026-08-26.md`, not `triage_2026-08-26.md`, not
+`selection_review_2026-08-26.md`, and not the published issue. Two independent
+discovery sources caught it and the aggregate summary hid both.
+
+This digest names every release so a drop becomes a visible editorial decision
+instead of an accident. It also flags the two things the old pipeline could not
+see at a glance:
+
+  * FIRST-RELEASE: the project has no earlier release in `coverage_history` or
+    in this fetch's own history. A project's first tagged release is inherently
+    newsworthy; Nail v0.1.0 was exactly this and was ranked no differently from
+    a patch bump.
+  * NEVER-COVERED: the project has never appeared in any published newsletter,
+    so there is no back-reference to lean on and no reason to assume it was
+    covered already.
+
+Output is deterministic and diffable: no timestamps, sorted by rank then name.
+
+Usage:
+  python3 scripts/build_release_digest.py --updates data/project_updates/updates_A_B.json \
+      [--zapstore data/zapstore_releases/zapstore_D.json] \
+      [--coverage data/coverage_history.json] [--out PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_json(path: Path | None):
+    if path is None or not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"error: {path} is not valid JSON: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def normalize_repo(value: str) -> str:
+    """`formstr-hq/nail`, `github.com/formstr-hq/nail` and a full URL all collapse
+    to the same key.
+
+    coverage_history.json is keyed by normalized repo URL
+    (`github.com/owner/repo`), while updates_*.json is keyed by `owner/repo`.
+    Comparing project *names* across the two never matches, which flagged all 40
+    projects NEVER-COVERED on the first run of this script and would have made
+    the flag pure noise.
+    """
+    v = value.strip().lower()
+    v = re.sub(r"^https?://", "", v)
+    v = re.sub(r"^(www\.)?", "", v)
+    v = re.sub(r"^(github|gitlab|codeberg)\.com/", "", v)
+    v = re.sub(r"\.git$", "", v)
+    return v.strip("/")
+
+
+def covered_repos(coverage: dict | None) -> dict[str, str]:
+    """Map normalized repo key -> last mention date for every covered project.
+
+    The date matters as much as the fact. A project introduced one issue ago
+    that now ships a release is a follow-up story, not a debut and not old news.
+    Nail is exactly that shape: introduced in #36, shipped v0.1.0 during #37's
+    window, and covered in neither.
+    """
+    if not coverage:
+        return {}
+    out: dict[str, str] = {}
+    projects = coverage.get("projects")
+    if isinstance(projects, dict):
+        for k, v in projects.items():
+            if not isinstance(k, str):
+                continue
+            last = ""
+            if isinstance(v, dict):
+                last = v.get("last_mention_date") or ""
+            out[normalize_repo(k)] = last if isinstance(last, str) else ""
+    elif isinstance(projects, list):
+        for entry in projects:
+            if isinstance(entry, dict):
+                last = entry.get("last_mention_date") or ""
+                for field in ("repo", "repository", "url", "name", "project"):
+                    v = entry.get(field)
+                    if isinstance(v, str):
+                        out[normalize_repo(v)] = last if isinstance(last, str) else ""
+            elif isinstance(entry, str):
+                out[normalize_repo(entry)] = ""
+    return {k: v for k, v in out.items() if k}
+
+
+def days_between(earlier: str, later: str) -> int | None:
+    """Whole days between two YYYY-MM-DD strings, or None if either is unusable."""
+    from datetime import date
+
+    try:
+        a = date.fromisoformat(earlier[:10])
+        b = date.fromisoformat(later[:10])
+    except (ValueError, TypeError):
+        return None
+    return (b - a).days
+
+
+SEMVER = re.compile(r"^v?0+\.(0+\.)?(\d+)")
+
+# A project mentioned this recently is still fresh in the reader's mind, so a
+# release from it is a follow-up rather than a re-introduction.
+FOLLOWUP_WINDOW_DAYS = 21
+
+
+def looks_like_first_release(tag: str | None, release_count_in_window: int) -> bool:
+    """A 0.0.x / 0.1.0 / v1.0 tag with no prior coverage reads as a debut.
+
+    Deliberately conservative: this only *raises* a release for review. It is a
+    ranking hint, never a claim in prose, and Triage still has to verify the
+    project's release history before calling anything a first release.
+    """
+    if not tag:
+        return False
+    return bool(SEMVER.match(tag.strip())) and release_count_in_window <= 2
+
+
+def rank(entry: dict) -> tuple[int, str]:
+    """Lower sorts first. Debuts and never-covered projects lead."""
+    score = 50
+    if entry["never_covered"]:
+        score -= 20
+    if entry["possible_first_release"]:
+        score -= 15
+    if entry["release_count"] >= 3:
+        score -= 5
+    if entry["zapstore_listing"]:
+        score -= 5
+    if entry["recent_followup"]:
+        score -= 25
+    return (score, entry["project"].lower())
+
+
+def build(updates: dict, zapstore: dict | None, coverage: dict | None) -> dict:
+    covered = covered_repos(coverage)
+    zap_by_project: dict[str, list[dict]] = {}
+    if zapstore:
+        for rel in zapstore.get("releases", []):
+            tp = rel.get("tracked_project")
+            if isinstance(tp, str):
+                zap_by_project.setdefault(tp.strip().lower(), []).append(rel)
+
+    entries: list[dict] = []
+    for repo_key, proj in (updates.get("projects") or {}).items():
+        if not isinstance(proj, dict):
+            continue
+        releases = proj.get("releases") or []
+        if not releases:
+            continue
+        name = proj.get("name") or repo_key
+        zap = zap_by_project.get(str(name).strip().lower(), [])
+        rels = []
+        for r in releases:
+            rels.append(
+                {
+                    "tag": r.get("tag") or r.get("tag_name") or r.get("name") or "(untagged)",
+                    "published_at": (r.get("published_at") or "")[:10],
+                    "url": r.get("url") or "",
+                    "body_chars": len(r.get("body") or ""),
+                }
+            )
+        rels.sort(key=lambda x: x["published_at"])
+        entry = {
+            "project": str(name),
+            "repo": repo_key,
+            "category": proj.get("category"),
+            "priority": proj.get("priority"),
+            "release_count": len(rels),
+            "releases": rels,
+            "merged_prs": len(proj.get("merged_prs") or []),
+            "never_covered": normalize_repo(repo_key) not in covered if covered else False,
+            "last_covered": covered.get(normalize_repo(repo_key)) or None,
+            "recent_followup": False,  # filled in below, needs the window end date
+            "possible_first_release": looks_like_first_release(rels[0]["tag"], len(rels)),
+            "zapstore_listing": [
+                {"app_id": z.get("app_id"), "version": z.get("version")} for z in zap[:3]
+            ],
+        }
+        # A project covered within FOLLOWUP_WINDOW_DAYS that now ships a release
+        # is the highest-value miss: the reader already met it, and the release
+        # is the payoff. Nail was introduced in #36 and its v0.1.0 went unwritten.
+        last = entry["last_covered"]
+        newest_release = entry["releases"][-1]["published_at"]
+        if last and newest_release:
+            gap = days_between(last, newest_release)
+            if gap is not None and 0 <= gap <= FOLLOWUP_WINDOW_DAYS:
+                entry["recent_followup"] = True
+        entries.append(entry)
+
+    entries.sort(key=rank)
+    return {
+        "period": updates.get("period"),
+        "release_bearing_projects": len(entries),
+        "total_releases": sum(e["release_count"] for e in entries),
+        "coverage_history_available": bool(covered),
+        "projects": entries,
+    }
+
+
+def render_markdown(digest: dict) -> str:
+    out: list[str] = []
+    p = digest.get("period") or {}
+    window = f"{p.get('start','?')} → {p.get('end','?')}" if isinstance(p, dict) else str(p)
+    out.append("# Release digest — every tagged release in the window")
+    out.append("")
+    out.append(
+        f"Window {window}. {digest['total_releases']} releases across "
+        f"{digest['release_bearing_projects']} projects."
+    )
+    if not digest["coverage_history_available"]:
+        out.append("")
+        out.append(
+            "**No coverage history available**, so never-covered flags are absent from this run. "
+            "Rebuild it with `python3 scripts/build_coverage_history.py` and regenerate."
+        )
+    out.append("")
+    out.append(
+        "Triage MUST record a decision for every project below. A release that is "
+        "neither written up nor given a skip reason is a pipeline defect, not an "
+        "editorial choice: that is how Nail v0.1.0 was lost from Newsletter #37."
+    )
+    out.append("")
+    for e in digest["projects"]:
+        flags = []
+        if e["never_covered"]:
+            flags.append("**NEVER-COVERED**")
+        if e["possible_first_release"]:
+            flags.append("**POSSIBLE-FIRST-RELEASE**")
+        if e["recent_followup"]:
+            flags.append(f"**FOLLOW-UP** (last covered {e['last_covered']})")
+        if e["zapstore_listing"]:
+            ids = ", ".join(
+                f"`{z['app_id']}`" + (f" v{z['version']}" if z.get("version") else "")
+                for z in e["zapstore_listing"]
+                if z.get("app_id")
+            )
+            if ids:
+                flags.append(f"Zapstore: {ids}")
+        head = f"- **{e['project']}** (`{e['repo']}`)"
+        if flags:
+            head += " — " + " · ".join(flags)
+        out.append(head)
+        for r in e["releases"]:
+            line = f"  - `{r['tag']}` {r['published_at']}"
+            if r["url"]:
+                line += f" — {r['url']}"
+            if r["body_chars"] == 0:
+                line += " (empty release notes; audit the commit range instead)"
+            out.append(line)
+        if e["merged_prs"]:
+            out.append(f"  - {e['merged_prs']} merged PRs in window")
+        out.append("  - Triage decision: __________ (write up / skip + reason)")
+    out.append("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--updates", type=Path, required=True)
+    ap.add_argument("--zapstore", type=Path)
+    ap.add_argument("--coverage", type=Path, default=PROJECT_ROOT / "data/coverage_history.json")
+    ap.add_argument("--out", type=Path)
+    ap.add_argument("--json-out", type=Path)
+    args = ap.parse_args()
+
+    updates = load_json(args.updates)
+    if updates is None:
+        print(f"error: --updates {args.updates} not found", file=sys.stderr)
+        return 1
+
+    digest = build(updates, load_json(args.zapstore), load_json(args.coverage))
+    md = render_markdown(digest)
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(md, encoding="utf-8")
+        print(f"wrote {args.out}", file=sys.stderr)
+    else:
+        print(md)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(digest, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {args.json_out}", file=sys.stderr)
+
+    print(
+        f"release digest: {digest['total_releases']} releases / "
+        f"{digest['release_bearing_projects']} projects",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_triage_coverage.py
+++ b/scripts/check_triage_coverage.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Blocking gate: every release in the digest must have a triage decision.
+
+WHY THIS EXISTS
+---------------
+Naming releases is not enough on its own. Newsletter #37's real failure was that
+nothing checked whether a discovered release had been *considered*. Nail v0.1.0
+sat in `updates_*.json` and in the Zapstore feed, and the triage artifact never
+mentioned it — so nobody could tell the difference between "we decided to skip
+Nail" and "we never saw Nail".
+
+This closes that loop. For every project in the release digest, the triage
+artifact must either mention the project or record a skip. A project that
+appears in neither is reported as UNTRIAGED, and the script exits non-zero.
+
+It deliberately does not judge editorial merit. Skipping a release is fine;
+skipping it silently is not.
+
+Usage:
+  python3 scripts/check_triage_coverage.py --digest data/project_updates/release_digest_D.json \
+      --triage data/newsletter_workspace/triage_D.md [--also FILE ...] [--min-priority N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Names too generic to match on alone: a bare hit would mean nothing.
+GENERIC_TOKENS = {"nostr", "app", "client", "relay", "bot", "protocol", "core", "sdk", "web"}
+
+
+def mention_keys(project: str, repo: str) -> list[str]:
+    """Strings whose presence in the triage text counts as 'considered'.
+
+    Three shapes are needed, learned from real false positives:
+
+    * the display name as-is;
+    * the repo path and its slug, because triage often writes
+      `formstr-hq/nail` or pastes a release URL instead of a name;
+    * the display name with a parenthetical suffix stripped. Newsletter #37
+      discusses Marmot five times, but the digest name is
+      "Marmot Protocol (mdk)", so the full-name test alone reported it
+      untriaged.
+    """
+    project = project.strip()
+    keys = [project]
+    base = re.sub(r"\s*\([^)]*\)\s*$", "", project).strip()
+    if base and base != project:
+        keys.append(base)
+    slug = repo.split("/")[-1] if "/" in repo else repo
+    keys.append(repo.strip())
+    if slug and slug.lower() != project.lower():
+        keys.append(slug.strip())
+    out = []
+    for k in keys:
+        if len(k) < 3:
+            continue
+        if k.lower() in GENERIC_TOKENS:
+            continue
+        out.append(k)
+    return out
+
+
+def is_mentioned(text_lower: str, project: str, repo: str) -> bool:
+    for key in mention_keys(project, repo):
+        # Word-ish boundary so "ants" does not match "constants".
+        if re.search(rf"(?<![a-z0-9]){re.escape(key.lower())}(?![a-z0-9])", text_lower):
+            return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--digest", type=Path, required=True)
+    ap.add_argument("--triage", type=Path, required=True)
+    ap.add_argument(
+        "--also",
+        type=Path,
+        nargs="*",
+        default=[],
+        help="Additional artifacts that count as a record of consideration "
+        "(selection review, human overrides, the newsletter itself).",
+    )
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on any untriaged project. Without it, only flagged "
+        "projects (never-covered, first release, follow-up) are blocking.",
+    )
+    args = ap.parse_args()
+
+    if not args.digest.is_file():
+        print(f"error: digest not found: {args.digest}", file=sys.stderr)
+        return 2
+    digest = json.loads(args.digest.read_text(encoding="utf-8"))
+
+    texts = []
+    for path in [args.triage, *args.also]:
+        if path and path.is_file():
+            texts.append(path.read_text(encoding="utf-8"))
+        elif path == args.triage:
+            print(f"error: triage artifact not found: {args.triage}", file=sys.stderr)
+            return 2
+    blob = "\n".join(texts).lower()
+
+    untriaged_flagged: list[dict] = []
+    untriaged_plain: list[dict] = []
+    for e in digest.get("projects", []):
+        if is_mentioned(blob, e["project"], e["repo"]):
+            continue
+        flagged = e.get("never_covered") or e.get("possible_first_release") or e.get("recent_followup")
+        (untriaged_flagged if flagged else untriaged_plain).append(e)
+
+    total = len(digest.get("projects", []))
+    print(f"Release digest projects: {total}")
+    print(f"Untriaged (flagged as high-signal): {len(untriaged_flagged)}")
+    print(f"Untriaged (unflagged): {len(untriaged_plain)}")
+
+    def show(rows: list[dict], label: str) -> None:
+        if not rows:
+            return
+        print(f"\n{label}:")
+        for e in rows:
+            flags = []
+            if e.get("never_covered"):
+                flags.append("NEVER-COVERED")
+            if e.get("possible_first_release"):
+                flags.append("POSSIBLE-FIRST-RELEASE")
+            if e.get("recent_followup"):
+                flags.append(f"FOLLOW-UP(last {e.get('last_covered')})")
+            tags = ", ".join(r["tag"] for r in e.get("releases", []))
+            print(f"  - {e['project']} ({e['repo']}) {tags} {' '.join(flags)}")
+
+    show(untriaged_flagged, "UNTRIAGED HIGH-SIGNAL RELEASES (blocking)")
+    show(untriaged_plain, "Untriaged releases (informational)")
+
+    if untriaged_flagged:
+        print(
+            "\nFAIL: a release flagged never-covered, first-release, or follow-up was "
+            "never named in triage. Write it up or record an explicit skip reason. "
+            "This is the exact gap that lost Nail v0.1.0 from Newsletter #37.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.strict and untriaged_plain:
+        print("\nFAIL (--strict): unflagged releases are also untriaged.", file=sys.stderr)
+        return 1
+    print("\nPASS: every high-signal release was considered in triage.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_all.sh
+++ b/scripts/fetch_all.sh
@@ -252,6 +252,35 @@ echo "  Failed:    $FAILED"
 echo "  Skipped:   $SKIPPED"
 echo ""
 
+# Release digest — MANDATORY post-pass.
+#
+# Stage 3 reads the fetch summary, not the raw JSON. When the summary carried
+# only aggregates ("100 releases, 146 active repos"), a release could exist in
+# the data and in no downstream artifact. Newsletter #37 lost Nail v0.1.0 that
+# way: present in project_updates AND in the Zapstore feed, named nowhere.
+#
+# This names every release so a drop is a recorded editorial decision.
+echo "==========================================="
+echo "  Release digest (names every release)"
+echo "==========================================="
+LATEST_UPDATES=$(ls -t "$PROJECT_ROOT/data/project_updates"/updates_*.json 2>/dev/null | head -1)
+LATEST_ZAPSTORE=$(ls -t "$PROJECT_ROOT/data/zapstore_releases"/zapstore_*.json 2>/dev/null | head -1)
+DIGEST_MD="$PROJECT_ROOT/data/newsletter_workspace/release_digest_${NEWSLETTER_DATE:-$(date -u +%F)}.md"
+DIGEST_JSON="$PROJECT_ROOT/data/project_updates/release_digest_${NEWSLETTER_DATE:-$(date -u +%F)}.json"
+if [ -n "$LATEST_UPDATES" ] && command -v python3 >/dev/null 2>&1; then
+    if python3 "$SCRIPT_DIR/build_release_digest.py"         --updates "$LATEST_UPDATES"         ${LATEST_ZAPSTORE:+--zapstore "$LATEST_ZAPSTORE"}         --out "$DIGEST_MD"         --json-out "$DIGEST_JSON"; then
+        echo "  Digest: $DIGEST_MD"
+        echo "  Triage MUST record a write-up-or-skip decision for every project listed."
+    else
+        echo "  FAILED to build the release digest. Stage 3 cannot enumerate releases without it."
+        FAILED=$((FAILED + 1))
+    fi
+else
+    echo "  SKIPPED: no updates_*.json found or python3 missing — Stage 3 has no release enumeration."
+    SKIPPED=$((SKIPPED + 1))
+fi
+echo ""
+
 # Show data freshness
 echo "Data freshness:"
 for dir in project_updates nostr_nip_discussions nostr_recap shakespeare_apps nip34_repos zapstore_releases app_discovery heartbeats spec_updates; do

--- a/scripts/fetch_app_discovery.py
+++ b/scripts/fetch_app_discovery.py
@@ -9,6 +9,7 @@ import json
 import re
 import subprocess
 from datetime import date, datetime, time, timedelta, timezone
+import os
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
@@ -918,7 +919,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--today", help="UTC date override for reproducible runs (YYYY-MM-DD)")
     parser.add_argument("--projects-file", type=Path, default=root / "data/projects.yml")
     parser.add_argument("--output-dir", type=Path, default=root / "data/app_discovery")
-    parser.add_argument("--state-file", type=Path, default=root / "data/app_discovery/seen_repos.json")
+    # Persistent baseline must outlive the working tree. `data/app_discovery/`
+    # is gitignored, and every newsletter runs in a fresh worktree from
+    # origin/main, so this file never existed at run time: first_run fired on
+    # every run and nothing was deduped against a baseline. Newsletter #37's
+    # triage was handed 603 candidates including 561 owner-siblings, which is
+    # not reviewable, so real launches were buried rather than surfaced.
+    default_state_dir = Path(
+        os.environ.get("COMPASS_STATE_DIR", "/opt/data/compass-state")
+    ) / "app_discovery"
+    parser.add_argument(
+        "--state-file",
+        type=Path,
+        default=default_state_dir / "seen_repos.json",
+        help="Persistent discovery baseline. Defaults under COMPASS_STATE_DIR so it "
+        "survives the per-issue worktree.",
+    )
     parser.add_argument("--relay", action="append", dest="relays")
     parser.add_argument("--github-fixture", type=Path)
     parser.add_argument("--nip89-fixture", type=Path)

--- a/scripts/fetch_zapstore_releases.sh
+++ b/scripts/fetch_zapstore_releases.sh
@@ -91,7 +91,26 @@ START_DATE=$(calc_start_date "$SINCE_DAYS")
 END_DATE=$(get_today)
 OUTPUT_FILE="$OUTPUT_DIR/zapstore_${END_DATE}.json"
 SINCE_TIMESTAMP=$(calc_since_timestamp "$SINCE_DAYS")
-SEEN_FILE="$OUTPUT_DIR/publishers_seen.yml"
+# Persistent newness state must OUTLIVE the working tree.
+#
+# WHY: every newsletter runs in a fresh worktree created from origin/main, and
+# `data/zapstore_releases/` is gitignored (.gitignore line 67). The seen file
+# therefore never existed at run time, the fresh-install guard fired on every
+# single run, and 100% of Zapstore releases were flagged first_run/new_app=false.
+# Newsletter #37 discarded 622 Nostr-relevant releases this way, including
+# Nail's own `com.formstr.mail` listing and Mostro Mobile v1.4.0.
+#
+# COMPASS_STATE_DIR keeps the baseline on the host, outside any worktree. The
+# in-repo path stays as a read-only fallback so an existing worktree's state can
+# still be migrated by scripts/migrate_discovery_state.py.
+COMPASS_STATE_DIR="${COMPASS_STATE_DIR:-/opt/data/compass-state}"
+mkdir -p "$COMPASS_STATE_DIR/zapstore_releases" 2>/dev/null || true
+SEEN_FILE="${COMPASS_ZAPSTORE_SEEN_FILE:-$COMPASS_STATE_DIR/zapstore_releases/publishers_seen.yml}"
+LEGACY_SEEN_FILE="$OUTPUT_DIR/publishers_seen.yml"
+if [ ! -f "$SEEN_FILE" ] && [ -f "$LEGACY_SEEN_FILE" ]; then
+    echo "  Adopting legacy in-worktree seen file into $COMPASS_STATE_DIR" >&2
+    cp "$LEGACY_SEEN_FILE" "$SEEN_FILE" 2>/dev/null || true
+fi
 PROJECTS_FILE="$PROJECT_ROOT/data/projects.yml"
 
 # Relays
@@ -565,6 +584,7 @@ save_output() {
               updates: ([$releases[] | select(.update and .nostr_relevant)] | length),
               sanity_demoted: ([$releases[] | select(.sanity_demoted)] | length),
               first_run_baseline: ([$releases[] | select(.first_run)] | length),
+              baseline_suppressed_nostr_relevant: ([$releases[] | select(.first_run and .nostr_relevant)] | length),
               tracked_in_projects_yml: ([$releases[] | select(.tracked_project != null)] | length),
               candidates_for_projects_yml: ([$releases[] | select(.nostr_relevant and .tracked_project == null)] | length)
             },
@@ -573,6 +593,21 @@ save_output() {
        ' "$JOINED_FILE" > "$OUTPUT_FILE"
 
     echo "Output saved to: $OUTPUT_FILE" >&2
+
+    # Distinguish "nothing shipped" from "everything suppressed". Newsletter #37
+    # got a 0-release run and a 1313-release run hours apart, and both read as a
+    # quiet week because neither said which it was.
+    local total suppressed relevant
+    total=$(jq '.summary.total_releases' "$OUTPUT_FILE")
+    relevant=$(jq '.summary.nostr_relevant' "$OUTPUT_FILE")
+    suppressed=$(jq '.summary.baseline_suppressed_nostr_relevant' "$OUTPUT_FILE")
+    if [ "$total" = "0" ]; then
+        echo "ZAPSTORE_STATUS=empty-window (0 releases returned; relay degradation cannot be ruled out — do NOT claim a quiet week)" >&2
+    elif [ "$suppressed" -gt 0 ]; then
+        echo "ZAPSTORE_STATUS=baseline-suppressed ($suppressed of $relevant Nostr-relevant releases unclassified; new_app signal unavailable this run)" >&2
+    else
+        echo "ZAPSTORE_STATUS=classified ($relevant Nostr-relevant releases with usable new_app/update flags)" >&2
+    fi
 }
 
 print_summary() {
@@ -595,6 +630,12 @@ print_summary() {
         "Tracked in projects.yml: \(.summary.tracked_in_projects_yml)",
         "Candidates for projects.yml: \(.summary.candidates_for_projects_yml)",
         "",
+        (if .summary.baseline_suppressed_nostr_relevant > 0 then
+           "!! BASELINE SUPPRESSION: \(.summary.baseline_suppressed_nostr_relevant) Nostr-relevant releases were flagged first_run and carry NO new_app/update signal.",
+           "!! This run cannot support any 'new app' or 'quiet week' claim. Treat the release list as unclassified candidates.",
+           "!! If this fires every week the baseline is not persisting; run scripts/migrate_discovery_state.py and check COMPASS_STATE_DIR.",
+           ""
+         else empty end),
         "Nostr-relevant releases (top 20):",
         (.releases | map(select(.nostr_relevant))[:20] | .[]
           | "  - \(.app_name) v\(.version) (\(if .new_app then "NEW" elif .update then "update" else "?" end))\(if .tracked_project then " [tracked: \(.tracked_project)]" else "" end) [\(.nostr_match_reason)]")

--- a/scripts/migrate_discovery_state.py
+++ b/scripts/migrate_discovery_state.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Consolidate per-worktree discovery baselines into the shared state directory.
+
+WHY THIS EXISTS
+---------------
+`data/zapstore_releases/` and `data/app_discovery/` are gitignored, and every
+newsletter runs in a fresh worktree created from origin/main. The persistent
+baselines therefore never existed at run time:
+
+  * Zapstore's fresh-install guard fired on every run, flagging every release
+    `first_run: true` / `new_app: false`. Newsletter #37 discarded 622
+    Nostr-relevant releases this way, including Nail's own `com.formstr.mail`
+    listing and Mostro Mobile v1.4.0.
+  * App discovery's `first_run` fired on every run, so nothing was deduped
+    against a baseline and triage received 603 candidates (561 owner-siblings) —
+    a volume nobody reviews, which buries real launches.
+
+Whatever state each worktree did accumulate is partial and mutually divergent
+(five worktrees held five different baselines, from 6 to 778 repositories).
+Picking one would throw away the others' knowledge and re-flag old apps as new,
+so this takes the UNION: an app or repository seen by any worktree counts as
+seen. The union is the conservative direction — it can only suppress a stale
+"new" flag, never invent one.
+
+Idempotent. Safe to re-run. Never deletes a source file.
+
+Usage:
+  python3 scripts/migrate_discovery_state.py [--dry-run] [--state-dir DIR]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+WORKTREE_ROOTS = [
+    Path("/opt/data/compass"),
+    *sorted(Path("/opt/data/compass-worktrees").glob("*")),
+]
+
+SEEN_HEADER = [
+    "# Persistent state for zapstore newness detection.",
+    "# Format: { <pubkey>: [<app_id>, ...] }",
+    "# DO NOT delete this file. Fresh install suppresses new_app flags on next run.",
+]
+
+
+def load_zapstore_seen(path: Path) -> dict[str, list[str]]:
+    """Parse the seen file, which is JSON below a block of `#` comments."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    body = "\n".join(
+        line for line in raw.splitlines() if not re.match(r"^\s*#", line) and line.strip()
+    )
+    if not body:
+        return {}
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        print(f"  warning: {path} is malformed; skipping", file=sys.stderr)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        k: [a for a in v if isinstance(a, str)]
+        for k, v in data.items()
+        if isinstance(k, str) and isinstance(v, list)
+    }
+
+
+def merge_zapstore(sources: list[Path]) -> tuple[dict[str, list[str]], list[str]]:
+    merged: dict[str, set[str]] = {}
+    notes: list[str] = []
+    for path in sources:
+        seen = load_zapstore_seen(path)
+        if not seen:
+            continue
+        pairs = sum(len(v) for v in seen.values())
+        notes.append(f"{path}: {len(seen)} publishers / {pairs} app ids")
+        for pubkey, apps in seen.items():
+            merged.setdefault(pubkey, set()).update(apps)
+    return {k: sorted(v) for k, v in sorted(merged.items())}, notes
+
+
+def merge_app_discovery(sources: list[Path]) -> tuple[dict, list[str]]:
+    repositories: set[str] = set()
+    owner_siblings: set[str] = set()
+    protocol_events: dict[str, str] = {}
+    notes: list[str] = []
+    for path in sources:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        repos = [r for r in data.get("repositories", []) if isinstance(r, str)]
+        sibs = [r for r in data.get("owner_sibling_repositories", []) if isinstance(r, str)]
+        events = {
+            k: v
+            for k, v in (data.get("protocol_events") or {}).items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
+        notes.append(
+            f"{path}: {len(repos)} repositories / {len(sibs)} owner siblings / {len(events)} protocol events"
+        )
+        repositories.update(repos)
+        owner_siblings.update(sibs)
+        # Later worktrees win for a given address; any recorded id is enough to
+        # stop the event being re-reported as brand new.
+        protocol_events.update(events)
+    return (
+        {
+            "repositories": sorted(repositories),
+            "owner_sibling_repositories": sorted(owner_siblings),
+            "protocol_events": dict(sorted(protocol_events.items())),
+        },
+        notes,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path(os.environ.get("COMPASS_STATE_DIR", "/opt/data/compass-state")),
+    )
+    args = ap.parse_args()
+
+    zap_sources = [
+        r / "data/zapstore_releases/publishers_seen.yml"
+        for r in WORKTREE_ROOTS
+        if (r / "data/zapstore_releases/publishers_seen.yml").is_file()
+    ]
+    app_sources = [
+        r / "data/app_discovery/seen_repos.json"
+        for r in WORKTREE_ROOTS
+        if (r / "data/app_discovery/seen_repos.json").is_file()
+    ]
+
+    zap_target = args.state_dir / "zapstore_releases/publishers_seen.yml"
+    app_target = args.state_dir / "app_discovery/seen_repos.json"
+    # An already-migrated target is itself a source, so re-running never regresses.
+    if zap_target.is_file():
+        zap_sources.append(zap_target)
+    if app_target.is_file():
+        app_sources.append(app_target)
+
+    print(f"Zapstore seen files found: {len(zap_sources)}")
+    zap_merged, zap_notes = merge_zapstore(zap_sources)
+    for n in zap_notes:
+        print(f"  {n}")
+    zap_pairs = sum(len(v) for v in zap_merged.values())
+    print(f"  => union: {len(zap_merged)} publishers / {zap_pairs} app ids")
+
+    print(f"App discovery state files found: {len(app_sources)}")
+    app_merged, app_notes = merge_app_discovery(app_sources)
+    for n in app_notes:
+        print(f"  {n}")
+    print(
+        f"  => union: {len(app_merged['repositories'])} repositories / "
+        f"{len(app_merged['owner_sibling_repositories'])} owner siblings / "
+        f"{len(app_merged['protocol_events'])} protocol events"
+    )
+
+    if args.dry_run:
+        print("\n--dry-run: nothing written")
+        return 0
+
+    zap_target.parent.mkdir(parents=True, exist_ok=True)
+    app_target.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp = zap_target.with_suffix(".tmp")
+    tmp.write_text(
+        "\n".join(SEEN_HEADER) + "\n" + json.dumps(zap_merged, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(zap_target)
+
+    tmp = app_target.with_suffix(".tmp")
+    tmp.write_text(json.dumps(app_merged, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(app_target)
+
+    print(f"\nwrote {zap_target}")
+    print(f"wrote {app_target}")
+    if zap_pairs == 0:
+        print(
+            "WARNING: the merged Zapstore baseline is empty. The next run will "
+            "legitimately baseline as a fresh install.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_release_digest.py
+++ b/tests/test_build_release_digest.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/build_release_digest.py.
+
+The regression these guard is concrete: Nail shipped v0.1.0 inside Newsletter
+#37's window, was present in both the GitHub and Zapstore fetches, and appeared
+in no downstream artifact because the fetch summary reported only aggregates.
+"""
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "build_release_digest.py"
+spec = importlib.util.spec_from_file_location("build_release_digest", SCRIPT)
+assert spec and spec.loader
+digest_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(digest_mod)
+
+
+def updates(projects: dict) -> dict:
+    return {"period": {"start": "2026-08-18", "end": "2026-08-26"}, "projects": projects}
+
+
+def project(name, tag, published, releases=None, prs=0):
+    return {
+        "name": name,
+        "releases": releases or [{"tag": tag, "published_at": published, "url": f"https://x/{tag}", "body": "notes"}],
+        "merged_prs": [{"number": i} for i in range(prs)],
+    }
+
+
+class TestNormalizeRepo(unittest.TestCase):
+    def test_collapses_url_forms_to_one_key(self):
+        forms = [
+            "formstr-hq/nail",
+            "github.com/formstr-hq/nail",
+            "https://github.com/formstr-hq/nail",
+            "https://github.com/formstr-hq/nail.git",
+            "GitHub.com/Formstr-HQ/Nail",
+        ]
+        keys = {digest_mod.normalize_repo(f) for f in forms}
+        self.assertEqual(keys, {"formstr-hq/nail"})
+
+
+class TestCoverageMatching(unittest.TestCase):
+    def test_matches_coverage_history_keyed_by_repo_url(self):
+        # coverage_history.json keys are `github.com/owner/repo`; updates keys are
+        # `owner/repo`. Comparing project NAMES across the two matched nothing and
+        # flagged all 40 projects NEVER-COVERED on this script's first run.
+        coverage = {"projects": {"github.com/formstr-hq/nail": {"last_mention_date": "2026-08-19"}}}
+        covered = digest_mod.covered_repos(coverage)
+        self.assertIn("formstr-hq/nail", covered)
+        self.assertEqual(covered["formstr-hq/nail"], "2026-08-19")
+
+    def test_absent_coverage_means_no_flags_rather_than_all_flags(self):
+        d = digest_mod.build(updates({"a/b": project("A", "v1.0.0", "2026-08-20")}), None, None)
+        self.assertFalse(d["coverage_history_available"])
+        self.assertFalse(d["projects"][0]["never_covered"])
+
+
+class TestFirstReleaseDetection(unittest.TestCase):
+    def test_debut_style_tags_are_flagged(self):
+        for tag in ("v0.1.0", "0.1.0", "v0.0.1", "v0.2.0"):
+            self.assertTrue(digest_mod.looks_like_first_release(tag, 1), tag)
+
+    def test_mature_tags_are_not_flagged(self):
+        for tag in ("v1.12.0", "v3.1.50", "2.21.1"):
+            self.assertFalse(digest_mod.looks_like_first_release(tag, 1), tag)
+
+    def test_many_releases_in_window_is_not_a_debut(self):
+        self.assertFalse(digest_mod.looks_like_first_release("v0.1.0", 7))
+
+
+class TestNailRegression(unittest.TestCase):
+    """The exact shape that was lost from Newsletter #37."""
+
+    def setUp(self):
+        self.coverage = {
+            "projects": {
+                "github.com/formstr-hq/nail": {"last_mention_date": "2026-08-19"},
+                "github.com/vitorpamplona/amethyst": {"last_mention_date": "2026-08-19"},
+            }
+        }
+        self.zapstore = {
+            "releases": [
+                {"tracked_project": "Nail", "app_id": "com.formstr.mail", "version": "1.0"}
+            ]
+        }
+        self.updates = updates(
+            {
+                "formstr-hq/nail": project("Nail", "v0.1.0", "2026-08-23", prs=5),
+                "vitorpamplona/amethyst": project("Amethyst", "v1.12.9", "2026-08-20", prs=40),
+            }
+        )
+
+    def test_nail_ranks_first(self):
+        d = digest_mod.build(self.updates, self.zapstore, self.coverage)
+        self.assertEqual(d["projects"][0]["project"], "Nail")
+
+    def test_nail_carries_every_signal(self):
+        d = digest_mod.build(self.updates, self.zapstore, self.coverage)
+        nail = d["projects"][0]
+        self.assertTrue(nail["possible_first_release"])
+        self.assertTrue(nail["recent_followup"], "introduced in #36, released during #37")
+        self.assertEqual(nail["last_covered"], "2026-08-19")
+        self.assertEqual(nail["zapstore_listing"][0]["app_id"], "com.formstr.mail")
+
+    def test_release_is_named_in_the_markdown(self):
+        d = digest_mod.build(self.updates, self.zapstore, self.coverage)
+        md = digest_mod.render_markdown(d)
+        # The whole point: the tag and URL appear as text, not as a count.
+        self.assertIn("v0.1.0", md)
+        self.assertIn("formstr-hq/nail", md)
+        self.assertIn("FOLLOW-UP", md)
+
+    def test_every_project_gets_a_decision_slot(self):
+        d = digest_mod.build(self.updates, self.zapstore, self.coverage)
+        md = digest_mod.render_markdown(d)
+        self.assertEqual(md.count("Triage decision:"), len(d["projects"]))
+
+
+class TestFollowUpWindow(unittest.TestCase):
+    def test_stale_coverage_is_not_a_followup(self):
+        coverage = {"projects": {"github.com/a/b": {"last_mention_date": "2026-01-01"}}}
+        d = digest_mod.build(updates({"a/b": project("A", "v0.1.0", "2026-08-20")}), None, coverage)
+        self.assertFalse(d["projects"][0]["recent_followup"])
+
+    def test_release_before_coverage_is_not_a_followup(self):
+        # Negative gap: the release predates the mention, so the mention already
+        # covered it. Flagging it would send triage after old news.
+        coverage = {"projects": {"github.com/a/b": {"last_mention_date": "2026-08-26"}}}
+        d = digest_mod.build(updates({"a/b": project("A", "v0.1.0", "2026-08-20")}), None, coverage)
+        self.assertFalse(d["projects"][0]["recent_followup"])
+
+    def test_unparseable_dates_do_not_crash(self):
+        coverage = {"projects": {"github.com/a/b": {"last_mention_date": "not-a-date"}}}
+        d = digest_mod.build(updates({"a/b": project("A", "v0.1.0", "2026-08-20")}), None, coverage)
+        self.assertFalse(d["projects"][0]["recent_followup"])
+
+
+class TestOutputHygiene(unittest.TestCase):
+    def test_projects_without_releases_are_omitted(self):
+        d = digest_mod.build(
+            updates({"a/b": {"name": "Quiet", "releases": [], "merged_prs": []}}), None, None
+        )
+        self.assertEqual(d["release_bearing_projects"], 0)
+
+    def test_empty_release_notes_are_called_out(self):
+        u = updates(
+            {"a/b": {"name": "A", "releases": [{"tag": "v0.1.0", "published_at": "2026-08-20", "url": "", "body": ""}], "merged_prs": []}}
+        )
+        md = digest_mod.render_markdown(digest_mod.build(u, None, None))
+        self.assertIn("empty release notes", md)
+
+    def test_deterministic_across_runs(self):
+        u = updates(
+            {
+                "a/b": project("A", "v0.1.0", "2026-08-20"),
+                "c/d": project("C", "v2.0.0", "2026-08-21"),
+            }
+        )
+        first = digest_mod.render_markdown(digest_mod.build(u, None, None))
+        second = digest_mod.render_markdown(digest_mod.build(u, None, None))
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_triage_coverage.py
+++ b/tests/test_check_triage_coverage.py
@@ -1,0 +1,167 @@
+"""Tests for scripts/check_triage_coverage.py.
+
+The gate answers one question: was this *release* considered? Newsletter #37
+could not distinguish "we skipped Nail" from "we never saw Nail", because
+nothing checked the triage artifact against the discovered release set.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_triage_coverage.py"
+spec = importlib.util.spec_from_file_location("check_triage_coverage", SCRIPT)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+class TestMentionKeys(unittest.TestCase):
+    def test_includes_name_repo_and_slug(self):
+        keys = gate.mention_keys("Nail", "formstr-hq/nail")
+        self.assertIn("Nail", keys)
+        self.assertIn("formstr-hq/nail", keys)
+
+    def test_strips_a_parenthetical_suffix(self):
+        keys = gate.mention_keys("Marmot Protocol (mdk)", "marmot-protocol/mdk")
+        self.assertIn("Marmot Protocol", keys)
+
+    def test_drops_generic_tokens_that_would_match_anything(self):
+        # A bare "nostr" hit proves nothing in a Nostr newsletter.
+        self.assertNotIn("nostr", [k.lower() for k in gate.mention_keys("Nostr", "a/nostr")])
+
+    def test_word_boundaries_prevent_substring_matches(self):
+        # "ants" must not be satisfied by "constants".
+        self.assertFalse(gate.is_mentioned("many constants here", "ants", "dergigi/ants"))
+        self.assertTrue(gate.is_mentioned("ants v0.4.6 shipped", "ants", "dergigi/ants"))
+
+
+class TestReleaseLevelConsideration(unittest.TestCase):
+    """A project-family mention is not consideration of a specific release.
+
+    #37 discussed Marmot's same-account-enrollment spec PR five times but never
+    mentioned MDK v0.9.14/v0.9.15 shipping. Treating the family mention as
+    coverage would let those releases vanish again, which is the original bug.
+    """
+
+    def test_family_mention_does_not_satisfy_a_library_release(self):
+        prose = "An open Marmot experiment would replace the withdrawn draft."
+        self.assertFalse(
+            gate.is_mentioned(prose.lower(), "Marmot Protocol (mdk)", "marmot-protocol/mdk")
+        )
+
+    def test_naming_the_repo_does_satisfy_it(self):
+        prose = "Skipping marmot-protocol/mdk v0.9.15: library-only, no user-facing surface."
+        self.assertTrue(
+            gate.is_mentioned(prose.lower(), "Marmot Protocol (mdk)", "marmot-protocol/mdk")
+        )
+
+
+def run_gate(digest: dict, triage_text: str, extra: list[str] | None = None, strict=False):
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "digest.json").write_text(json.dumps(digest), encoding="utf-8")
+        (d / "triage.md").write_text(triage_text, encoding="utf-8")
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--digest",
+            str(d / "digest.json"),
+            "--triage",
+            str(d / "triage.md"),
+        ]
+        for i, text in enumerate(extra or []):
+            p = d / f"extra{i}.md"
+            p.write_text(text, encoding="utf-8")
+            cmd += ["--also", str(p)]
+        if strict:
+            cmd.append("--strict")
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        return proc.returncode, proc.stdout + proc.stderr
+
+
+def entry(project, repo, tag, **flags):
+    base = {
+        "project": project,
+        "repo": repo,
+        "releases": [{"tag": tag, "published_at": "2026-08-23", "url": "", "body_chars": 10}],
+        "never_covered": False,
+        "possible_first_release": False,
+        "recent_followup": False,
+        "last_covered": None,
+        "zapstore_listing": [],
+        "merged_prs": 0,
+        "release_count": 1,
+    }
+    base.update(flags)
+    return base
+
+
+class TestGateExitCodes(unittest.TestCase):
+    def test_fails_when_a_flagged_release_is_untriaged(self):
+        digest = {"projects": [entry("Nail", "formstr-hq/nail", "v0.1.0", possible_first_release=True)]}
+        code, out = run_gate(digest, "Considered Amethyst and Shopstr this week.")
+        self.assertEqual(code, 1)
+        self.assertIn("Nail", out)
+        self.assertIn("FAIL", out)
+
+    def test_passes_when_the_release_is_written_up(self):
+        digest = {"projects": [entry("Nail", "formstr-hq/nail", "v0.1.0", possible_first_release=True)]}
+        code, out = run_gate(digest, "Nail v0.1.0 ships the mail bridge; writing it up as a top story.")
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", out)
+
+    def test_passes_when_the_release_is_explicitly_skipped(self):
+        # Skipping is a legitimate editorial choice. Skipping silently is not.
+        digest = {"projects": [entry("Nail", "formstr-hq/nail", "v0.1.0", possible_first_release=True)]}
+        code, _ = run_gate(digest, "SKIP formstr-hq/nail v0.1.0 — no Nostr surface change since #36.")
+        self.assertEqual(code, 0)
+
+    def test_unflagged_releases_are_informational_by_default(self):
+        digest = {"projects": [entry("Astraea", "mouse484/astraea", "v5.35.62")]}
+        code, out = run_gate(digest, "nothing relevant")
+        self.assertEqual(code, 0)
+        self.assertIn("informational", out)
+
+    def test_strict_mode_blocks_on_unflagged_releases_too(self):
+        digest = {"projects": [entry("Astraea", "mouse484/astraea", "v5.35.62")]}
+        code, _ = run_gate(digest, "nothing relevant", strict=True)
+        self.assertEqual(code, 1)
+
+    def test_additional_artifacts_count_as_consideration(self):
+        digest = {"projects": [entry("Nail", "formstr-hq/nail", "v0.1.0", recent_followup=True)]}
+        code, _ = run_gate(digest, "triage says nothing", extra=["Selection: Nail deferred to #38."])
+        self.assertEqual(code, 0)
+
+    def test_missing_triage_artifact_is_an_error_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "digest.json").write_text(json.dumps({"projects": []}), encoding="utf-8")
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--digest",
+                    str(d / "digest.json"),
+                    "--triage",
+                    str(d / "absent.md"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(proc.returncode, 2)
+
+    def test_empty_digest_passes(self):
+        code, out = run_gate({"projects": []}, "quiet week")
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Newsletter #37 should have covered `formstr-hq/nail` v0.1.0 and did not. This traces the failure end to end and fixes the three defects that caused it. Every number below comes from #37's own committed artifacts.

## What happened to Nail

Nail shipped v0.1.0 on 2026-08-23, inside #37's window, and **two independent discovery sources caught it**:

- `data/project_updates/updates_2026-08-18_2026-08-26.json` held the release with a full changelog (tag, date, URL, and the seven PRs in it).
- `data/zapstore_releases/zapstore_2026-08-26.json` held its Zapstore listing as `com.formstr.mail` v1.0.

It was named in **none** of `fetch_2026-08-26.md`, `triage_2026-08-26.md`, `selection_review_2026-08-26.md`, or the published issue. Nail had been introduced in #36 the week before, so this was a follow-up release from a project readers had just met.

So the answer to "did discovery catch them, or did the architect drop them?" is: discovery caught them twice, and the aggregate fetch summary hid both.

## Defect 1 — discovery baselines never persisted

`data/zapstore_releases/` and `data/app_discovery/` are gitignored (`.gitignore` line 67), and every issue runs in a fresh worktree created from `origin/main`. The persistent seen files therefore never existed at run time. The two fetchers then failed in opposite directions, and both destroyed signal:

- **Zapstore** hit its fresh-install guard every run and flagged every release `first_run: true` / `new_app: false`. #37 discarded **622 Nostr-relevant releases** this way, including Nail's own listing, Mostro Mobile v1.4.0, Haven v0.1.12, Imwald v0.4.0 and deepmarks v2.2.13. `new_apps: 0, updates: 0` reads as a quiet week.
- **App discovery** hit `first_run` every run, so nothing deduped against a baseline. The #37 fetch produced **603 candidates including 561 owner-siblings**; the very next run, which could read the state file its predecessor had just written, produced **14 candidates including 10 owner-siblings**. Same window, 43× less noise. 561 rows is not reviewable, so real launches were buried rather than surfaced.

Five worktrees held five divergent baselines, from 6 to 778 repositories, and the clean checkout the automation uses held neither file.

Both now resolve under `COMPASS_STATE_DIR` (default `/opt/data/compass-state/`), outside any worktree. `scripts/migrate_discovery_state.py` consolidates by **union** — an app seen by any worktree counts as seen — because picking one baseline would discard the others' knowledge and re-flag old apps as new. Union can only suppress a stale "new" flag, never invent one. It recovered 164 publishers / 1798 app IDs against 60 / 479 in the best single worktree, and 924 repositories. Idempotent.

## Defect 2 — the fetch summary never named a release

Stage 3 reads the Stage 2 summary, not the raw JSON. `fetch_2026-08-26.md` said "100 releases, 905 merged PRs, 146 active repos of 713 fetched" and named nothing, so any release not manually dug out of the JSON was invisible.

`scripts/build_release_digest.py` names every release and ranks by signal:

- **FOLLOW-UP** — covered within 21 days and now shipping. The reader already met the project and the release is the payoff. This is the Nail shape.
- **POSSIBLE-FIRST-RELEASE** — a `0.x` tag with few releases in window. A debut previously ranked identically to a patch bump.
- **NEVER-COVERED** — no prior mention in any published issue.

Against #37's real data it puts **Nail at rank 1 of 40** with all three signals plus its Zapstore cross-reference. `fetch_all.sh` builds it as a required post-pass; a failure increments `FAILED`.

## Defect 3 — nothing checked that a release was considered

`scripts/check_triage_coverage.py` fails when a flagged release is named in no artifact. Run against #37 it reports **23 untriaged high-signal releases**, Nail first, alongside Zeus v13.2.0, Marmot MDK v0.9.15, Chama v6.0.1, Buzz desktop-v0.5.20 and diVine 1.0.22.

Skipping a release stays a legitimate editorial choice; skipping it *silently* does not. Naming the project or repo with a reason passes the gate.

A project-family mention deliberately does not satisfy a specific release: #37 discussed Marmot's same-account-enrollment spec PR five times and never mentioned MDK v0.9.14/v0.9.15 shipping, so the gate still flags MDK. That distinction is tested.

## Zapstore status is now legible

`ZAPSTORE_STATUS` distinguishes `empty-window`, `baseline-suppressed` and `classified`. #37 had a 0-release run and a 1313-release run hours apart and both read as a quiet week.

## Autonomy

Wired into the Tuesday triage prompt (`compass_tuesday_prepare.py`) and the Wednesday refresh template so the gate holds without a human. `CLAUDE.md` gains a CRITICAL section for each defect, and its previous claim that the script "persists `seen_repos.json` so the weekly query does not repeat its baseline forever" is corrected — that was true of the code and false in deployment.

## Verification

- 110 Python tests pass, including 30 new ones across the digest and the gate.
- Digest and gate exercised against #37's committed artifacts, not fixtures.
- `bash -n` clean on both modified shell scripts; both dispatchers dry-run.
- Migration re-run is idempotent.
- Two bugs in my own code were caught by testing against real data and are fixed: coverage history is keyed by normalized repo URL rather than project name (every project was flagged NEVER-COVERED on the first run), and a `$SEEN_FILE` reference inside a single-quoted jq program would not have expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)