### PR TITLE
Enforce documented style rules and verify recap signatures

### DIFF
--- a/scripts/check_newsletter_style.py
+++ b/scripts/check_newsletter_style.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Block known Compass filler phrases before editorial review."""
+"""Block known Compass filler phrases and opaque link anchors before editorial review."""
 
 from __future__ import annotations
 
 import argparse
+import re
 from collections import namedtuple
 from pathlib import Path
 
-Finding = namedtuple("Finding", "line phrase")
+Finding = namedtuple("Finding", "line kind detail")
 BANNED_PHRASES = (
     "join Shipping This Week with",
     "developer-signed release expands the browser",
@@ -18,6 +19,25 @@ BANNED_PHRASES = (
     "discovered through",
     "surfaced on",
     "made the final scope cut",
+    "nothing from it appears",
+    "in compass at all",
+    "no nostr surface, so nothing",
+    "did not qualify",
+    "was not included",
+    "outside the reporting window",
+)
+LINK_ANCHOR_ID_RE = re.compile(
+    r"\[(?:GHSA-[a-z0-9-]+|CVE-\d{4}-\d+)\]\(",
+    re.IGNORECASE,
+)
+BARE_GHSA_PROSE_RE = re.compile(
+    r"(?<![\[/\w-])(GHSA-[a-z0-9-]{4,})(?![\]/\w-])",
+    re.IGNORECASE,
+)
+ORDINAL_GHSA_RE = re.compile(
+    r"\b(?:one|two|three|four|five|six|seven|eight|nine|ten|first|second|third|"
+    r"highest|lowest|most serious|several)\s*,\s*GHSA-",
+    re.IGNORECASE,
 )
 
 
@@ -27,7 +47,17 @@ def review(markdown: str) -> list[Finding]:
         lower = line.lower()
         for phrase in BANNED_PHRASES:
             if phrase.lower() in lower:
-                findings.append(Finding(number, phrase))
+                findings.append(Finding(number, "phrase", phrase))
+        for match in LINK_ANCHOR_ID_RE.finditer(line):
+            findings.append(
+                Finding(number, "link_anchor", match.group(0).strip("["))
+            )
+        for match in ORDINAL_GHSA_RE.finditer(line):
+            findings.append(Finding(number, "bare_ghsa", match.group(0)))
+        for match in BARE_GHSA_PROSE_RE.finditer(line):
+            if LINK_ANCHOR_ID_RE.search(line):
+                continue
+            findings.append(Finding(number, "bare_ghsa", match.group(1)))
     return findings
 
 
@@ -37,10 +67,21 @@ def main() -> int:
     args = parser.parse_args()
     findings = review(args.newsletter.read_text())
     if not findings:
-        print("PASS: no banned Compass filler phrases")
+        print("PASS: no banned Compass filler phrases or opaque link anchors")
         return 0
     for finding in findings:
-        print(f"FAIL line {finding.line}: banned phrase: {finding.phrase}")
+        if finding.kind == "phrase":
+            print(f"FAIL line {finding.line}: banned phrase: {finding.detail}")
+        elif finding.kind == "link_anchor":
+            print(
+                f"FAIL line {finding.line}: opaque link anchor {finding.detail}; "
+                "use descriptive text (see CLAUDE.md Link anchor text)"
+            )
+        else:
+            print(
+                f"FAIL line {finding.line}: bare advisory id in prose: {finding.detail}; "
+                "link with descriptive anchor text instead"
+            )
     return 1
 
 

--- a/scripts/fetch_nostr_recap.sh
+++ b/scripts/fetch_nostr_recap.sh
@@ -77,38 +77,43 @@ done
 
 RESULTS_FILE="$NOSTR_TEMP_DIR/recap_results.json"
 echo "[]" > "$RESULTS_FILE"
+REJECTED_SIGNATURES=0
+
+fetch_verified_kind() {
+    local kind="$1"
+    local fetched="$NOSTR_TEMP_DIR/kind_${kind}.jsonl"
+    nak req \
+        --kind "$kind" \
+        --author "$RECAP_PUBKEY" \
+        --since "$SINCE_TS" \
+        $RELAY_ARGS 2>/dev/null > "$fetched" || true
+
+    while IFS= read -r event; do
+        [ -n "$event" ] || continue
+        if printf '%s\n' "$event" | nak verify >/dev/null 2>&1; then
+            printf '%s\n' "$event" | jq -c '
+                if .kind == 1 then
+                    {id, pubkey, kind, created_at,
+                     tags: [.tags[] | select(.[0] == "t" or .[0] == "subject" or .[0] == "title" or .[0] == "p")],
+                     content}
+                else
+                    {id, pubkey, kind, created_at,
+                     tags: [.tags[] | select(.[0] == "t" or .[0] == "title" or .[0] == "summary" or .[0] == "d")],
+                     content}
+                end' >> "$NOSTR_TEMP_DIR/raw_results.jsonl"
+        else
+            REJECTED_SIGNATURES=$((REJECTED_SIGNATURES + 1))
+        fi
+    done < "$fetched"
+}
 
 # Strategy 1: Fetch all kind 1 notes from the Nostr Recap author in the time window
 echo "Fetching posts from Nostr Recap author ($RECAP_PUBKEY)..."
-nak req \
-    --kind 1 \
-    --author "$RECAP_PUBKEY" \
-    --since "$SINCE_TS" \
-    $RELAY_ARGS 2>/dev/null | \
-jq -c '{
-    id: .id,
-    pubkey: .pubkey,
-    kind: .kind,
-    created_at: .created_at,
-    tags: [.tags[] | select(.[0] == "t" or .[0] == "subject" or .[0] == "title" or .[0] == "p")],
-    content: .content
-}' >> "$NOSTR_TEMP_DIR/raw_results.jsonl" 2>/dev/null || true
+fetch_verified_kind 1
 
 # Strategy 2: Also fetch long-form articles (kind 30023) from the same author
 echo "Fetching long-form articles from Nostr Recap author..."
-nak req \
-    --kind 30023 \
-    --author "$RECAP_PUBKEY" \
-    --since "$SINCE_TS" \
-    $RELAY_ARGS 2>/dev/null | \
-jq -c '{
-    id: .id,
-    pubkey: .pubkey,
-    kind: .kind,
-    created_at: .created_at,
-    tags: [.tags[] | select(.[0] == "t" or .[0] == "title" or .[0] == "summary" or .[0] == "d")],
-    content: .content
-}' >> "$NOSTR_TEMP_DIR/raw_results.jsonl" 2>/dev/null || true
+fetch_verified_kind 30023
 
 # Deduplicate by event ID
 if [ -f "$NOSTR_TEMP_DIR/raw_results.jsonl" ] && [ -s "$NOSTR_TEMP_DIR/raw_results.jsonl" ]; then
@@ -133,6 +138,7 @@ jq --arg start "$START_DATE" \
    --arg end "$END_DATE" \
    --arg days "$SINCE_DAYS" \
    --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   --arg rejected "$REJECTED_SIGNATURES" \
    '{
     generated_at: $generated,
     period: {
@@ -141,7 +147,8 @@ jq --arg start "$START_DATE" \
         days: ($days | tonumber)
     },
     summary: {
-        total_events: length
+        total_events: length,
+        rejected_invalid_signatures: ($rejected | tonumber)
     },
     events: .
 }' "$RESULTS_FILE" > "$OUTPUT_FILE"
@@ -149,3 +156,4 @@ jq --arg start "$START_DATE" \
 echo ""
 echo "Output saved to: $OUTPUT_FILE"
 echo "Events found: $(jq '.summary.total_events' "$OUTPUT_FILE")"
+echo "Invalid signatures rejected: $(jq '.summary.rejected_invalid_signatures' "$OUTPUT_FILE")"

--- a/tests/test_check_newsletter_style.py
+++ b/tests/test_check_newsletter_style.py
@@ -16,15 +16,15 @@ def load_module():
 
 
 class NewsletterStyleTests(unittest.TestCase):
-    def test_flags_banned_join_section_phrase(self):
+    def test_flags_banned_join_section_detail(self):
         checker = load_module()
         findings = checker.review("Mafrend and Hanami join Shipping This Week with Android releases.")
-        self.assertEqual("join Shipping This Week with", findings[0].phrase)
+        self.assertEqual("join Shipping This Week with", findings[0].detail)
 
-    def test_flags_banned_developer_signed_release_phrase(self):
+    def test_flags_banned_developer_signed_release_detail(self):
         checker = load_module()
         findings = checker.review("A developer-signed release expands the browser forge.")
-        self.assertEqual("developer-signed release expands the browser", findings[0].phrase)
+        self.assertEqual("developer-signed release expands the browser", findings[0].detail)
 
     def test_accepts_direct_specific_prose(self):
         checker = load_module()
@@ -37,18 +37,30 @@ class NewsletterStyleTests(unittest.TestCase):
         )
         self.assertEqual(
             ["has been added to Compass's", "so later releases"],
-            [finding.phrase for finding in findings],
+            [finding.detail for finding in findings],
         )
 
     def test_flags_source_discovery_commentary(self):
         checker = load_module()
         findings = checker.review("The project was discovered through the weekly feed.")
-        self.assertEqual("discovered through", findings[0].phrase)
+        self.assertEqual("discovered through", findings[0].detail)
 
     def test_flags_internal_selection_commentary(self):
         checker = load_module()
         findings = checker.review("Eleven versioned releases made the final scope cut.")
-        self.assertEqual("made the final scope cut", findings[0].phrase)
+        self.assertEqual("made the final scope cut", findings[0].detail)
+
+    def test_flags_opaque_advisory_link_anchor(self):
+        checker = load_module()
+        findings = checker.review("The fix is documented in [GHSA-abcd-1234-efgh](https://example.com).")
+        self.assertEqual("link_anchor", findings[0].kind)
+
+    def test_accepts_descriptive_advisory_link_anchor(self):
+        checker = load_module()
+        self.assertEqual(
+            [],
+            checker.review("The [relay parser advisory](https://example.com/GHSA-abcd-1234-efgh) is fixed."),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Two gates that were documented or assumed but not implemented.

`scripts/check_newsletter_style.py` — CLAUDE.md calls this "a blocking gate, not an advisory pass" and specifies both the opaque-anchor rule (GHSA/CVE identifiers must never be link anchor text or bare prose list items) and the "No exclusion meta in publishable prose" rule. Neither was implemented. Both are now, and `Finding` carries a `kind` so phrase hits and anchor hits are distinguishable.

`scripts/fetch_nostr_recap.sh` — every fetched event now passes through `nak verify` before entering the pipeline, with a rejection count reported. Previously an unsigned or tampered event from a relay was indistinguishable from a real one.

## Why now

This work was sitting uncommitted in the shared checkout at `/opt/data/compass`, which had drifted 27 commits behind `main` and was missing Newsletters #36 and #37 on disk. Nothing in the weekly automation keeps that checkout current, so the code never reached a run. The checkout is now fast-forwarded and clean.

## Verification

- `python3 -m unittest discover -s tests` — 125 tests, all pass
- The style gate returns PASS against the three most recently merged issues (2026-08-12, 2026-08-19, 2026-08-26), so it does not retroactively block published prose
- `nak verify` confirmed to accept a validly signed event and reject the same event with mutated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)