### PR TITLE
Allow race-safe Compass merges without admin branch rules

### DIFF
--- a/publish/README.md
+++ b/publish/README.md
@@ -52,10 +52,14 @@ the file matches the configured one and warns on mismatch.
    the 21-word TL;DR, validate the banner URL, parse optional Tags line.
    Writes `out/{N}/metadata.json` and `out/{N}/article.unsigned.json`.
 2. **MERGE PREPARE/COMMIT:** consumes the explicit PR number, head SHA, and base
-   SHA; computes and records the prospective merge tree under the server
-   current-base guard. The mutation pass requires the identical prepared tree,
-   scoped edition authorization, source/feedback/review receipts, and exact-head
-   CI, then merges with the expected-head precondition and verifies the result.
+   SHA; computes and records the prospective merge tree under a race-free
+   current-base guard. Strict server status checks are preferred. When the
+   authenticated publisher lacks repository-admin access to configure them, the
+   pipeline fetches GitHub's exact two-parent prospective merge commit, verifies
+   its base, head, and tree, and fast-forward pushes that immutable commit to the
+   base ref. Git rejects the push if the base advanced. The mutation pass still
+   requires the identical prepared tree, scoped edition authorization,
+   source/feedback/review receipts, and exact-head CI, then verifies the result.
 3. **DEPLOY:** selects the Pages run attributable to the confirmed merge SHA and
    verifies the canonical page serves the expected merged content.
 4. **SIGN:** after deployment confirmation, requests an Amber bunker signature

--- a/publish/lib/journal.ts
+++ b/publish/lib/journal.ts
@@ -21,7 +21,7 @@ export type PullRequestEvidence = {
   head_sha: string;
   base_sha: string;
   prospective_tree_sha?: string;
-  base_guard?: { method: "branch-protection-strict"; base_ref: string; verified_at: string };
+  base_guard?: { method: "branch-protection-strict" | "git-ref-cas"; base_ref: string; verified_at: string };
   merge_sha?: string;
   merge_tree_sha?: string;
 };

--- a/publish/publish.ts
+++ b/publish/publish.ts
@@ -273,7 +273,7 @@ async function main() {
         const preview = await previewMergeIssue(args.issue, { outDir: OUT_DIR, identity: args.prIdentity });
         if (!authorizationPreview || authorizationPreview.prospective_tree_sha !== preview.prospective_tree_sha) throw new Error("Read-only preview authorization does not match the exact prospective merge tree");
         if (new Date() < new Date(authorizationPreview.not_before)) throw new Error("Read-only preview is before the scoped Wednesday publication boundary");
-        console.log(`[dry-run] exact PR #${preview.number} ${preview.state}; head/base/prospective tree and server currentness gate verified`);
+        console.log(`[dry-run] exact PR #${preview.number} ${preview.state}; head/base/prospective tree and race-free currentness gate verified`);
         if (preview.state === "open") {
           if (args.stage === "all") console.log("[dry-run] merge would run next; deployment, signing, broadcast, and log remain downstream plans");
           return;

--- a/publish/stages/merge.test.ts
+++ b/publish/stages/merge.test.ts
@@ -28,7 +28,7 @@ async function setup() {
 }
 const head = "a".repeat(40), base = "b".repeat(40), merge = "c".repeat(40), potential = "d".repeat(40), tree = "e".repeat(40);
 const view = (state = "OPEN", actualHead = head) => JSON.stringify({ number: 7, state, mergeable: "MERGEABLE", mergeStateStatus: "CLEAN", headRefOid: actualHead, baseRefOid: base, baseRefName: "main", potentialMergeCommit: state === "OPEN" ? { oid: potential } : null, mergeCommit: state === "MERGED" ? { oid: merge } : null });
-function runner(options: { mergedAfter?: boolean; loseReadback?: boolean; strict?: boolean } = {}) {
+function runner(options: { mergedAfter?: boolean; loseReadback?: boolean; strict?: boolean; remoteBase?: string } = {}) {
   let views = 0; const calls: string[][] = [];
   const run = async (_cmd: string, args: string[]) => {
     calls.push(args);
@@ -39,6 +39,10 @@ function runner(options: { mergedAfter?: boolean; loseReadback?: boolean; strict
     }
     if (args[0] === "api" && args[1].includes("/git/commits/")) return { code: 0, stdout: tree + "\n", stderr: "" };
     if (args[0] === "api" && args[1].includes("/protection")) return { code: options.strict === false ? 1 : 0, stdout: options.strict === false ? "" : "true\n", stderr: options.strict === false ? "not found" : "" };
+    if (args.includes("ls-remote")) return { code: 0, stdout: `${options.remoteBase ?? base}\trefs/heads/main\n`, stderr: "" };
+    if (args.includes("fetch")) return { code: 0, stdout: "", stderr: "" };
+    if (args.includes("cat-file")) return { code: 0, stdout: `tree ${tree}\nparent ${base}\nparent ${head}\n\nmerge\n`, stderr: "" };
+    if (args.includes("push")) return { code: 0, stdout: "", stderr: "" };
     if (args[0] === "pr" && args[1] === "merge") return { code: 1, stdout: "", stderr: "connection lost" };
     return { code: 1, stdout: "", stderr: "unexpected" };
   };
@@ -56,10 +60,18 @@ describe("exact PR merge", () => {
     const out = await setup(); await pinPullRequest(out, 1, { number: 7, head_sha: head, base_sha: base });
     await expect(mergeIssue(1, { reallyMerge: true, outDir: out, run: async () => ({ code: 0, stdout: view("OPEN", "f".repeat(40)), stderr: "" }) })).rejects.toThrow("head no longer matches");
   });
-  test("fails closed when the server does not enforce base currentness", async () => {
-    const out = await setup(); await pinPullRequest(out, 1, { number: 7, head_sha: head, base_sha: base }); const { run, calls } = runner({ strict: false });
-    await expect(mergeIssue(1, { reallyMerge: true, outDir: out, run })).rejects.toThrow("server does not enforce");
+  test("uses a fast-forward git ref CAS when strict server protection is unavailable", async () => {
+    const out = await setup(); await pinPullRequest(out, 1, { number: 7, head_sha: head, base_sha: base }); const { run, calls } = runner({ strict: false, mergedAfter: true });
+    expect(await mergeIssue(1, { reallyMerge: true, outDir: out, run })).toBe("confirmed");
     expect(calls.some((args) => args[1] === "merge")).toBe(false);
+    const push = calls.find((args) => args.includes("push"))!;
+    expect(push).toContain(`--force-with-lease=refs/heads/main:${base}`);
+    expect(push).toContain(`${potential}:refs/heads/main`);
+  });
+  test("fails closed when the CAS remote base no longer matches the pinned base", async () => {
+    const out = await setup(); const { run, calls } = runner({ strict: false, remoteBase: "f".repeat(40) });
+    await expect(mergeIssue(1, { reallyMerge: true, outDir: out, run })).rejects.toThrow("remote base is not the pinned base");
+    expect(calls.some((args) => args.includes("push"))).toBe(false);
   });
   test("returns prepared without claiming a merge", async () => {
     const out = await setup(); await pinPullRequest(out, 1, { number: 7, head_sha: head, base_sha: base }); const { run, calls } = runner();

--- a/publish/stages/merge.ts
+++ b/publish/stages/merge.ts
@@ -1,13 +1,15 @@
-// Stage 6: exact-identity merge with server-enforced base currentness.
+// Stage 6: exact-identity merge with race-free base currentness.
 import { spawn } from "node:child_process";
 import { loadJournal, mutateJournal } from "../lib/journal.ts";
 import { assertMergeAuthorized } from "../lib/authorization.ts";
 
 const OUT_DIR = new URL("../out", import.meta.url).pathname;
 const REPO = "andotherstuff/nostr-compass";
+const COMPASS_DIR = process.env.COMPASS_DIR || new URL("../..", import.meta.url).pathname;
 export type PullRequestIdentity = { number: number; head_sha: string; base_sha: string };
 type PRView = { number: number; state: string; mergeable: string; mergeStateStatus: string; headRefOid: string; baseRefOid: string; baseRefName: string; mergeCommit?: { oid: string } | null; potentialMergeCommit?: { oid: string } | null };
 type Runner = (cmd: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>;
+type BaseGuard = { method: "branch-protection-strict" | "git-ref-cas"; base_ref: string; verified_at: string };
 const defaultRun: Runner = (cmd, args) => new Promise((resolve) => {
   const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, GH_CACHE_TTL: "0", HERMES_GH_NO_CACHE: "1" } }); let stdout = "", stderr = "";
   child.stdout.on("data", (data) => stdout += data); child.stderr.on("data", (data) => stderr += data);
@@ -32,9 +34,39 @@ async function commitTree(commit: string, run: Runner): Promise<string> {
   if (result.code !== 0 || !/^[0-9a-f]{40}$/.test(tree)) throw new Error(`Cannot verify commit tree for ${commit}: ${result.stderr.trim()}`);
   return tree;
 }
-async function requireServerBaseGuard(baseRef: string, run: Runner): Promise<void> {
-  const result = await run("gh", ["api", `repos/${REPO}/branches/${baseRef}/protection`, "--jq", ".required_status_checks.strict"]);
-  if (result.code !== 0 || result.stdout.trim() !== "true") throw new Error("Refusing merge: server does not enforce strict current-base status checks, so base identity can race the merge");
+async function selectBaseGuard(pr: PRView, run: Runner): Promise<BaseGuard> {
+  const result = await run("gh", ["api", `repos/${REPO}/branches/${pr.baseRefName}/protection`, "--jq", ".required_status_checks.strict"]);
+  if (result.code === 0 && result.stdout.trim() === "true") {
+    return { method: "branch-protection-strict", base_ref: pr.baseRefName, verified_at: new Date().toISOString() };
+  }
+
+  const remote = await run("git", ["-C", COMPASS_DIR, "ls-remote", "--heads", "origin", `refs/heads/${pr.baseRefName}`]);
+  const remoteHead = remote.stdout.trim().split(/\s+/)[0] ?? "";
+  if (remote.code !== 0 || remoteHead !== pr.baseRefOid) {
+    throw new Error("Refusing merge: strict server currentness is unavailable and the remote base is not the pinned base SHA");
+  }
+  return { method: "git-ref-cas", base_ref: pr.baseRefName, verified_at: new Date().toISOString() };
+}
+
+async function mergeWithGitRefCas(pr: PRView, prospectiveTree: string, run: Runner) {
+  const candidate = pr.potentialMergeCommit?.oid;
+  if (!candidate || !/^[0-9a-f]{40}$/.test(candidate)) throw new Error("Git ref CAS merge requires GitHub's prospective merge commit");
+
+  const fetched = await run("git", ["-C", COMPASS_DIR, "fetch", "--no-tags", "--no-write-fetch-head", "origin", `refs/pull/${pr.number}/merge`]);
+  if (fetched.code !== 0) throw new Error(`Cannot fetch the exact prospective merge commit: ${fetched.stderr.trim()}`);
+  const inspected = await run("git", ["-C", COMPASS_DIR, "cat-file", "-p", candidate]);
+  if (inspected.code !== 0) throw new Error(`Cannot inspect the exact prospective merge commit: ${inspected.stderr.trim()}`);
+  const lines = inspected.stdout.split("\n");
+  const tree = lines.find((line) => line.startsWith("tree "))?.slice(5);
+  const parents = lines.filter((line) => line.startsWith("parent ")).map((line) => line.slice(7));
+  if (tree !== prospectiveTree || parents.length !== 2 || parents[0] !== pr.baseRefOid || parents[1] !== pr.headRefOid) {
+    throw new Error("Fetched prospective merge commit does not match the pinned base, head, and tree");
+  }
+
+  const baseRef = `refs/heads/${pr.baseRefName}`;
+  const pushed = await run("git", ["-C", COMPASS_DIR, "push", "origin", `--force-with-lease=${baseRef}:${pr.baseRefOid}`, `${candidate}:${baseRef}`]);
+  if (pushed.code !== 0) throw new Error(`Git ref CAS merge rejected; the base probably advanced: ${pushed.stderr.trim()}`);
+  return pushed;
 }
 
 export async function previewMergeIssue(
@@ -57,7 +89,7 @@ export async function previewMergeIssue(
   if (pr.mergeable !== "MERGEABLE" || pr.mergeStateStatus !== "CLEAN") throw new Error(`PR #${pr.number} is not clean and mergeable`);
   if (!pr.potentialMergeCommit?.oid) throw new Error("GitHub did not provide a prospective merge identity");
   const prospectiveTree = await commitTree(pr.potentialMergeCommit.oid, run);
-  await requireServerBaseGuard(pr.baseRefName, run);
+  await selectBaseGuard(pr, run);
   if (pinned.prospective_tree_sha && pinned.prospective_tree_sha !== prospectiveTree) throw new Error("Current prospective merge tree differs from the journal-pinned review candidate");
   return { state: "open", number: pinned.number, head_sha: pinned.head_sha, base_sha: pinned.base_sha, prospective_tree_sha: prospectiveTree };
 }
@@ -84,11 +116,12 @@ export async function mergeIssue(issue: number, opts: { reallyMerge: boolean; ou
   if (pr.mergeable !== "MERGEABLE" || pr.mergeStateStatus !== "CLEAN") throw new Error(`PR #${pr.number} is not clean and mergeable`);
   if (!pr.potentialMergeCommit?.oid) throw new Error("GitHub did not provide a prospective merge identity");
   const prospectiveTree = await commitTree(pr.potentialMergeCommit.oid, run);
-  await requireServerBaseGuard(pr.baseRefName, run);
+  const baseGuard = await selectBaseGuard(pr, run);
+  if (pinned.base_guard && pinned.base_guard.method !== baseGuard.method) throw new Error("Current base guard differs from the prepared merge guard");
   if (!opts.reallyMerge) {
     await mutateJournal(outDir, issue, (j) => {
       j.pull_request!.prospective_tree_sha = prospectiveTree;
-      j.pull_request!.base_guard = { method: "branch-protection-strict", base_ref: pr.baseRefName, verified_at: new Date().toISOString() };
+      j.pull_request!.base_guard = baseGuard;
       j.effects.merge = { state: "prepared", intent_sha256: `${pinned.number}:${pinned.head_sha}:${pinned.base_sha}:${prospectiveTree}` };
     });
     return "prepared";
@@ -96,10 +129,12 @@ export async function mergeIssue(issue: number, opts: { reallyMerge: boolean; ou
   if (pinned.prospective_tree_sha !== prospectiveTree || journal.effects.merge?.state !== "prepared") throw new Error("merge mutation requires a previously prepared identical prospective tree");
   await assertMergeAuthorized(outDir, issue, prospectiveTree);
   await mutateJournal(outDir, issue, (j) => {
-    j.pull_request!.base_guard = { method: "branch-protection-strict", base_ref: pr.baseRefName, verified_at: new Date().toISOString() };
+    j.pull_request!.base_guard = baseGuard;
   });
   await mutateJournal(outDir, issue, (j) => { j.effects.merge.state = "attempted"; });
-  const merged = await run("gh", ["pr", "merge", String(pinned.number), "--repo", REPO, "--squash", "--delete-branch", "--match-head-commit", pinned.head_sha]);
+  const merged = baseGuard.method === "branch-protection-strict"
+    ? await run("gh", ["pr", "merge", String(pinned.number), "--repo", REPO, "--squash", "--delete-branch", "--match-head-commit", pinned.head_sha])
+    : await mergeWithGitRefCas(pr, prospectiveTree, run);
   try { pr = await viewPR(pinned.number, run); }
   catch (error) {
     await mutateJournal(outDir, issue, (j) => { j.effects.merge.state = "ambiguous"; j.effects.merge.error = `authoritative readback failed: ${(error as Error).message}`; });

--- a/skills/_COMPASS/SKILL.md
+++ b/skills/_COMPASS/SKILL.md
@@ -320,8 +320,8 @@ At 14:30 UTC, a broad delta pass starts across every relevant source family. At 
 The recurring Wednesday publication starts at or after 16:00 UTC. It requires current evidence-bearing full-refresh, broad-delta, cutoff, feedback, source, review, and exact-head CI receipts, the scoped edition authorization, and no authenticated hold/cancellation. It follows `agents/PublishAgent.md`. Steps:
 
 1. Recheck the strict UTC clock, authenticated hold version, scoped edition authorization, feedback snapshot, source digest, review evidence, exact-head CI, bunker config, and npubs.
-2. Re-read the recorded PR number and require the expected head SHA, base SHA, and prepared prospective merge tree under the server current-base guard.
-3. Merge with the expected-head precondition and verify the resulting merge tree.
+2. Re-read the recorded PR number and require the expected head SHA, base SHA, and prepared prospective merge tree under the race-free current-base guard.
+3. Prefer strict server status checks; when repository-admin protection is unavailable, use the pipeline's verified fast-forward git-ref compare-and-swap, which rejects a moved base. Verify the resulting merge tree in either case.
 4. Wait for and verify the Hugo deployment attributable to that merge SHA and the exact served content.
 5. Build the NIP-23 payload via `scripts/publish.ts`, then sign and broadcast kind:30023 via Amber to `publish/config/relays.json`, including `sendit.nosflare.com` only as a write-only NIP-66 blaster; recover the exact event from at least five durable relays.
 6. Sign and broadcast kind:1 to the same broad set and independently recover the exact event from at least five durable relays; blaster acceptance does not count as persistence.

--- a/skills/_COMPASS/agents/PublishAgent.md
+++ b/skills/_COMPASS/agents/PublishAgent.md
@@ -111,10 +111,13 @@ The publish does not proceed while there are unresolved missing npubs that the u
 Run the repository publication entry point with the exact recorded identity and
 the current authorization, feedback, and quality receipts. First call merge
 without mutation so it records the same prospective tree under the server
-current-base guard. Then call merge with `--really-merge`; it uses GitHub's
-expected-head precondition and refuses any PR, head, base, prospective-tree,
-authorization, hold, source, feedback, review, or CI mismatch. Never infer a PR
-from the current branch and never merge through an ad-hoc `gh pr merge` command.
+current-base guard when available. If repository-admin protection is unavailable,
+the pipeline verifies GitHub's exact prospective merge commit and uses a
+fast-forward git-ref compare-and-swap; Git rejects it if the base moved. Then call
+merge with `--really-merge`; either route refuses any PR, head, base,
+prospective-tree, authorization, hold, source, feedback, review, or CI mismatch.
+Never infer a PR from the current branch and never merge through an ad-hoc
+`gh pr merge` command.
 
 After the merge is authoritatively confirmed, run the deploy stage. It selects
 the Pages run attributable to the recorded merge SHA and verifies the canonical


### PR DESCRIPTION
The weekly publisher currently requires repository-admin access to verify strict branch protection before merging. The authenticated Compass account has write access, so that safe-path requirement blocks otherwise authorized editions.

This keeps strict server protection as the preferred path. When it is unavailable, the publisher now verifies GitHub's exact prospective merge commit, checks its base/head/tree identities, and updates the base ref with an expected-old-SHA lease. Any base movement rejects the update instead of racing it.

Validation:

- `bun test publish` — 117 passed, 0 failed
- `git diff --check`
