### PR TITLE
Add Logbook homepage entry

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,6 +17,7 @@ ignoreFiles = ['newsletter_workspace']
   npub = "npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923"
   github_username = "andotherstuff"
   repository_name = "nostr-compass"
+  logbook_url = "https://npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.nsite.lol/#/login"
   author = "Nostr Compass"
   bold = "**"
   # Buttondown newsletter signup - just add your username from buttondown.email/YOUR_USERNAME

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass ist eine technische Ressource für das Nostr-Protokoll und hilft Entwicklern, Relay-Betreibern und Buildern, über die Protokollentwicklung auf dem Laufenden zu bleiben."
 home_description: "Wir veröffentlichen <a href=\"{{.newslettersURL}}\">wöchentliche Newsletter</a>, die NIP-Vorschläge, Client-Updates, Relay-Entwicklungen und bemerkenswerte Code-Änderungen behandeln. Unser <a href=\"{{.podcastURL}}\">Podcast</a> bietet Gespräche mit den Entwicklern, die Nostr bauen. Der <a href=\"{{.topicsURL}}\">Themenindex</a> dokumentiert wichtige Konzepte mit Links zu Primärquellen."
 home_learn_more: "Erfahre mehr über uns"
+home_logbook_title: "Logbook"
+home_logbook_description: "Probiere unsere frühe asynchrone Voice-Podcast-Erfahrung aus und trage zu Aufnahmen von Nostr Compass bei."
 recent_newsletters: "Aktuelle Newsletter"
 no_newsletters: "Noch keine Newsletter gefunden."
 view_more_newsletters: "Mehr <a href=\"{{.newslettersURL}}\">Newsletter</a> ansehen. Abonnieren via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Folge uns <a href=\"{{.nostrURL}}\">auf Nostr</a>."

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass is a technical resource for the Nostr protocol, helping developers, relay operators, and builders stay current on protocol evolution."
 home_description: "We publish <a href=\"{{.newslettersURL}}\">weekly newsletters</a> covering NIP proposals, client updates, relay developments, and notable code changes. Our <a href=\"{{.podcastURL}}\">podcast</a> features conversations with the developers building Nostr. The <a href=\"{{.topicsURL}}\">topic index</a> documents key concepts with links to primary sources."
 home_learn_more: "Learn more about us"
+home_logbook_title: "Logbook"
+home_logbook_description: "Try our early asynchronous voice-podcast experience for contributing to Nostr Compass recordings."
 recent_newsletters: "Recent Newsletters"
 no_newsletters: "No newsletters found yet."
 view_more_newsletters: "View more <a href=\"{{.newslettersURL}}\">newsletters</a>. Subscribe via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Follow us <a href=\"{{.nostrURL}}\">on Nostr</a>."

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass es un recurso técnico para el protocolo Nostr, ayudando a desarrolladores, operadores de relays y constructores a mantenerse al día con la evolución del protocolo."
 home_description: "Publicamos <a href=\"{{.newslettersURL}}\">boletines semanales</a> que cubren propuestas de NIP, actualizaciones de clientes, desarrollos de relays y cambios de código notables. Nuestro <a href=\"{{.podcastURL}}\">podcast</a> presenta conversaciones con los desarrolladores que construyen Nostr. El <a href=\"{{.topicsURL}}\">índice de temas</a> documenta conceptos clave con enlaces a fuentes primarias."
 home_learn_more: "Conoce más sobre nosotros"
+home_logbook_title: "Logbook"
+home_logbook_description: "Prueba nuestra primera experiencia de pódcast de voz asincrónico para contribuir a las grabaciones de Nostr Compass."
 recent_newsletters: "Boletines Recientes"
 no_newsletters: "Aún no hay boletines publicados."
 view_more_newsletters: "Ver más <a href=\"{{.newslettersURL}}\">boletines</a>. Suscríbete via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Síguenos <a href=\"{{.nostrURL}}\">en Nostr</a>."

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass est une ressource technique pour le protocole Nostr, aidant les développeurs, opérateurs de relais et constructeurs à rester informés de l'évolution du protocole."
 home_description: "Nous publions des <a href=\"{{.newslettersURL}}\">newsletters hebdomadaires</a> couvrant les propositions NIP, les mises à jour des clients, les développements des relais et les changements de code notables. Notre <a href=\"{{.podcastURL}}\">podcast</a> propose des conversations avec les développeurs qui construisent Nostr. L'<a href=\"{{.topicsURL}}\">index des sujets</a> documente les concepts clés avec des liens vers les sources primaires."
 home_learn_more: "En savoir plus sur nous"
+home_logbook_title: "Logbook"
+home_logbook_description: "Essayez notre première expérience de podcast vocal asynchrone pour contribuer aux enregistrements de Nostr Compass."
 recent_newsletters: "Newsletters Récentes"
 no_newsletters: "Aucune newsletter trouvée pour le moment."
 view_more_newsletters: "Voir plus de <a href=\"{{.newslettersURL}}\">newsletters</a>. S'abonner via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Suivez-nous <a href=\"{{.nostrURL}}\">sur Nostr</a>."

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass è una risorsa tecnica per il protocollo Nostr, che aiuta sviluppatori, operatori di relay e builder a rimanere aggiornati sull'evoluzione del protocollo."
 home_description: "Pubblichiamo <a href=\"{{.newslettersURL}}\">newsletter settimanali</a> che coprono proposte NIP, aggiornamenti dei client, sviluppi dei relay e modifiche al codice degne di nota. Il nostro <a href=\"{{.podcastURL}}\">podcast</a> presenta conversazioni con gli sviluppatori che costruiscono Nostr. L'<a href=\"{{.topicsURL}}\">indice degli argomenti</a> documenta i concetti chiave con link alle fonti primarie."
 home_learn_more: "Scopri di più su di noi"
+home_logbook_title: "Logbook"
+home_logbook_description: "Prova la nostra prima esperienza di podcast vocale asincrono per contribuire alle registrazioni di Nostr Compass."
 recent_newsletters: "Newsletter Recenti"
 no_newsletters: "Nessuna newsletter trovata."
 view_more_newsletters: "Vedi altre <a href=\"{{.newslettersURL}}\">newsletter</a>. Iscriviti via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Seguici <a href=\"{{.nostrURL}}\">su Nostr</a>."

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compassは、Nostrプロトコルの技術リソースであり、開発者、リレー運営者、ビルダーがプロトコルの進化について最新情報を得られるよう支援します。"
 home_description: "<a href=\"{{.newslettersURL}}\">週刊ニュースレター</a>では、NIP提案、クライアントのアップデート、リレーの開発、注目すべきコード変更を取り上げています。<a href=\"{{.podcastURL}}\">ポッドキャスト</a>では、Nostrを構築している開発者との対話を配信しています。<a href=\"{{.topicsURL}}\">トピックインデックス</a>では、主要な概念を一次情報源へのリンクとともに文書化しています。"
 home_learn_more: "私たちについてもっと知る"
+home_logbook_title: "Logbook"
+home_logbook_description: "Nostr Compassの収録に参加できる、初期段階の非同期音声ポッドキャスト体験をお試しください。"
 recent_newsletters: "最新のニュースレター"
 no_newsletters: "ニュースレターはまだありません。"
 view_more_newsletters: "<a href=\"{{.newslettersURL}}\">ニュースレター</a>をもっと見る。<a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">ポッドキャストRSS</a>で購読。<a href=\"{{.nostrURL}}\">Nostr</a>でフォロー。"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass는 Nostr 프로토콜을 위한 기술 리소스로, 개발자, 릴레이 운영자, 빌더들이 프로토콜 발전에 대해 최신 정보를 얻을 수 있도록 돕습니다."
 home_description: "<a href=\"{{.newslettersURL}}\">주간 뉴스레터</a>에서 NIP 제안, 클라이언트 업데이트, 릴레이 개발, 주목할 만한 코드 변경 사항을 다룹니다. <a href=\"{{.podcastURL}}\">팟캐스트</a>에서는 Nostr를 구축하는 개발자들과의 대화를 제공합니다. <a href=\"{{.topicsURL}}\">주제 색인</a>은 주요 개념을 원본 자료 링크와 함께 문서화합니다."
 home_learn_more: "우리에 대해 더 알아보기"
+home_logbook_title: "Logbook"
+home_logbook_description: "Nostr Compass 녹음에 참여할 수 있는 초기 비동기 음성 팟캐스트 환경을 사용해 보세요."
 recent_newsletters: "최신 뉴스레터"
 no_newsletters: "아직 뉴스레터가 없습니다."
 view_more_newsletters: "더 많은 <a href=\"{{.newslettersURL}}\">뉴스레터</a> 보기. <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">팟캐스트 RSS</a>로 구독. <a href=\"{{.nostrURL}}\">Nostr</a>에서 팔로우."

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass is een technische bron voor het Nostr-protocol, die ontwikkelaars, relay-operators en bouwers helpt om op de hoogte te blijven van de protocolontwikkeling."
 home_description: "We publiceren <a href=\"{{.newslettersURL}}\">wekelijkse nieuwsbrieven</a> over NIP-voorstellen, client-updates, relay-ontwikkelingen en opmerkelijke codewijzigingen. Onze <a href=\"{{.podcastURL}}\">podcast</a> biedt gesprekken met de ontwikkelaars die Nostr bouwen. De <a href=\"{{.topicsURL}}\">onderwerpenindex</a> documenteert belangrijke concepten met links naar primaire bronnen."
 home_learn_more: "Meer over ons"
+home_logbook_title: "Logbook"
+home_logbook_description: "Probeer onze vroege asynchrone spraakpodcastervaring en draag bij aan opnames van Nostr Compass."
 recent_newsletters: "Recente Nieuwsbrieven"
 no_newsletters: "Nog geen nieuwsbrieven gevonden."
 view_more_newsletters: "Bekijk meer <a href=\"{{.newslettersURL}}\">nieuwsbrieven</a>. Abonneer via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Volg ons <a href=\"{{.nostrURL}}\">op Nostr</a>."

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass é um recurso técnico para o protocolo Nostr, ajudando desenvolvedores, operadores de relays e construtores a se manterem atualizados sobre a evolução do protocolo."
 home_description: "Publicamos <a href=\"{{.newslettersURL}}\">newsletters semanais</a> cobrindo propostas de NIP, atualizações de clientes, desenvolvimentos de relays e mudanças de código notáveis. Nosso <a href=\"{{.podcastURL}}\">podcast</a> apresenta conversas com os desenvolvedores que constroem o Nostr. O <a href=\"{{.topicsURL}}\">índice de tópicos</a> documenta conceitos-chave com links para fontes primárias."
 home_learn_more: "Saiba mais sobre nós"
+home_logbook_title: "Logbook"
+home_logbook_description: "Experimente nossa primeira experiência assíncrona de podcast de voz para contribuir com as gravações do Nostr Compass."
 recent_newsletters: "Newsletters Recentes"
 no_newsletters: "Nenhuma newsletter encontrada ainda."
 view_more_newsletters: "Ver mais <a href=\"{{.newslettersURL}}\">newsletters</a>. Inscreva-se via <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">Podcast RSS</a>. Siga-nos <a href=\"{{.nostrURL}}\">no Nostr</a>."

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -1,6 +1,8 @@
 home_intro: "Nostr Compass 是 Nostr 协议的技术资源，帮助开发者、中继运营者和构建者了解协议的最新发展。"
 home_description: "我们发布<a href=\"{{.newslettersURL}}\">每周通讯</a>，涵盖 NIP 提案、客户端更新、中继发展和值得注意的代码更改。我们的<a href=\"{{.podcastURL}}\">播客</a>提供与构建 Nostr 的开发者的对话。<a href=\"{{.topicsURL}}\">主题索引</a>记录关键概念并提供原始资料链接。"
 home_learn_more: "了解更多关于我们"
+home_logbook_title: "Logbook"
+home_logbook_description: "体验我们早期的异步语音播客功能，为 Nostr Compass 的录制贡献内容。"
 recent_newsletters: "最新通讯"
 no_newsletters: "暂无通讯。"
 view_more_newsletters: "查看更多<a href=\"{{.newslettersURL}}\">通讯</a>。通过 <a href=\"{{.rssURL}}\">RSS</a> | <a href=\"{{.podcastRSSURL}}\" target=\"_blank\" rel=\"noopener\">播客 RSS</a> 订阅。在 <a href=\"{{.nostrURL}}\">Nostr</a> 上关注我们。"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,6 +11,11 @@
 
     <p><a href="{{ "/about/" | relLangURL }}">{{ i18n "home_learn_more" }}</a>.</p>
 
+    <section class="home-logbook" aria-labelledby="home-logbook-heading">
+      <h2 id="home-logbook-heading"><a href="{{ .Site.Params.logbook_url }}">{{ i18n "home_logbook_title" }}</a></h2>
+      <p>{{ i18n "home_logbook_description" }}</p>
+    </section>
+
     <h2>{{ i18n "recent_newsletters" }}</h2>
     {{- $langPrefix := printf "/%s/newsletters/" .Site.Language.Lang -}}
     <ul class="post-list">

--- a/tests/test_logbook_homepage.py
+++ b/tests/test_logbook_homepage.py
@@ -1,0 +1,62 @@
+from html.parser import HTMLParser
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).parents[1]
+LANGUAGES = ("en", "es", "pt", "de", "fr", "it", "ja", "ko", "zh", "nl")
+LOGBOOK_URL = "https://npub1wav4fae3gyfy3xj298kxj2mj8phavz7vavps34przq02j7w902qq902923.nsite.lol/#/login"
+
+
+class LogbookSectionParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.section_depth = 0
+        self.sections = 0
+        self.links = []
+        self.text = []
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag == "section" and "home-logbook" in attributes.get("class", "").split():
+            self.sections += 1
+            self.section_depth = 1
+        elif self.section_depth:
+            self.section_depth += 1
+            if tag == "a":
+                self.links.append(attributes)
+
+    def handle_endtag(self, tag):
+        if self.section_depth:
+            self.section_depth -= 1
+
+    def handle_data(self, data):
+        if self.section_depth and data.strip():
+            self.text.append(data.strip())
+
+
+class LogbookHomepageTests(unittest.TestCase):
+    def test_logbook_is_linked_and_described_on_each_homepage(self):
+        with tempfile.TemporaryDirectory() as destination:
+            subprocess.run(
+                ["hugo", "--destination", destination, "--quiet"],
+                cwd=ROOT,
+                check=True,
+            )
+
+            for language in LANGUAGES:
+                with self.subTest(language=language):
+                    parser = LogbookSectionParser()
+                    parser.feed((Path(destination) / language / "index.html").read_text())
+
+                    self.assertEqual(1, parser.sections)
+                    self.assertEqual([LOGBOOK_URL], [link.get("href") for link in parser.links])
+                    self.assertTrue(any("Logbook" in text for text in parser.text))
+                    self.assertGreater(len(" ".join(parser.text)), len("Logbook"))
+                    self.assertNotIn("target", parser.links[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a concise Logbook entry to the multilingual homepage
- link the currently live Logbook nsite and describe it as an early asynchronous voice-podcast experience
- keep the entry in the existing document flow with a semantic section, heading, and native link
- add focused rendered-homepage coverage for all ten languages

## Validation

- `python3 /opt/data/scripts/hermes_test_gate.py --tier focused -- python3 -m unittest tests.test_logbook_homepage` — PASS
- `HUGO_ENV=production python3 /opt/data/scripts/hermes_test_gate.py --tier fast -- bun run build` — PASS (Hugo production build and Pagefind indexing across ten languages)
- responsive audit: the entry uses the existing fluid homepage flow without fixed dimensions or new breakpoints
- keyboard/screen-reader audit: named section, heading-linked destination, native keyboard-focusable anchor, descriptive visible copy, and no forced new tab
- destination readback: HTTP 200 with page title `Logbook` at the configured nsite URL
