### PR TITLE
Add Newsletter #37 publication log

### DIFF
--- a/data/newsletter_workspace/publish_log_2026-08-26.md
+++ b/data/newsletter_workspace/publish_log_2026-08-26.md
@@ -18,9 +18,9 @@ Deployed page: https://nostrcompass.org/en/newsletters/2026-08-26-newsletter/
 
 ## Nostr publication
 
-- **Replaced after first publication.** The addressable event was re-signed and rebroadcast at 2026-08-27T07:29:30Z on the same `d` tag, so the event id below differs from the one recorded at first publication. `published_at` is preserved.
+- **Replaced after first publication.** The addressable event was re-signed and rebroadcast at 2026-08-27T08:10:03Z on the same `d` tag, so the event id below differs from the one recorded at first publication. `published_at` is preserved.
 
-- Kind 30023 event ID: `aafccc73d40aa9c1cee8839cbc6459a28f999ea3ba99f261f665ba1bfc7586df`
+- Kind 30023 event ID: `e0511f5695af97a5fdc066b5377fd0a3b155383f0c24bee451b1a22ceefeaafc`
   - `d` tag `newsletter-37`, `published_at` `1787763698` (2026-08-26T17:01:38Z)
   - Banner image https://image.nostr.build/fbf98ad0d8f84fd6b60fd920c0364df3549ea7a2e0ca16a159202a2cd87b8baf.png
 - Kind 1 event ID: `f595842931c116e3b07e9fe50d249b02996908235f86df2c49b1fc357d766837`


### PR DESCRIPTION
Publication evidence for Nostr Compass #37, generated by the publish pipeline's log stage from `publish/out/37/receipts.json`, `publish/published.json`, the GitHub deploy run, and a fresh exact-id relay readback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)