### PR TITLE
Correct Newsletter #38 publication evidence record

### DIFF
--- a/data/newsletter_workspace/post_delivery_refresh_2026-09-02.md
+++ b/data/newsletter_workspace/post_delivery_refresh_2026-09-02.md
@@ -5,9 +5,9 @@ Task: t_4ad062e3. Trigger: owner feedback after Markdown delivery and before pub
 ## Changes made
 
 1. Voca prose shortened from three paragraphs to two paragraphs. Preserved the two source-backed claims the owner required: (a) every fetched event is checked against its recomputed id and BIP-340 Schnorr signature before persistence, and (b) adding an author's npub subscribes Voca to their NIP-23 long-form articles in a single on-device inbox. Timestamps corrected per relay readback: the 1.1.0 kind-1 announcement was published 2026-08-28, while the Zapstore kind-30267 release event is 2026-08-29; the final prose distinguishes announcement from Zapstore release.
-2. `data/npubs.yml` Voca evidence preserved unchanged: the exact signed-event and Zapstore evidence links from the reviewed revision were kept, not rewritten.
+2. Final publication preflight rejected two non-HTTP annotations in Voca's `data/npubs.yml` evidence. They were normalized to the exact GitWorkshop repository page and an `njump.me/nevent` link for Zapstore application event `5bb516cb29571ee0db367a4cc2cd8e3a73cafd92b15560baaf5f0e2b17475ad7`; source specificity was preserved.
 3. Assembled newsletter and `sections/lead-stories.md` synchronized via `scripts/sync_newsletter_sections.py`.
-4. Final gate evidence (all run on committed revision `da60895`):
+4. Final editorial gate evidence (run on committed revision `da60895`; publication proof is consolidated in `publish_log_2026-09-02.md`):
    - `check_newsletter_style.py` → PASS (no banned filler phrases or opaque link anchors)
    - `check_newsletter_continuity.py --history-dir content/en/newsletters` → PASS
    - `check_newsletter_paragraph_links.py` → PASS
@@ -20,4 +20,4 @@ Task: t_4ad062e3. Trigger: owner feedback after Markdown delivery and before pub
 5. PR #147 updated via force-with-lease push to `da60895`. CI: build COMPLETED/SUCCESS at 2026-09-02T18:20:01Z (run 33666463263); deploy SKIPPED (expected on draft PRs). Frontmatter `draft: false` set for publication.
 6. Publication hold (`publication_hold_2026-09-02.md`) conditions 1–3 satisfied by this run. Condition 4 (finalized English Markdown durably delivered to the originating Marmot group) is fulfilled by the prior attachment delivery of the exact committed file. The hold is now released.
 
-GATE: PASS (Voca prose shortened to two source-backed claims with corrected timestamps; all style/continuity/paragraph-link/event-example/npub/test/build/backlink gates pass on committed revision da60895; no duplicates found; PR #147 updated and CI green; draft:false set; hold released for publication)
+GATE: PASS (Voca prose shortened to two source-backed claims with corrected timestamps; style/continuity/paragraph-link/event-example/test/build/backlink gates passed on revision da60895; the npub validator passed after evidence URL normalization; no duplicates found; publication proof is authoritative in publish_log_2026-09-02.md)

--- a/data/npubs.yml
+++ b/data/npubs.yml
@@ -1303,9 +1303,9 @@ Voca:
   npub: npub17h9fn2ny0lycg7kmvxmw6gqdnv2epya9h9excnjw9wvml87nyw8sqy3hpu
   identity_type: project
   evidence:
-    - nostr://npub17h9fn2ny0lycg7kmvxmw6gqdnv2epya9h9excnjw9wvml87nyw8sqy3hpu/relay.ngit.dev/voca
+    - https://gitworkshop.dev/npub17h9fn2ny0lycg7kmvxmw6gqdnv2epya9h9excnjw9wvml87nyw8sqy3hpu/voca
     - https://njump.me/naddr1qq98vmmrvyknzt3s9ccqyg84e2v65erlexz84kmpkmkjqrvmzkgf8fdewfkyun3tnxlel5er3upsgqqqw4rsw0l3en
-    - https://relay.zapstore.dev (kind 32267 application event 5bb516cb29571ee0db367a4cc2cd8e3a73cafd92b15560baaf5f0e2b17475ad7)
+    - https://njump.me/nevent1qqs9hdgkev54w8hqmvm85nxzek8r5u72lkftz4tqh2h47r3tzar444cprpmhxue69uhhyetvv9uju7npwpehgmmjv5hxgetkqgs0tj5e4fj8ljvy0tdkrdhdyqxek9vsjwjmjunvfe8zhxdlnlfj8rcymzps5
 
 # Exact aliases produced by the outreach scope parser; each de-duplicates to the
 # already verified project or maintainer recipient above.


### PR DESCRIPTION
## Summary
- correct the post-delivery record after publication preflight normalized Voca evidence URLs
- point downstream work to the authoritative publication log
- remove the stale claim that evidence was unchanged

## Validation
- `git diff --check`
- `bun run check:npubs` (0 errors; 2 legacy warnings)
- `bun run build` (2,289 pages indexed)
