### PR TITLE
Review Zapstore per app, and surface Zapstore-only releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,10 @@ python3 scripts/check_triage_coverage.py \
   --also data/newsletter_workspace/selection_review_<date>.md
 ```
 
+**Review Zapstore per app, not per release.** The fetcher emits an `apps` rollup and `distinct_nostr_relevant_apps` alongside the raw release list. #37's summary said "622 Nostr-relevant releases", but 476 of those were PosterChan CI builds and 60 were Boris: the real figure was **48 distinct apps, 19 of them tracked**. A reviewer handed 622 skims; 48 with latest versions is a list somebody reads. Zapstore publisher identity is not a relevance signal either — one publisher mirrors 404 unrelated apps (prayer apps, money managers) with a single Nostr-relevant row, so provenance cannot be used the way the GitHub owner sweep uses it.
+
+The digest also carries a **Zapstore releases with no GitHub release in window** section. A tracked project can ship to Zapstore without cutting a GitHub release, and six did inside #37's window — Nostria 4.1.72, Flotilla 1.9.1, Imwald Android 0.4.0, Deepmarks 2.2.13, Surveil 0.1.8 and Treasures 2.10.1 — all invisible to a GitHub-only sweep. Sort Zapstore rows on `release_created_at`; `published_at` is null on every row, so sorting on it returns an arbitrary "latest" version.
+
 The digest ranks by signal rather than alphabetically. Three flags lead:
 
 - **FOLLOW-UP** — the project was covered within the last 21 days and has now shipped a release. The reader already met it and the release is the payoff. This is the Nail shape, and it ranks first.

--- a/scripts/build_release_digest.py
+++ b/scripts/build_release_digest.py
@@ -153,14 +153,55 @@ def rank(entry: dict) -> tuple[int, str]:
     return (score, entry["project"].lower())
 
 
+def zapstore_apps(zapstore: dict | None) -> list[dict]:
+    """Per-app view of the Zapstore feed.
+
+    Prefers the `apps` rollup the fetcher emits; falls back to computing it from
+    `releases` so older artifacts still work. Per-release counts are unusable for
+    review: #37 reported 622 Nostr-relevant releases, of which 476 were
+    PosterChan CI builds and 60 were Boris. The real figure was 48 apps.
+    """
+    if not zapstore:
+        return []
+    apps = zapstore.get("apps")
+    if isinstance(apps, list) and apps:
+        return apps
+    grouped: dict[str, list[dict]] = {}
+    for rel in zapstore.get("releases", []):
+        if rel.get("nostr_relevant") and rel.get("app_id"):
+            grouped.setdefault(rel["app_id"], []).append(rel)
+    out = []
+    for app_id, rows in grouped.items():
+        # release_created_at, not published_at: published_at is null on every
+        # Zapstore row, so sorting on it yields arbitrary "latest" versions.
+        rows.sort(key=lambda r: r.get("release_created_at") or 0)
+        tracked = next((r.get("tracked_project") for r in rows if r.get("tracked_project")), None)
+        out.append(
+            {
+                "app_id": app_id,
+                "app_name": rows[0].get("app_name"),
+                "tracked_project": tracked,
+                "release_count": len(rows),
+                "latest_version": rows[-1].get("version"),
+                "latest_at": rows[-1].get("release_created_at_iso"),
+                "new_app": any(r.get("new_app") for r in rows),
+                "baseline_suppressed": all(r.get("first_run") for r in rows),
+            }
+        )
+    out.sort(key=lambda a: (0 if a.get("tracked_project") else 1, -a.get("release_count", 0)))
+    return out
+
+
 def build(updates: dict, zapstore: dict | None, coverage: dict | None) -> dict:
     covered = covered_repos(coverage)
+    apps = zapstore_apps(zapstore)
     zap_by_project: dict[str, list[dict]] = {}
-    if zapstore:
-        for rel in zapstore.get("releases", []):
-            tp = rel.get("tracked_project")
-            if isinstance(tp, str):
-                zap_by_project.setdefault(tp.strip().lower(), []).append(rel)
+    for app in apps:
+        tp = app.get("tracked_project")
+        if isinstance(tp, str):
+            zap_by_project.setdefault(tp.strip().lower(), []).append(
+                {"app_id": app.get("app_id"), "version": app.get("latest_version")}
+            )
 
     entries: list[dict] = []
     for repo_key, proj in (updates.get("projects") or {}).items():
@@ -194,9 +235,7 @@ def build(updates: dict, zapstore: dict | None, coverage: dict | None) -> dict:
             "last_covered": covered.get(normalize_repo(repo_key)) or None,
             "recent_followup": False,  # filled in below, needs the window end date
             "possible_first_release": looks_like_first_release(rels[0]["tag"], len(rels)),
-            "zapstore_listing": [
-                {"app_id": z.get("app_id"), "version": z.get("version")} for z in zap[:3]
-            ],
+            "zapstore_listing": zap[:3],
         }
         # A project covered within FOLLOWUP_WINDOW_DAYS that now ships a release
         # is the highest-value miss: the reader already met it, and the release
@@ -210,11 +249,23 @@ def build(updates: dict, zapstore: dict | None, coverage: dict | None) -> dict:
         entries.append(entry)
 
     entries.sort(key=rank)
+    # A tracked project can ship on Zapstore without cutting a GitHub release.
+    # Six did inside #37's window (Imwald 0.4.0, Nostria 4.1.72, Flotilla 1.9.1,
+    # Deepmarks 2.2.13, Surveil 0.1.8, Treasures 2.10.1) and a GitHub-only sweep
+    # could not see any of them.
+    named = {e["project"].strip().lower() for e in entries}
+    zapstore_only = [
+        a for a in apps if (a.get("tracked_project") or "").strip().lower() not in named
+    ]
+    zapstore_only.sort(key=lambda a: (0 if a.get("tracked_project") else 1, a.get("app_id") or ""))
+
     return {
         "period": updates.get("period"),
         "release_bearing_projects": len(entries),
         "total_releases": sum(e["release_count"] for e in entries),
         "coverage_history_available": bool(covered),
+        "zapstore_apps": len(apps),
+        "zapstore_only": zapstore_only,
         "projects": entries,
     }
 
@@ -272,6 +323,33 @@ def render_markdown(digest: dict) -> str:
         if e["merged_prs"]:
             out.append(f"  - {e['merged_prs']} merged PRs in window")
         out.append("  - Triage decision: __________ (write up / skip + reason)")
+
+    zo = digest.get("zapstore_only") or []
+    shown = [a for a in zo if a.get("tracked_project") or a.get("new_app")]
+    if shown:
+        tracked_n = sum(1 for a in shown if a.get("tracked_project"))
+        out.append("")
+        out.append("## Zapstore releases with no GitHub release in window")
+        out.append("")
+        out.append(
+            f"{len(shown)} of {digest.get('zapstore_apps', 0)} Zapstore apps shipped without a "
+            f"matching GitHub release, {tracked_n} of them tracked projects. A GitHub-only sweep "
+            "cannot see these."
+        )
+        out.append("")
+        for a in shown:
+            label = a.get("app_name") or a.get("app_id")
+            line = f"- **{label}** `{a.get('app_id')}` {a.get('latest_version') or '?'}"
+            if a.get("latest_at"):
+                line += f" ({str(a['latest_at'])[:10]})"
+            if a.get("tracked_project"):
+                line += f" — tracked: {a['tracked_project']}"
+            if a.get("new_app"):
+                line += " — **NEW-APP**"
+            if a.get("baseline_suppressed"):
+                line += " — unclassified (baseline suppressed this run)"
+            out.append(line)
+            out.append("  - Triage decision: __________ (write up / skip + reason)")
     out.append("")
     return "\n".join(out)
 

--- a/scripts/fetch_zapstore_releases.sh
+++ b/scripts/fetch_zapstore_releases.sh
@@ -585,10 +585,32 @@ save_output() {
               sanity_demoted: ([$releases[] | select(.sanity_demoted)] | length),
               first_run_baseline: ([$releases[] | select(.first_run)] | length),
               baseline_suppressed_nostr_relevant: ([$releases[] | select(.first_run and .nostr_relevant)] | length),
+              distinct_nostr_relevant_apps: ([$releases[] | select(.nostr_relevant) | .app_id] | unique | length),
               tracked_in_projects_yml: ([$releases[] | select(.tracked_project != null)] | length),
               candidates_for_projects_yml: ([$releases[] | select(.nostr_relevant and .tracked_project == null)] | length)
             },
-            releases: $releases
+            releases: $releases,
+            # App-level rollup. Per-release counts overstate reviewable signal by
+            # an order of magnitude: #37 reported 622 Nostr-relevant releases, but
+            # 476 came from PosterChan CI builds and 60 from Boris, so the real
+            # figure was 48 distinct apps. A reviewer seeing 622 skims; 48 with
+            # latest versions is a list somebody actually reads.
+            apps: (
+              [$releases[] | select(.nostr_relevant)]
+              | group_by(.app_id)
+              | map(sort_by(.release_created_at // 0) as $s | {
+                  app_id: $s[0].app_id,
+                  app_name: $s[0].app_name,
+                  app_repository: ($s | map(.app_repository) | map(select(. != null and . != "")) | first),
+                  tracked_project: ($s | map(.tracked_project) | map(select(. != null)) | first),
+                  release_count: ($s | length),
+                  latest_version: ($s | last | .version),
+                  latest_at: ($s | last | .release_created_at_iso),
+                  new_app: ($s | any(.new_app == true)),
+                  baseline_suppressed: ($s | all(.first_run == true))
+                })
+              | sort_by([(if .tracked_project then 0 else 1 end), -.release_count])
+            )
           }
        ' "$JOINED_FILE" > "$OUTPUT_FILE"
 
@@ -636,9 +658,15 @@ print_summary() {
            "!! If this fires every week the baseline is not persisting; run scripts/migrate_discovery_state.py and check COMPASS_STATE_DIR.",
            ""
          else empty end),
-        "Nostr-relevant releases (top 20):",
-        (.releases | map(select(.nostr_relevant))[:20] | .[]
-          | "  - \(.app_name) v\(.version) (\(if .new_app then "NEW" elif .update then "update" else "?" end))\(if .tracked_project then " [tracked: \(.tracked_project)]" else "" end) [\(.nostr_match_reason)]")
+        "Distinct Nostr-relevant apps: \(.apps | length)  <-- review this, not the release count",
+        "  tracked in projects.yml: \(.apps | map(select(.tracked_project)) | length)",
+        "",
+        "Nostr-relevant apps (tracked first, latest version):",
+        (.apps[:40] | .[]
+          | "  - \(.app_name // .app_id) \(.latest_version // "?") (\((.latest_at // "?")[0:10]))"
+            + (if .release_count > 1 then " [\(.release_count) releases in window]" else "" end)
+            + (if .tracked_project then " [tracked: \(.tracked_project)]" else "" end)
+            + (if .new_app then " NEW-APP" elif .baseline_suppressed then " unclassified(baseline)" else "" end))
     ' "$OUTPUT_FILE" >&2
     echo "" >&2
 }

--- a/tests/test_build_release_digest.py
+++ b/tests/test_build_release_digest.py
@@ -81,9 +81,18 @@ class TestNailRegression(unittest.TestCase):
                 "github.com/vitorpamplona/amethyst": {"last_mention_date": "2026-08-19"},
             }
         }
+        # A real row matching a tracked project carries nostr_relevant via the
+        # tracked-project-override reason; the rollup requires it.
         self.zapstore = {
             "releases": [
-                {"tracked_project": "Nail", "app_id": "com.formstr.mail", "version": "1.0"}
+                {
+                    "tracked_project": "Nail",
+                    "app_id": "com.formstr.mail",
+                    "version": "1.0",
+                    "nostr_relevant": True,
+                    "release_created_at": 1787700000,
+                    "release_created_at_iso": "2026-08-24T00:00:00Z",
+                }
             ]
         }
         self.updates = updates(
@@ -117,6 +126,60 @@ class TestNailRegression(unittest.TestCase):
         d = digest_mod.build(self.updates, self.zapstore, self.coverage)
         md = digest_mod.render_markdown(d)
         self.assertEqual(md.count("Triage decision:"), len(d["projects"]))
+
+
+class TestZapstoreRollup(unittest.TestCase):
+    def test_prefers_the_fetcher_apps_rollup(self):
+        z = {
+            "apps": [{"app_id": "a.b", "app_name": "A", "tracked_project": "A", "latest_version": "9.9"}],
+            "releases": [{"app_id": "ignored", "nostr_relevant": True}],
+        }
+        apps = digest_mod.zapstore_apps(z)
+        self.assertEqual([a["app_id"] for a in apps], ["a.b"])
+
+    def test_falls_back_to_grouping_releases(self):
+        z = {
+            "releases": [
+                {"app_id": "a.b", "app_name": "A", "version": "1.0", "nostr_relevant": True, "release_created_at": 1},
+                {"app_id": "a.b", "app_name": "A", "version": "1.1", "nostr_relevant": True, "release_created_at": 2},
+            ]
+        }
+        apps = digest_mod.zapstore_apps(z)
+        self.assertEqual(len(apps), 1)
+        self.assertEqual(apps[0]["release_count"], 2)
+        # Sorted on release_created_at, because published_at is null on every row.
+        self.assertEqual(apps[0]["latest_version"], "1.1")
+
+    def test_excludes_apps_that_are_not_nostr_relevant(self):
+        z = {"releases": [{"app_id": "x.y", "nostr_relevant": False, "release_created_at": 1}]}
+        self.assertEqual(digest_mod.zapstore_apps(z), [])
+
+    def test_zapstore_only_tracked_project_is_surfaced(self):
+        # Imwald shipped 0.4.0 on Zapstore inside #37's window with no GitHub
+        # release. A GitHub-only digest could not see it.
+        z = {
+            "apps": [
+                {
+                    "app_id": "eu.imwald.android",
+                    "app_name": "Imwald Android",
+                    "tracked_project": "Imwald Android",
+                    "latest_version": "0.4.0",
+                    "latest_at": "2026-08-25T00:00:00Z",
+                    "release_count": 4,
+                }
+            ]
+        }
+        d = digest_mod.build(updates({"a/b": project("Other", "v1.0.0", "2026-08-20")}), z, None)
+        self.assertEqual(len(d["zapstore_only"]), 1)
+        md = digest_mod.render_markdown(d)
+        self.assertIn("Imwald Android", md)
+        self.assertIn("no GitHub release in window", md)
+
+    def test_zapstore_app_matching_a_github_release_is_not_listed_twice(self):
+        z = {"apps": [{"app_id": "a.b", "app_name": "A", "tracked_project": "A", "latest_version": "1.0"}]}
+        d = digest_mod.build(updates({"a/b": project("A", "v1.0.0", "2026-08-20")}), z, None)
+        self.assertEqual(d["zapstore_only"], [])
+        self.assertEqual(d["projects"][0]["zapstore_listing"][0]["app_id"], "a.b")
 
 
 class TestFollowUpWindow(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #153. That PR fixed releases being *lost*; this one addresses whether discovery *catches* enough. Both gaps below are measured against Newsletter #37's committed artifacts.

## Per-release counts overstate signal by an order of magnitude

#37's fetch summary reported "622 Nostr-relevant releases". Broken down by app:

| app | releases in window |
|---|---|
| PosterChan (`place.poster.app`) | 476 |
| Boris (`org.dergigi.boris`) | 60 |
| Armada | 12 |
| everything else | ~74 |

The real figure is **48 distinct apps, 19 of them tracked projects**. Two publishers accounted for 86% of the rows. A reviewer handed 622 skims; 48 with latest versions is a list somebody reads — and that skim is part of why #37 covered none of them.

The fetcher now emits an `apps` rollup (latest version per app, tracked projects first, release count, `new_app`, `baseline_suppressed`) plus `distinct_nostr_relevant_apps`, and `print_summary` reports apps instead of a truncated release list.

## Zapstore-only releases were invisible

A tracked project can ship to Zapstore without cutting a GitHub release. Six did inside #37's window and a GitHub-only sweep could see none of them:

- Nostria 4.1.72, Flotilla 1.9.1, Imwald Android 0.4.0, Deepmarks 2.2.13, Surveil 0.1.8, Treasures 2.10.1

The digest now carries a **Zapstore releases with no GitHub release in window** section with the same write-up-or-skip obligation, and it propagates the `baseline_suppressed` caveat so a reviewer knows the newness flags were unavailable on that run.

## A negative result worth recording

I tested whether a Zapstore **publisher pubkey** matching a known Nostr identity in `npubs.yml` could serve as a relevance signal, mirroring the GitHub owner sweep that found Nail. It cannot. 406 excluded apps matched a known publisher, but they were prayer apps, money managers and lyrics apps: one publisher (`78ce6faa…`) mirrors **404 distinct apps with a single Nostr-relevant row**. Zapstore is a general Android store whose indexer republishes the catalogue, so owner provenance does not transfer from GitHub.

I measured this before building anything, so no code rests on it. `CLAUDE.md` records it so nobody re-derives the same wrong idea.

## Also fixed

`published_at` is null on every Zapstore row; the correct field is `release_created_at`. Sorting on `published_at` returned an arbitrary "latest" version — PosterChan reported 1.0.1185 when the window reached 1.0.1714.

## Verification

- 115 tests pass, 5 new covering the rollup, the fallback path, the `nostr_relevant` requirement, Zapstore-only surfacing, and no double-listing when GitHub and Zapstore agree.
- Digest and rollup exercised against #37's real artifacts.
- `bash -n` clean. An apostrophe in a jq comment inside a single-quoted shell string broke the script during development and is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)