### PR TITLE
Add translations for Newsletter #39 and topic pages

### DIFF
--- a/content/de/newsletters/2026-09-09-newsletter.md
+++ b/content/de/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 begleitet signierte Git-Workflows, Veröffentlichung im Browser, selbst gehostete Livestreams, Relay-Einwilligung in Communities, private Veranstaltungen, fokussierte Releases und den NIP-21/NIP-27-Linkvertrag."
+---
+
+Willkommen zurück bei [Nostr Compass](https://nostrcompass.org), deinem wöchentlichen Wegweiser durch Nostr.
+
+**Diese Woche:** [ngit und GitWorkshop](https://ngit.dev/v3) bringen signierte Git-Workflows auf Nostr und [Blossom](/de/topics/blossom/), [nsite-clay](https://github.com/jooray/nsite-clay) macht das Veröffentlichen im Browser wiederherstellbar, und die [Wingman App](https://github.com/OtherStuffAI/wm-app) verbindet Browsing, lokale Signierung, Authentifizierung und Dateien. [Shosho und Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) verbinden selbst gehostete Streams mit Nostr, [Communitator](https://github.com/dyne/communitator) macht Relay-Vorlagen vor der Signierung prüfbar, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) veröffentlicht Terminslots, und [Plektos](https://github.com/derekross/plektos/pull/16) verschlüsselt private Veranstaltungen. Getaggte Releases bringen Arbeit an Wiederherstellung und Privatsphäre in [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) und [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). Die Entwicklungsarbeit umfasst [NIP-27](/de/topics/nip-27/)-Rendering, signierte Relay-Einstellungen in [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), [NIP-A3](/de/topics/nip-a3/)-Zahlungsziele und Blossom-Mirrors. Gemergte Änderungen im [NIPs-Repository](https://github.com/nostr-protocol/nips) präzisieren reine Live-Abonnements und authentifizierte Anwendungsdaten. Unser Deep Dive erklärt, wie [NIP-21](/de/topics/nip-21/)-Links und NIP-27-Referenzen Nostr-Profile und -Events über Anwendungen hinweg transportieren.
+
+## Top-Storys
+
+### Signierte Git-Workflows bringen CI, private Repositories und Releases auf Nostr
+
+Der [v3-Launch vom 8. September](https://ngit.dev/v3) vereint ngit, GitWorkshop, ngit-grasp und ngit-ci in einem signierten Workflow. [ngit](https://ngit.dev/ngit.git) überträgt Branches, Patches und Pull Requests als [NIP-34](/de/topics/nip-34/)-Events, während [GitWorkshop](https://ngit.dev/gitworkshop.git) die Review-Oberfläche bereitstellt. Der Launch ergänzt ngit-ci 0.1, einen selbst gehosteten Continuous-Integration-Dienst, dessen Anweisungen und Ergebnisse als signierte Nostr-Events übertragen werden, sodass Checks auf von Maintainern kontrollierter Hardware parallel zur Code-Review laufen können.
+
+Derselbe Release bringt [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) private Repositories über die GRASP-08-Erweiterung für private Repositories und macht die Autorität der Maintainer explizit. Signierte Release-Einträge können auf Assets in [Blossom](/de/topics/blossom/) verweisen, wodurch sowohl Release-Metadaten als auch inhaltsadressierte Dateien außerhalb einer gehosteten Forge bleiben. Die [neue Dokumentationsseite](https://ngit.dev/v3) bündelt die Client-, Private-Repository-, CI- und Web-Komponenten.
+
+### nsite-clay macht das Veröffentlichen im Browser wiederherstellbar
+
+Eine [Signer-Prompt-Korrektur vom 31. August](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), die [Wiederherstellung von Veröffentlichungen](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) und die [Bearbeitungssteuerung vom 2. September](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) machen [nsite-clay](https://github.com/jooray/nsite-clay) zu einem Veröffentlichungswerkzeug im Browser für eine Single-Page-Site. Ein Nutzer bearbeitet das Document Object Model direkt, serialisiert das Ergebnis, lädt es als inhaltsadressiertes [Blossom](/de/topics/blossom/)-Blob hoch und veröffentlicht das [NIP-5A](/de/topics/nip-5a/)-Manifest der Site neu. Kein lokaler Build oder Server ist erforderlich.
+
+Der [Browser-Publisher](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) macht fehlgeschlagene Veröffentlichungen nun wiederherstellbar und reduziert wiederholte Signer-Abfragen, während der [Bearbeitungsleitfaden](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) den Ablauf dokumentiert. Das Ergebnis bleibt für bestehende Gateways eine gewöhnliche NIP-5A-Site.
+
+### Wingman App verbindet Browsing, Signierung und Dateien
+
+Die Arbeiten im September ergänzen die [Wingman App](https://github.com/OtherStuffAI/wm-app) um [Datei-Dialoge](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), [Profilveröffentlichung](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), [sicheren Signer und Sitzungswiederherstellung](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) sowie [getestete mobile Builds](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac). Ihre Flutter-Shell injiziert einen [NIP-07](/de/topics/nip-07/)-Provider in Seiten, die innerhalb der App geöffnet werden, während Flight Deck und das Tower-gestützte Drive eine Arbeitsfläche und einen Datei-Arbeitsbereich neben dem Browser bereitstellen.
+
+Wingman signiert authentifizierte HTTP-Anfragen mittels [NIP-98](/de/topics/nip-98/). Die [Anfrage-Implementierung](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) erstellt das Event, das ein Server vor der Antwort verifiziert, und gibt einer installierten Identität damit einen konsistenten Genehmigungsweg für Relay-Aktionen, Web-App-Signierung und Dateien.
+
+### Shosho liefert Liveliers selbst gehostete Streams
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) erschien am 1. September mit Unterstützung für [Livelier](https://github.com/r0d8lsh0p/livelier), dessen [Attributions-Update vom 31. August](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) die Bridge und die Owncast-Quelle in überbrückten Profilen kennzeichnet. Livelier beobachtet das öffentliche Verzeichnis von Owncast, prüft, ob ein Videostream live ist, und veröffentlicht dann ein adressierbares `kind:30311`-Ereignis nach [NIP-53](/de/topics/nip-53/). Die Entdeckung läuft über Nostr, während das Video auf dem Server des Streamers bleibt.
+
+Der Chat durchquert die Bridge als `kind:1311`-Ereignisse. Das [Bridge-Design](https://github.com/r0d8lsh0p/livelier) öffnet eine quellseitige Verbindung nur, solange ein Nostr-Reader abonniert ist, kennzeichnet abgeleitete Identitäten und sendet flüchtige Chats an ein Relay, das sie nach drei Stunden löscht. Das Discovery-Relay akzeptiert Schreibzugriffe für Live-Ereignisse nur vom Bridge-Schlüssel; das Chat-Relay verwendet [NIP-42-Authentifizierung](/de/topics/nip-42/) und [NIP-70-Flags für geschützte Ereignisse](/de/topics/nip-70/).
+
+### Communitator macht Relay-Vorlagen vor der Signierung überprüfbar
+
+Die [Veröffentlichungsserie vom 31. August](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) stattet [Communitator](https://github.com/dyne/communitator) mit kanonischen Vorlagen für Relay-Listen der Art `10002`, Blossom-Server der Art `10063` und Posteingänge für private Nachrichten der Art `10050` aus. Bevor ein Signer verbunden wird, zeigt die Anwendung normalisierte Endpunkte, Lese- und Schreibberechtigungen, Ereignisarten, feste Veröffentlichungs-Relays und Ziele an.
+
+Der [begrenzte Signier- und Veröffentlichungsablauf](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) trennt das Verbinden vom Anwenden. Jedes Ereignis wird einzeln signiert, ein Durchlauf nutzt höchstens vier WebSocket-Verbindungen, und ein Ziel zählt erst nach einem positiven [NIP-01](/de/topics/nip-01/)-`OK`. Die Ergebnisse unterscheiden zwischen vollständiger, teilweiser, fehlgeschlagener und abgebrochener Zustellung. Geteilte Vorlagen bleiben unvertrauenswürdige Empfehlungen; die [Zustimmungsoberfläche](https://github.com/dyne/communitator#security-and-consent) erläutert die Beobachtbarkeit von Relays und Netzwerk.
+
+### cal.emre.xyz veröffentlicht Terminverfügbarkeit nach NIP-52
+
+Das öffentliche Repository wurde mit einem [ersten Commit vom 2. September](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) eröffnet, gefolgt von einer signierten [Handler-Ankündigung vom 3. September](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) für [cal.emre.xyz](https://cal.emre.xyz). Ein Gastgeber veröffentlicht Verfügbarkeit als `kind:31923`-Ereignis nach [NIP-52](/de/topics/nip-52/); ein Gast veröffentlicht eine `kind:31925`-RSVP.
+
+Es liest Gastgeber-Ereignisse und akzeptierte Besetzt-RSVPs von Relays, schließt sich überschneidende Zeitspannen aus und behält Nostr-Ereignisse als Terminplanungsaufzeichnung bei, ohne sie in eine separate Datenbank zu kopieren. Gastgeber können mit [NIP-07](/de/topics/nip-07/), [NIP-46](/de/topics/nip-46/) oder einem lokalen Schlüssel signieren; Gäste können einen separaten Schlüssel erzeugen. Das [Repository](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) stellt außerdem die resultierenden `naddr`- und Kalender-Links bereit, wobei E-Mail standardmäßig deaktiviert ist.
+
+### Plektos macht private Veranstaltungen zu einem verschlüsselten Kanal
+
+Die [Implementierung privater Veranstaltungen vom 2. September](https://github.com/derekross/plektos/pull/12) macht jede [Plektos](https://github.com/derekross/plektos)-Zusammenkunft zu einem privaten Kanal innerhalb einer mit [Concord](/de/topics/concord-protocol/) verschlüsselten Community. Gästeliste, RSVP-Liste, Anmeldeboard, Thread, Beiträge, Titelbilder, Bearbeitungen und Löschungen werden gemeinsam verschlüsselt; eine Einladung enthält nur den Schlüssel des jeweiligen Ereignisses, und es wird kein Klartext-Kalenderereignis veröffentlicht.
+
+Das [Lebenszyklus-Audit vom 6. September](https://github.com/derekross/plektos/pull/14) verankert die ID der Ereignisdefinition für den direkten Abruf, wenn mehr als 500 Wraps existieren, und behält zugleich einen paginierten Fallback bei. Einladungspakete laufen 30 Tage nach dem Ende eines Ereignisses ab und können deaktiviert werden, doch wer einen Kanalschlüssel bereits erhalten hat, kann ihn behalten. Eine separate [Parser-Sicherheitsreparatur](https://github.com/derekross/plektos/pull/16) sorgt dafür, dass fehlerhafte Type-Length-Value (TLV)-[NIP-19](/de/topics/nip-19/)-Bezeichner fehlschlagen, statt den Parser festzuhängen.
+
+## Releases
+
+### Vector 0.4.4 macht die Wiederherstellung verschlüsselter Communities sicherer
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) erschien am 31. August mit Korrekturen für Community-Wiederherstellung, Schlüsselrotation, Moderation und Antwort-Routing. Die Neugründung schließt eine angegriffene Community für den Einladungspfad, den Angreifer genutzt haben; der Ersatz der Mitgliedschaft ersetzt veralteten lokalen Zustand; und ein einzelnes unerreichbares Mitglied friert die Liste nicht mehr ein. Leere Rotationen werden abgelehnt, Beförderungen erhalten online befindliche Mitglieder, und Operationen verweigern die Ausführung, wenn erforderliche Mitglieder nicht erreichbar sind.
+
+Die [Veröffentlichung](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) persistiert außerdem Löschungen und Sperren durch Moderatoren, verschlüsselt das Gästebuch nach einer Passwortänderung neu, bindet Benachrichtigungsantworten nach einem Neustart an ihre Konversation und verwendet ausschließlich verifizierte Mehrspieler-Pfade. Es handelt sich um Wiederherstellungskontrollen, nicht um den Widerruf bereits erlangter Schlüssel.
+
+### Primal Android 3.5.27 prüft Signer- und Wallet-Identität
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) erschien am 3. September, nachdem [die Signer-Identitätsprüfung](https://github.com/PrimalHQ/primal-android-app/pull/1108) und [die Wallet-Anfrage-Authentifizierung](https://github.com/PrimalHQ/primal-android-app/pull/1105) am 31. August gemergt wurden. Die lokale Signierung lehnt eine Anfrage ab, deren Identität nicht zum gehaltenen Konto passt, und eingehende [NIP-47](/de/topics/nip-47/)-Anfragen werden vor der Verarbeitung authentifiziert. Das Zap-Poll-Routing sendet Stimmen außerdem an den Autor der Umfrage, wenn die Umfrage in einer Antwort erscheint.
+
+### GRAIN 0.8.0-rc2 schließt einen Pfad, der bestätigt, aber nicht gespeichert wird
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) erschien am 7. September, nachdem ein Speicherfehler ein `OK` erlaubt hatte, bevor deren asynchroner LMDB-Datenbank-Writer die volle Speicherkapazität bemerkte. Der Relay warnt jetzt bei 80 und 95 Prozent, verweigert neue Events bei 97 Prozent, lässt aber Raum für Löschungen, und meldet Writer-Fehler nach der Annahme. Die Retention läuft vom ältesten zum neuesten Eintrag, das Teardown behandelt späte Nachrichten, und ungültige Filter verwerfen keine gültigen Geschwister mehr.
+
+Das [Release](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) bestätigt außerdem Monitor-Ankündigungen von Kind `10166` und Relay-Reports von Kind `30166`, entfernt veraltete Reports, behält konfigurierte Relays als Fallback und meldet Live-Limits und Authentifizierung in [NIP-11](/de/topics/nip-11/) statt statischer Nullen.
+
+### LibreNostr 0.5.0–0.5.2 macht Tor-Routing fail-closed
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) erschien am 7. September mit einem Orbot-Modus, der Relays, Zaps, Uploads, Medien, Wiedergabe und Vorschauen über einen SOCKS-Port leitet, plus einer Reparatur für einen Zap-Sheet-Absturz. Wenn Orbot oder der Proxy nicht verfügbar ist, stoppen Verbindungen, anstatt auf eine direkte Route zu leaken. [Version 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) verhindert, dass langsame [NIP-50](/de/topics/nip-50/)-Suchen lokale Ergebnisse verzögern; [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) ersetzt das rekursive Thread-Layout und repariert die Thread-Reihenfolge.
+
+Das [Fail-Closed-Verhalten](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) gilt für jede im Release aufgeführte Netzwerkfläche, und ein Neustart ist erforderlich, weil diese Clients langlebig sind. Die Patch-Releases bewahren diese Wahl, begrenzen zugleich aber unzusammenhängende Such-, Stack-Tiefen- und Layout-Fehler.
+
+### SkateSpots fügt einen On-Device-Relay-Pfad hinzu
+
+Der signierte [Zapstore-Release vom 8. September](https://zapstore.dev/apps/org.skatespots.app) fügt SkateSpots einen optionalen Citrine-Relay hinzu. Spots, Crews, Nachrichten und Kartendaten können lokal geladen werden; Beiträge werden offline in die Warteschlange gestellt; und das Telefon behält eine lokale Kopie. Bestehende Stash- und Nachrichteninhalte bleiben Ende-zu-Ende-verschlüsselt. Zahlungsprüfungen verlangen Rechnungsbeträge und vom Anbieter ausgestellte Zap-Receipts, bevor Zugriff gewährt oder Beiträge gezählt werden.
+
+Der [lokale Relay](https://zapstore.dev/apps/org.skatespots.app) ist eine Speicher- und Kontinuitätsoption, kein Ersatz für jeden Remote-Relay. Er lässt einen Skater durch eine unverbundene Phase weiterarbeiten und später signierte Aktivität abgleichen, während die Zahlungsänderungen verhindern, dass ein selbsterstellter Receipt zum Nachweis der Abrechnung wird.
+
+### Whistle 1.8.15 repariert die Recovery des Lebenszyklus verschlüsselter Gruppen
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) erschien am 3. September, nachdem eine Android-Lebenszyklus-Reparatur verhinderte, dass route-ebene State-Holder anwendungsweite Relay-Subscriptions und Standortupdates zerstören. Die Release-Notes beschreiben außerdem aktualisierten Verbindungsstatus nach Sperre oder Doze sowie einen im beobachteten Fall zurückgewonnenen 501-Event-Backlog.
+
+Der [Bug](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) band den Besitz eines langlebigen Dienstes an einen kurzlebigen Bildschirm. Die aktivitätsbezogene Instanz am Leben zu halten und den Socket vor einem Einmal-Lesezugriff zu prüfen, macht es weniger wahrscheinlich, dass gewöhnliche Android-Navigation und Hintergrund-Suspendierung wie eine leere Gruppe aussehen.
+
+### TWENTY ONE Companion 1.12.0 trennt verschlüsselte DMs von Legacy-Chat
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) erschien am 5. September mit gift-wrapped DMs nach [NIP-17](/de/topics/nip-17/). Der verschlüsselte Posteingang ist von älterem Space-Chat getrennt, der eigen bleibt, weil diese Nachrichten nie verschlüsselt waren und nicht migriert werden können. PDFs und Videos werden unter Vorbehalt der Relay-Richtlinie unterstützt, und persönliche Verbergungen synchronisieren, ohne zu Moderator-Bans zu werden.
+
+Die [sichtbare Trennung](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) ist Teil des Sicherheitsmodells. Die alte Historie als sicheren Posteingang zu bezeichnen, würde deren Herkunft falsch darstellen, während eine stille Migration eine Verschlüsselung suggerieren würde, die bei deren Erstellung nicht existierte.
+
+### ZapStore 1.1.2 validiert Event-Ids und Zertifikatsrotation
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) erschien am 4. September mit NIP-01-Event-Id-Validierung: Der Client berechnet die Id eines eingehenden Events neu und lehnt Abweichungen vor der Verwendung ab. Das Release identifiziert außerdem Pakete, die außerhalb von ZapStore installiert wurden. Auf dem Server bewahrt die [Zertifikat-Hash-Retention](https://github.com/zapstore/relay/pull/8) wiederholte `apk_certificate_hash`-Tags, sodass die Rotation des Android-Signierschlüssels eine genehmigte Herkunft bewahren kann.
+
+Die [Event-Id-Prüfung](https://github.com/zapstore/zapstore/releases/tag/1.1.2) verhindert, dass ein Relay oder Cache Tags oder Inhalt ändert, während die alte Id behalten wird. Der Installationsquellen-Indikator liefert separate Herkunft, wenn ein Android-Paket mit gleicher Anwendungs-Id aus einem anderen Kanal stammt.
+
+### Amber 6.6.1 hält Signer-Antworten zuordenbar
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) erschien am 4. September, nachdem das Berechtigungs-Parsing so repariert wurde, dass ein fehlendes optionales `kind` toleriert wird, und abgelehnte Signieranfragen begannen, ihren ursprünglichen Anfrage-Id zurückzugeben. Aufrufende Anwendungen können eine Ablehnung der eingereichten Operation zuordnen. Das Release aktualisiert außerdem Remote-Signer-Standardeinstellungen und fügt einen Indexer-Relay hinzu.
+
+Gemeinsam bewahren diese [Fixes](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) die Zuordnung in beide Richtungen: Ein Berechtigungseintrag bleibt nutzbar, wenn ein optionales Feld fehlt, und eine Ablehnung bleibt an die auslösende Anfrage gebunden. Die Änderungen der Relay-Standardeinstellungen betreffen die Discovery, ersetzen aber nicht die lokale Autorisierungsentscheidung des Signers.
+
+## Unveröffentlichte Änderungen
+
+### Zap Cooking rendert NIP-27-Referenzen mit Relay-Hinweisen
+
+[Der Merge vom 4. September](https://github.com/zapcooking/frontend/pull/665) sorgt dafür, dass [Zap Cooking](https://github.com/zapcooking/frontend) `nostr:npub`- und `nostr:nprofile`-Referenzen in Artikeln, Rezepten, Editor-Vorschauen und Druckansichten rendert. Ungültige Bezeichner bleiben Text, die Auflösung erfolgt nicht-blockierend, und der Editor zeigt eine Vorschau des Markdowns, das signiert wird. Wenn Relay-Informationen vorhanden sind, wird aus einem nackten `npub` ein `nprofile` mit Outbox-Relays und einem passenden `p`-Tag.
+
+In derselben Woche wurden [autorenbezogene Kind-`30023`-Abfragen](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7) korrigiert, [verifizierte NIP-50-Suchrelays](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea) mit Deduplizierung und Schutz vor veralteten Abfragen hinzugefügt und [NIP-47-Wallet-Aufrufe](https://github.com/zapcooking/frontend/pull/705) repariert, nachdem Änderungen an Abhängigkeiten Guthaben und Verlauf beschädigt hatten.
+
+### Conduit gleicht signierte Relay- und Blossom-Einstellungen ab
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) hat am 2. September die [Bearbeitung von Blossom-Einstellungen](https://github.com/Conduit-BTC/conduit-mono/pull/374) und am 7. September den [Abgleich signierter Einstellungen](https://github.com/Conduit-BTC/conduit-mono/pull/397) gemergt. Market und Merchant behalten die neueste gültige Kind-`10002`-Relay-Liste und die Kind-`10050`-Inbox-Deklaration, bewahren eine nutzbare signierte Liste, wenn ein neueres Event fehlerhaft ist, unterscheiden eine explizit leere Liste von einer nicht verfügbaren Abfrage und ersetzen fehlgeschlagene deklarierte Relays nicht durch Code-Standardwerte.
+
+Der [Kind-`10063`-Editor](https://github.com/Conduit-BTC/conduit-mono/pull/374) ermöglicht es einem Nutzer, eine geordnete HTTPS-Medienserver-Liste zu laden, neu zu ordnen, zu prüfen, extern zu signieren, zu veröffentlichen und zurückzulesen, ohne diese Server zu kontaktieren oder einen nicht deklarierten Standardwert einzufügen.
+
+### NIP-A3-Zahlungsziele erreichen drei Clients
+
+Vom 1. bis 3. September haben [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) und [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) NIP-A3-Zahlungsziele vom Kind `10133` implementiert. Amethyst bietet eine optionale Übergabe nur an, wenn ein kompatibles Ziel existiert, und verwandelt sie nicht in einen Zap; Grimoire nutzt eine feste Registry, bevor Wallet-URIs erstellt werden; Pollerama validiert Monero-Adressen und ruft die Relay-Liste des Autors ab, bevor Ziele abgefragt werden. Jeder Client benötigt weiterhin eine erlaubte Zahlungsmethode, eine Relay-Route und eine korrekte Anzeige.
+
+### Ditto erweitert Blossom-Fallback und Live-Einbettungen
+
+[Ditto](https://github.com/soapbox-pub/ditto) hat am 6. September [breiten Blossom-Fallback und Mirroring](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) gemergt. Avatare, Badges, Banner, Community-Bilder, benutzerdefinierte Emojis und Anwendungssymbole versuchen nun deklarierte Server mit demselben Blob-Hash; Mirror-Uploads verwenden ein standardmäßiges BUD-11-Autorisierungstoken. Eine [Änderung vom 4. September](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) fügte kompakte `kind:30311`-Livestream-Einbettungen hinzu.
+
+## NIP-Aktualisierungen und Arbeit an Protokollspezifikationen
+
+### Nostr Implementation Possibilities
+
+[NIP-01](/de/topics/nip-01/) präzisiert nun [den `limit: 0`-Filter](https://github.com/nostr-protocol/nips/pull/2460), gemergt am 4. September. Ein Relay MUSS keine gespeicherten Events zurückliefern, MUSS `EOSE` senden, sobald die initialen Abfragen abgeschlossen sind, und MUSS das Abonnement für neue passende Events aktiv halten. Clients können mit einem einzigen Filterfeld ein reines Live-Abonnement öffnen und dabei den lokalen Verlauf behalten. Die Klarstellung dokumentiert kompatibles Verhalten über mehrere Relay-Implementierungen und öffentliche Relays hinweg.
+
+[NIP-78](/de/topics/nip-78/) erhielt eine [Anforderung für authentifizierte App-Daten](https://github.com/nostr-protocol/nips/pull/2458), gemergt am 3. September. Relays SOLLTEN [NIP-42](/de/topics/nip-42/)-Authentifizierung für die Kinds `78` und `30078` verlangen und SOLLTEN diese nur an den authentifizierten Event-Autor ausliefern. Das ist ein SOLLTE, keine Vertraulichkeitsgarantie: Clients können beliebige Relays nicht als privaten Speicher behandeln. Der Merge rät außerdem davon ab, benutzerdefinierte App-Daten-Kinds als generischen öffentlichen Austausch zu verwenden.
+
+[NIP-AC](/de/topics/nip-ac/) wurde am 4. September als ausdrücklich offener [WebRTC-Signalisierungsvorschlag](https://github.com/nostr-protocol/nips/pull/2461) eröffnet. Er verwendet vorläufige ephemere Kinds für Ping, Verbindungsanfragen, Angebote, Antworten und ICE-Kandidaten, adressiert mit `p` und gruppiert über ein Sitzungs-`e`-Tag; Kind `30600` unterstützt die Auffindbarkeit. Relays SOLLTEN diese Signalisierungs-Events weiterverbreiten und DÜRFEN sie NICHT speichern, während Peers sich direkt verbinden. Die Nummern bleiben vorläufig, Clients SOLLTEN [NIP-65-Relay-Listen](/de/topics/nip-65/) verwenden, und Anwendungen, die Vertraulichkeit benötigen, SOLLTEN Angebots-, Antwort- und Kandidateninhalte mit [NIP-44](/de/topics/nip-44/) verschlüsseln.
+
+## NIP Deep Dive: URI-Links und Referenzen im Event-Text
+
+Ein Nostr-Bezeichner braucht eine transportierbare Bedeutung, bevor eine andere Anwendung ihn öffnen kann. [NIP-21](/de/topics/nip-21/) setzt einen [NIP-19](/de/topics/nip-19/)-Bezeichner hinter das `nostr:`-URI-Schema und gibt Browsern, Betriebssystemen und Anwendungen damit eine einzige weiterleitbare Form. [NIP-27](/de/topics/nip-27/) definiert, was dasselbe URI innerhalb eines lesbaren Event-`content` bedeutet. NIP-21 überschreitet eine Anwendungsgrenze; NIP-27 hält eine Profil- oder Event-Referenz in signiertem Fließtext. Keines der beiden erzeugt ein Event-Kind oder ändert Relay-Nachrichten; die [beiden Spezifikationen](https://github.com/nostr-protocol/nips/tree/master) definieren ausschließlich Verlinkungs- und Darstellungsverhalten.
+
+### URI-Dispatch und NIP-19-Semantik
+
+[Die Grammatik von NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) besteht aus `nostr:` gefolgt von einer NIP-19-bech32-Entität. `nsec` ist ausgeschlossen, da es einen privaten Schlüssel kodiert. Es gibt keine Authority-, Pfad- oder Query-Komponente, daher ist ein konformer Link `nostr:npub1...` und nicht `nostr://npub1...`. Eine Plattform oder ein Client kann sich als Handler registrieren; die Spezifikation wählt weder die installierte Anwendung aus noch definiert sie einen Web-Fallback.
+
+Das Präfix teilt einem Client mit, was zu dekodieren ist. `npub` enthält einen öffentlichen Schlüssel und `note` eine Event-ID. `nprofile` fügt einem Profil optionale Relay-Hinweise hinzu; `nevent` ergänzt eine Event-ID um Relays, Autor und Kind; und `naddr` enthält Autor, Kind und die `d`-Kennung eines adressierbaren Events, mit optionalen Relays. Diese Formen verwenden [NIP-19-Type-Length-Value-Felder](https://github.com/nostr-protocol/nips/blob/master/19.md). Hinweise grenzen die Auffindbarkeit ein, beweisen aber weder den Besitz des Relays noch die Kontrolle des Autors. Jedes abgerufene Event erfordert weiterhin eine Neuberechnung der ID und eine Signaturprüfung.
+
+Die Profilform in der [NIP-21-Spezifikation](https://github.com/nostr-protocol/nips/blob/master/21.md) lautet:
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definiert außerdem HTML-Brücken: Eine Seite, die ein Nostr-Event ausliefert, kann dessen `naddr` in `<link rel="alternate">` einbetten, und ein Profil kann ein `nprofile` in `<link rel="me">` oder `<link rel="author">` einbetten.
+
+### NIP-27-Rendering und optionale Tags
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) gilt für lesbaren Event-Inhalt wie Notizen des Kinds `1` und Artikel des Kinds `30023`. Ein Composer kann `@name` anzeigen, veröffentlicht aber `nostr:nprofile1...` im signierten String. Ein Reader scannt die URI, dekodiert ihre NIP-19-Entität, ruft das Ziel ab und kann einen Namen, eine Karte, eine Vorschau oder einen lokalen Link rendern. Schlägt die Dekodierung fehl, bleibt die URI gewöhnlicher Text. Der Rohinhalt darf nicht umgeschrieben werden: Eine Änderung verändert die NIP-01-Serialisierung, die ID und die Signatur.
+
+Inhaltsreferenzen und Tags haben verwandte, aber unterschiedliche Aufgaben. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) beschreibt optionale `p`- und `e`-Tags sowie den `q`-Tag aus [NIP-18](/de/topics/nip-18/). Ein Client kann eine Referenz anzeigen, ohne eine Benachrichtigung oder eine Thread-Beziehung zu erzeugen; die Ermittlung von Zitaten sollte sowohl die URI als auch ein `q`-Tag schreiben. [Die Implementierung von Zap Cooking vom 4. September](https://github.com/zapcooking/frontend/pull/665) folgt dieser Trennung, indem die URI beibehalten und gleichzeitig Relay-Hinweise sowie ein passendes `p`-Tag hinzugefügt werden. Das Hinzufügen von `p` oder `q` macht die URI nicht privat, und NIP-27 kennt keinen Modus für versteckte Erwähnungen.
+
+Das folgende [Event des Kinds `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) wurde von `wss://nos.lol` wiederhergestellt und vor der Aufnahme als konkrete NIP-27-Referenz verifiziert. Sein `content` enthält ein `naddr` für ein versionsunabhängiges adressierbares Event. Die Dekodierung ergibt Kind `30402`, den Autor `91036d...310a`, die `d`-Kennung des Workbooks und einen Hinweis auf `wss://nos.lol/`. Die Tags `q`, `p`, `t`, `zap` und `client` sind Entscheidungen der Anwendung, keine Anforderungen von NIP-27.
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Vertrauen, Fehlerverhalten und Client-Implementierungen
+
+Ein sicherer Parser findet ein vollständiges `nostr:`-Token, validiert bech32, dekodiert NIP-19, weist `nsec` zurück, ignoriert unbekannte TLV-Typen und lässt fehlerhaften oder übergroßen Text unverändert. `npub` und `nprofile` führen zu Profilabfragen; `note` und `nevent` identifizieren unveränderliche Events; `naddr` wählt das neueste gültige adressierbare Event für seinen Kind, Autor und `d`-Tag aus. Relay-Hinweise verringern den Suchaufwand, erweitern aber nicht das Vertrauen. Gemäß den [NIP-01-Event-Regeln](https://github.com/nostr-protocol/nips/blob/master/01.md) verifiziert der Client die ID eines abgerufenen `nevent` und prüft jede Signatur eines `naddr`-Kandidaten, bevor er die Ersetzungsregeln für adressierbare Events anwendet.
+
+Inline-Vorschauen sind eine Entscheidung des Clients mit Kosten für Privatsphäre und Ressourcen. Das Abrufen jeder Referenz offenbart die Interessen des Lesers und kann einen Anfragesturm auslösen, daher können Clients einen Cache verwenden, Abrufe bis zur Sichtbarkeit aufschieben, die Parallelität begrenzen und für unbekannte Medien einen Klick verlangen. Gemäß [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) muss eine Vorschau vom signierten Text des aktuellen Autors unterscheidbar bleiben. Ein Fehlschlag sollte als unaufgelöster Text oder nicht verfügbare Karte sichtbar sein, nicht stillschweigend als verifizierter Inhalt behandelt werden.
+
+Das Vertrauen ändert sich auch je nach Identifikatortyp. Ein `nevent` bezeichnet unveränderliche Bytes, daher kann ein Client ein abgerufenes Event zurückweisen, dessen serialisierte ID von der angeforderten ID abweicht. Ein `naddr` bezeichnet eine ersetzbare Koordinate, daher muss ein Client jeden Kandidaten verifizieren und die Regeln für adressierbare Events anwenden, bevor er entscheidet, welche Version angezeigt wird. Ein Relay-Hinweis ist in beiden Fällen für die erste Abfrage nützlich, aber keine Empfehlung für das Relay oder den zurückgegebenen Inhalt. Die [TLV-Definition von NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) liefert die Daten, die nötig sind, um diese Prüfungen explizit zu machen.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definiert einen portablen Link, der von außerhalb von Nostr geöffnet werden kann, während NIP-27 denselben Link innerhalb signierten Texts dauerhaft macht. Ein Client, der nur NIP-21 implementiert, kann einen eingefügten URI öffnen, aber keine eingebetteten Referenzen darstellen. Vollständige NIP-27-Unterstützung fügt Scanning, sicheres Dekodieren, Abrufstrategien, lokale Darstellung und eine explizite Entscheidung über Benachrichtigungs- und Zitat-Tags hinzu. Der gemeinsame URI hält diese Ebenen interoperabel, ohne Clients zu zwingen, sie identisch darzustellen. [Damus](https://github.com/damus-io/damus) modelliert Inline-Referenzen als typisierte Erwähnungen. Sein [Mention-Code](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) bildet `npub` und `nprofile` auf Profilreferenzen, `note` und `nevent` auf Event-Referenzen und `naddr` auf Adressreferenzen ab; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) leitet sie an das passende Ziel weiter. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [parst das Schema und eingefügte Formen](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), validiert bech32 und extrahiert Relay-Hinweise, und [bildet Referenzen anschließend auf Notizinhaltsmodelle ab](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) stellt dieselben Referenzen in Artikeln, Rezepten, Editor-Vorschauen und Druckansichten dar.
+
+---
+
+Sende eine NIP-17-DM, um ein Projekt oder eine Nachricht über das [Nostr-Compass-Projekt](https://github.com/andotherstuff/nostr-compass) zu teilen.

--- a/content/de/topics/nip-a3.md
+++ b/content/de/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Zahlungsziele"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 definiert eine portable Möglichkeit für ein Nostr-Konto, Zahlungsadressen für mehrere Netzwerke und Dienste zu veröffentlichen. Ein austauschbares Event der Art `10133` trägt ein oder mehrere `payto`-Tags.
+
+## Funktionsweise
+
+Jedes Tag hat die Form `["payto", "<type>", "<address>"]`. Der Typ wird kleingeschrieben, zum Beispiel `bitcoin`, `lightning` oder `monero`. Clients können bekannte Formate validieren und, sofern vorhanden, eine native Zahlungs-URI darstellen; unbekannte Typen greifen auf das `payto:`-URI-Schema aus RFC 8905 zurück.
+
+Das Event deklariert Ziele, keine abgeschlossene Zahlung und keinen Nostr-Zap. Clients entscheiden weiterhin selbst, welche Zahlungstypen sie unterstützen, wie sie eine Adresse validieren und wie deutlich sie das Ziel anzeigen, bevor sie es an ein Wallet übergeben.
+
+## Implementierungen
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) bietet eine optionale Zahlungsübergabe an, wenn ein kompatibles Ziel erkannt wird.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) bildet erlaubte Zieltypen auf Zahlungs-URIs ab.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) validiert Monero-Ziele und fragt die Relays des Autors ab.
+
+---
+
+**Primärquellen:**
+- [NIP-A3-Spezifikation](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: Das payto-URI-Schema](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Erwähnt in:**
+- [Newsletter Nr. 39: NIP-A3-Zahlungsziele erreichen drei Clients](/de/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Siehe auch:**
+- [NIP-47: Nostr Wallet Connect](/de/topics/nip-47/)

--- a/content/es/newsletters/2026-09-09-newsletter.md
+++ b/content/es/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 sigue los flujos de trabajo de git firmados, la publicación desde el navegador, las retransmisiones en directo autoalojadas, el consentimiento de relays comunitarios, los eventos privados, los lanzamientos enfocados y el contrato de enlaces NIP-21/NIP-27."
+---
+
+Bienvenidos de nuevo a [Nostr Compass](https://nostrcompass.org), tu guía semanal de Nostr.
+
+**Esta semana:** [ngit y GitWorkshop](https://ngit.dev/v3) llevan los flujos de trabajo de git firmados a Nostr y [Blossom](/es/topics/blossom/), [nsite-clay](https://github.com/jooray/nsite-clay) hace recuperable la publicación desde el navegador, y [Wingman App](https://github.com/OtherStuffAI/wm-app) une la navegación, la firma local, la autenticación y los archivos. [Shosho y Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) conectan retransmisiones autoalojadas con Nostr, [Communitator](https://github.com/dyne/communitator) hace que las plantillas de relays sean inspeccionables antes de firmar, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) publica franjas de citas, y [Plektos](https://github.com/derekross/plektos/pull/16) cifra eventos privados. Los lanzamientos etiquetados añaden trabajo de recuperación y privacidad en [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) y [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). El trabajo de desarrollo abarca el renderizado de [NIP-27](/es/topics/nip-27/), las preferencias de relays firmadas en [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), los objetivos de pago de [NIP-A3](/es/topics/nip-a3/) y los espejos de Blossom. Los cambios fusionados en el [repositorio de NIPs](https://github.com/nostr-protocol/nips) aclaran las suscripciones solo en directo y los datos de aplicación autenticados. Nuestro análisis en profundidad explica cómo los enlaces de [NIP-21](/es/topics/nip-21/) y las referencias de NIP-27 transportan perfiles y eventos de Nostr entre aplicaciones.
+
+## Historias principales
+
+### Los flujos de trabajo de git firmados llevan la CI, los repositorios privados y los lanzamientos a Nostr
+
+El [lanzamiento de la v3 del 8 de septiembre](https://ngit.dev/v3) reúne ngit, GitWorkshop, ngit-grasp y ngit-ci en un único flujo de trabajo firmado. [ngit](https://ngit.dev/ngit.git) transporta ramas, parches y pull requests como eventos de [NIP-34](/es/topics/nip-34/), mientras que [GitWorkshop](https://ngit.dev/gitworkshop.git) proporciona la interfaz de revisión. El lanzamiento añade ngit-ci 0.1, un servicio de integración continua autoalojado cuyas instrucciones y resultados viajan como eventos firmados de Nostr, de modo que las comprobaciones pueden ejecutarse en hardware controlado por el mantenedor junto con la revisión del código.
+
+La misma versión da a [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) repositorios privados mediante la extensión de repositorios privados GRASP-08 y hace explícita la autoridad del mantenedor. Los registros de lanzamientos firmados pueden apuntar a recursos en [Blossom](/es/topics/blossom/), manteniendo tanto los metadatos de los lanzamientos como los archivos direccionados por contenido fuera de una forja alojada. El [nuevo sitio de documentación](https://ngit.dev/v3) reúne los componentes de cliente, repositorios privados, CI y web.
+
+### nsite-clay hace recuperable la publicación desde el navegador
+
+Una [corrección del aviso del firmante del 31 de agosto](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), la [recuperación de publicaciones](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) y los [controles de edición del 2 de septiembre](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) convierten a [nsite-clay](https://github.com/jooray/nsite-clay) en una herramienta de publicación en el navegador para un sitio de una sola página. Un usuario edita el modelo de objetos del documento directamente, serializa el resultado, lo sube como un blob de [Blossom](/es/topics/blossom/) direccionado por contenido y republica el manifiesto [NIP-5A](/es/topics/nip-5a/) del sitio. No se requiere compilación local ni servidor.
+
+El [publicador en el navegador](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) ahora hace que las publicaciones fallidas sean recuperables y reduce los avisos repetidos del firmante, mientras que la [guía de edición](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) documenta el ciclo. El resultado sigue siendo un sitio NIP-5A ordinario para las pasarelas existentes.
+
+### Wingman App une navegación, firma y archivos
+
+El trabajo de septiembre añade [selectores de archivos](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), [publicación de perfiles](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), [restauración segura del firmante y la sesión](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) y [compilaciones móviles probadas](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac) a [Wingman App](https://github.com/OtherStuffAI/wm-app). Su capa de Flutter inyecta un proveedor de [NIP-07](/es/topics/nip-07/) en las páginas abiertas dentro de la aplicación, mientras que Flight Deck y Drive, respaldado por Tower, proporcionan una superficie de trabajo y un espacio de archivos junto al navegador.
+
+Wingman firma las peticiones HTTP autenticadas usando [NIP-98](/es/topics/nip-98/). La [implementación de la petición](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) construye el evento que un servidor verifica antes de responder, dando a una identidad instalada una ruta de aprobación coherente para acciones de relays, firma en aplicaciones web y archivos.
+
+### Shosho incorpora las transmisiones autoalojadas de Livelier
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) se publicó el 1 de septiembre con soporte para [Livelier](https://github.com/r0d8lsh0p/livelier), cuya [actualización de atribución del 31 de agosto](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) identifica el puente y la fuente de Owncast en los perfiles puenteados. Livelier observa el directorio público de Owncast, comprueba si una transmisión de video está en vivo y luego publica un evento [NIP-53](/es/topics/nip-53/) direccionable `kind:30311`. El descubrimiento viaja sobre Nostr mientras el video permanece en el servidor del transmisor.
+
+El chat cruza el puente como eventos `kind:1311`. El [diseño del puente](https://github.com/r0d8lsh0p/livelier) abre una conexión del lado de la fuente solo mientras un lector de Nostr está suscrito, etiqueta las identidades derivadas y envía el chat transitorio a un relay que lo elimina después de tres horas. El relay de descubrimiento acepta escrituras de eventos en vivo solo desde la clave del puente; el relay de chat usa [autenticación NIP-42](/es/topics/nip-42/) y [banderas de eventos protegidos NIP-70](/es/topics/nip-70/).
+
+### Communitator hace inspeccionables las plantillas de relays antes de firmar
+
+La [serie de lanzamiento del 31 de agosto](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) otorga a [Communitator](https://github.com/dyne/communitator) plantillas canónicas para listas de relays de kind `10002`, servidores Blossom de kind `10063` y bandejas de entrada de mensajes privados de kind `10050`. Antes de que un firmante se conecte, la aplicación muestra endpoints normalizados, permisos de lectura y escritura, kinds de eventos, relays de publicación fijos y destinos.
+
+El [flujo de firma y publicación acotado](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) separa la conexión de la aplicación. Cada evento se firma por separado, una ejecución usa como máximo cuatro conexiones WebSocket, y un destino solo cuenta después de un `OK` positivo de [NIP-01](/es/topics/nip-01/). Los resultados distinguen entre entrega completa, parcial, fallida y cancelada. Las plantillas compartidas siguen siendo recomendaciones no confiables; la [superficie de consentimiento](https://github.com/dyne/communitator#security-and-consent) explica la observabilidad de relays y de red.
+
+### cal.emre.xyz publica disponibilidad de citas con NIP-52
+
+El repositorio público se abrió con un [commit inicial del 2 de septiembre](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743), seguido de un [anuncio firmado del manejador el 3 de septiembre](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) para [cal.emre.xyz](https://cal.emre.xyz). Un anfitrión publica su disponibilidad como un evento `kind:31923` de [NIP-52](/es/topics/nip-52/); un invitado publica un RSVP `kind:31925`.
+
+Lee los eventos del anfitrión y los RSVPs de ocupado aceptados desde los relays, excluye los intervalos de tiempo que se solapan y mantiene los eventos de Nostr como el registro de programación sin copiarlos a una base de datos separada. Los anfitriones pueden firmar con [NIP-07](/es/topics/nip-07/), [NIP-46](/es/topics/nip-46/) o una clave local; los invitados pueden generar una clave separada. Su [repositorio](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) también expone el `naddr` resultante y enlaces de calendario, con el correo electrónico deshabilitado por defecto.
+
+### Plektos convierte los eventos privados en un solo canal cifrado
+
+La [implementación de eventos privados del 2 de septiembre](https://github.com/derekross/plektos/pull/12) convierte cada reunión de [Plektos](https://github.com/derekross/plektos) en un canal privado dentro de una comunidad cifrada de [Concord](/es/topics/concord-protocol/). La lista de invitados, el registro de RSVPs, el tablero de inscripciones, el hilo, las contribuciones, las imágenes de portada, las ediciones y las eliminaciones se cifran juntas; una invitación lleva solo la clave de ese evento y no se publica ningún evento de calendario en texto plano.
+
+La [auditoría de ciclo de vida del 6 de septiembre](https://github.com/derekross/plektos/pull/14) ancla el id de definición del evento para búsqueda directa cuando existen más de 500 wraps, manteniendo un respaldo paginado. Los paquetes de invitación expiran 30 días después de que termina un evento y pueden deshabilitarse, pero alguien que ya obtuvo una clave de canal puede conservarla. Una [reparación de seguridad del analizador](https://github.com/derekross/plektos/pull/16) separada hace que los identificadores [NIP-19](/es/topics/nip-19/) de tipo-longitud-valor (TLV) mal formados fallen en lugar de atrapar al analizador.
+
+## Lanzamientos etiquetados
+
+### Vector 0.4.4 hace más segura la recuperación de comunidades cifradas
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) se publicó el 31 de agosto con correcciones de recuperación de comunidades, rotación de claves, moderación y enrutamiento de respuestas. La refundación cierra una comunidad asaltada a la ruta de invitación usada por los atacantes; la membresía de reemplazo sustituye el estado local obsoleto; y un miembro inalcanzable ya no congela la lista. Las rotaciones vacías se rechazan, las promociones preservan a los miembros en línea, y las operaciones se niegan a ejecutarse cuando los miembros requeridos no pueden ser contactados.
+
+El [lanzamiento](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) también persiste las eliminaciones y expulsiones de moderadores, vuelve a cifrar el libro de visitas tras un cambio de contraseña, vincula las respuestas de notificaciones a su conversación después de reiniciar, y usa solo rutas multijugador verificadas. Estos son controles de recuperación, no revocación de claves ya obtenidas.
+
+### Primal Android 3.5.27 verifica la identidad del firmante y de la billetera
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) se publicó el 3 de septiembre después de que [la verificación de identidad del firmante](https://github.com/PrimalHQ/primal-android-app/pull/1108) y [la autenticación de solicitudes de billetera](https://github.com/PrimalHQ/primal-android-app/pull/1105) se fusionaran el 31 de agosto. La firma local rechaza una solicitud cuya identidad no coincide con la cuenta retenida, y las solicitudes entrantes de [NIP-47](/es/topics/nip-47/) se autentican antes de procesarse. El enrutamiento de encuestas con zaps también envía los votos al autor de la encuesta cuando esta aparece en una respuesta.
+
+### GRAIN 0.8.0-rc2 cierra una vía de aceptado pero no almacenado
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) se publicó el 7 de septiembre después de que un fallo de almacenamiento permitiera un `OK` antes de que su escritor asíncrono de la base de datos LMDB detectara que la capacidad de almacenamiento estaba llena. El relay ahora advierte al 80 y 95 por ciento, rechaza nuevos eventos al 97 por ciento dejando espacio para eliminaciones, e informa de fallos del escritor posteriores a la aceptación. La retención recorre primero los más antiguos, el cierre maneja mensajes tardíos y los filtros inválidos ya no descartan a sus hermanos válidos.
+
+La [publicación](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) también corrobora los anuncios de monitores de kind `10166` y los informes de relay de kind `30166`, expulsa informes obsoletos, mantiene los relays configurados como respaldo y reporta límites en vivo y autenticación en [NIP-11](/es/topics/nip-11/) en lugar de ceros estáticos.
+
+### LibreNostr 0.5.0–0.5.2 hace que el enrutamiento por Tor falle de forma cerrada
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) se publicó el 7 de septiembre con un modo Orbot que enruta relays, zaps, subidas, medios, reproducción y vistas previas a través de un único puerto SOCKS, además de una reparación para un fallo en la hoja de zaps. Si Orbot o el proxy no están disponibles, las conexiones se detienen en lugar de filtrarse a una ruta directa. La [versión 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) evita que las búsquedas [NIP-50](/es/topics/nip-50/) lentas retrasen los resultados locales; [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) reemplaza el diseño recursivo de hilos y repara el ordenamiento de hilos.
+
+El [comportamiento de fallo cerrado](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) se aplica a cada superficie de red enumerada por la publicación, y se requiere un reinicio porque esos clientes son de larga duración. Las versiones de parche preservan esa decisión mientras limitan fallos ajenos de búsqueda, profundidad de pila y diseño.
+
+### SkateSpots añade una vía de relay en el dispositivo
+
+La [publicación firmada del 8 de septiembre en Zapstore](https://zapstore.dev/apps/org.skatespots.app) añade un relay Citrine opcional a SkateSpots. Los spots, crews, mensajes y datos del mapa pueden cargarse localmente; las publicaciones se encolan sin conexión; y el teléfono conserva una copia local. El contenido existente de stash y mensajes permanece cifrado de extremo a extremo. Las verificaciones de pago requieren importes de factura y recibos de zap emitidos por el proveedor antes de conceder acceso o contar contribuciones.
+
+El [relay local](https://zapstore.dev/apps/org.skatespots.app) es una opción de almacenamiento y continuidad, no un reemplazo de todos los relays remotos. Permite que un skater siga trabajando durante un período desconectado y luego reconcilie la actividad firmada, mientras que los cambios de pago impiden que un recibo autoescrito se convierta en prueba de liquidación.
+
+### Whistle 1.8.15 repara la recuperación del ciclo de vida de grupos cifrados
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) se publicó el 3 de septiembre después de que una reparación del ciclo de vida de Android impidiera que los contenedores de estado a nivel de ruta destruyeran las suscripciones de relay y las actualizaciones de ubicación de toda la aplicación. Sus notas de publicación también describen el estado de conexión actualizado tras el bloqueo o el modo doze y una acumulación de 501 eventos recuperada en el caso observado.
+
+El [error](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) vinculaba la propiedad de un servicio de larga duración a una pantalla de corta duración. Mantener viva la instancia con alcance de actividad y comprobar el socket antes de una lectura única hace menos probable que la navegación ordinaria de Android y la suspensión en segundo plano parezcan un grupo vacío.
+
+### TWENTY ONE Companion 1.12.0 separa los DMs cifrados del chat heredado
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) se publicó el 5 de septiembre con DMs envueltos en regalo según [NIP-17](/es/topics/nip-17/). La bandeja de entrada cifrada está separada del chat de espacios antiguo, que permanece distinto porque esos mensajes nunca fueron cifrados y no pueden migrarse. Los PDF y videos están soportados sujetos a la política del relay, y los ocultamientos personales se sincronizan sin convertirse en baneos de moderador.
+
+La [separación visible](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) es parte del modelo de seguridad. Llamar al historial antiguo una bandeja de entrada segura tergiversaría su procedencia, mientras que migrarlo silenciosamente sugeriría un cifrado que no existía cuando fue escrito.
+
+### ZapStore 1.1.2 valida ids de eventos y rotación de certificados
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) se publicó el 4 de septiembre con validación de id de evento según NIP-01: el cliente recalcula el id de un evento entrante y rechaza las discrepancias antes de usarlo. La publicación también identifica paquetes instalados fuera de ZapStore. En el servidor, la [retención de hash de certificado](https://github.com/zapstore/relay/pull/8) preserva las etiquetas `apk_certificate_hash` repetidas para que la rotación de claves de firma de Android pueda mantener un linaje aprobado.
+
+La [verificación del id de evento](https://github.com/zapstore/zapstore/releases/tag/1.1.2) impide que un relay o caché cambie etiquetas o contenido manteniendo el id antiguo. El indicador de fuente del instalador aporta procedencia separada cuando un paquete de Android con el mismo id de aplicación provino de otro canal.
+
+### Amber 6.6.1 mantiene las respuestas del firmante atribuibles
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) se publicó el 4 de septiembre después de que se corrigiera el análisis de permisos para tolerar un `kind` opcional ausente, y las solicitudes de firma rechazadas comenzaron a devolver su id de solicitud original. Las aplicaciones que llaman pueden asociar un rechazo con la operación enviada. La publicación también actualiza los valores predeterminados del firmante remoto y añade un relay indexador.
+
+En conjunto, estas [correcciones](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) preservan la atribución en ambas direcciones: un registro de permiso sigue siendo utilizable cuando falta un campo opcional, y un rechazo permanece vinculado a la solicitud que lo causó. Los cambios en los relays predeterminados afectan el descubrimiento, pero no reemplazan la decisión de autorización local del firmante.
+
+## En desarrollo
+
+### Zap Cooking renderiza referencias NIP-27 con pistas de relays
+
+[La fusión del 4 de septiembre](https://github.com/zapcooking/frontend/pull/665) hace que [Zap Cooking](https://github.com/zapcooking/frontend) renderice referencias `nostr:npub` y `nostr:nprofile` en artículos, recetas, vistas previas del editor y vistas de impresión. Los identificadores no válidos permanecen como texto, la resolución no es bloqueante, y el editor muestra una vista previa del Markdown que se firmará. Cuando existe información de relays, un `npub` simple se convierte en un `nprofile` con relays de outbox y una etiqueta `p` correspondiente.
+
+Esa misma semana se corrigieron [las lecturas de kind `30023` con alcance de autor](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7), se añadieron [relays de búsqueda NIP-50 verificados](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea) con deduplicación y protecciones contra consultas obsoletas, y se repararon [las llamadas de billetera NIP-47](https://github.com/zapcooking/frontend/pull/705) después de que cambios en las dependencias rompieran los saldos y el historial.
+
+### Conduit reconcilia las preferencias firmadas de relays y Blossom
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) fusionó la [edición de preferencias de Blossom](https://github.com/Conduit-BTC/conduit-mono/pull/374) el 2 de septiembre y la [reconciliación de preferencias firmadas](https://github.com/Conduit-BTC/conduit-mono/pull/397) el 7 de septiembre. Market y Merchant conservan la lista de relays de kind `10002` y la declaración de bandeja de entrada de kind `10050` válidas más recientes, preservan una lista firmada utilizable cuando un evento más nuevo está mal formado, distinguen una lista vacía explícita de una consulta no disponible, y no reemplazan los relays declarados fallidos con valores predeterminados del código.
+
+El [editor de kind `10063`](https://github.com/Conduit-BTC/conduit-mono/pull/374) permite al usuario cargar, reordenar, revisar, firmar externamente, publicar y leer de vuelta una lista ordenada de servidores de medios HTTPS sin contactar esos servidores ni insertar un valor predeterminado no declarado.
+
+### Los objetivos de pago de NIP-A3 llegan a tres clientes
+
+Del 1 al 3 de septiembre, [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) y [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) implementaron los objetivos de pago de kind `10133` de NIP-A3. Amethyst ofrece una transferencia opcional solo cuando existe un objetivo compatible y no lo convierte en un zap; Grimoire utiliza un registro fijo antes de construir los URI de billetera; Pollerama valida direcciones de Monero y obtiene la lista de relays del autor antes de consultar los objetivos. Cada cliente sigue necesitando un método de pago permitido, una ruta de relays y una visualización precisa.
+
+### Ditto amplía el respaldo de Blossom y las incrustaciones en vivo
+
+[Ditto](https://github.com/soapbox-pub/ditto) fusionó [un amplio respaldo y espejado de Blossom](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) el 6 de septiembre. Los avatares, insignias, banners, imágenes de comunidades, emoji personalizados e iconos de aplicaciones ahora prueban los servidores declarados con el mismo hash de blob; las subidas de espejado usan un token de autorización BUD-11 estándar. Un [cambio del 4 de septiembre](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) añadió incrustaciones compactas de transmisiones en vivo `kind:30311`.
+
+## Trabajo de Protocolo y Especificaciones
+
+### Nostr Implementation Possibilities
+
+[NIP-01](/es/topics/nip-01/) ahora aclara [el filtro `limit: 0`](https://github.com/nostr-protocol/nips/pull/2460), fusionado el 4 de septiembre. Un relay DEBE devolver cero eventos almacenados, DEBE enviar `EOSE` cuando se completan las consultas iniciales y DEBE mantener la suscripción activa para nuevos eventos coincidentes. Los clientes pueden abrir una suscripción solo en vivo con un único campo de filtro conservando el historial local. La aclaración registra un comportamiento compatible en varias implementaciones de relays y relays públicos.
+
+[NIP-78](/es/topics/nip-78/) incorporó un [requisito de autenticación para datos de aplicación](https://github.com/nostr-protocol/nips/pull/2458), fusionado el 3 de septiembre. Los relays DEBERÍAN exigir autenticación [NIP-42](/es/topics/nip-42/) para los kinds `78` y `30078` y DEBERÍAN servirlos únicamente al autor autenticado del evento. Eso es un DEBERÍA, no una garantía de confidencialidad: los clientes no pueden tratar relays arbitrarios como almacenamiento privado. La fusión también desaconseja los kinds personalizados de datos de aplicación como intercambio público genérico.
+
+[NIP-AC](/es/topics/nip-ac/) se abrió el 4 de septiembre como una [propuesta de señalización WebRTC](https://github.com/nostr-protocol/nips/pull/2461) explícitamente abierta. Utiliza kinds efímeros provisionales para ping, solicitudes de conexión, ofertas, respuestas y candidatos ICE, direccionados con `p` y agrupados por una etiqueta `e` de sesión; el kind `30600` admite el descubrimiento. Los relays DEBERÍAN difundir y NO DEBEN almacenar esos eventos de señalización mientras los pares se conectan directamente. Los números siguen siendo provisionales, los clientes DEBERÍAN usar [listas de relays NIP-65](/es/topics/nip-65/), y las aplicaciones que necesiten confidencialidad DEBERÍAN cifrar el contenido de ofertas, respuestas y candidatos con [NIP-44](/es/topics/nip-44/).
+
+## Análisis en Profundidad de NIP: Enlaces URI y Referencias en el Texto de Eventos
+
+Un identificador de Nostr necesita un significado transportable antes de que otra aplicación pueda abrirlo. [NIP-21](/es/topics/nip-21/) coloca un identificador [NIP-19](/es/topics/nip-19/) después del esquema URI `nostr:`, dando a navegadores, sistemas operativos y aplicaciones una forma única y despachable. [NIP-27](/es/topics/nip-27/) define qué significa ese mismo URI dentro del `content` legible de un evento. NIP-21 cruza una frontera de aplicaciones; NIP-27 mantiene una referencia a un perfil o evento dentro de la prosa firmada. Ninguno crea un kind de evento ni cambia los mensajes de los relays; las [dos especificaciones](https://github.com/nostr-protocol/nips/tree/master) definen únicamente el comportamiento de enlazado y renderizado.
+
+### Despacho de URI y semántica de NIP-19
+
+La [gramática de NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) es `nostr:` seguido de una entidad bech32 de NIP-19. `nsec` está excluido porque codifica una clave privada. No hay componente de autoridad, ruta o consulta, así que un enlace conforme es `nostr:npub1...`, no `nostr://npub1...`. Una plataforma o cliente puede registrarse como el manejador; la especificación no elige la aplicación instalada ni define una alternativa web.
+
+El prefijo indica al cliente qué decodificar. `npub` lleva una clave pública y `note` un id de evento. `nprofile` añade pistas opcionales de relays a un perfil; `nevent` añade relays, autor y kind a un id de evento; y `naddr` lleva el autor, el kind y el identificador `d` de un evento direccionable, con relays opcionales. Estas formas usan los [campos type-length-value de NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md). Las pistas estrechan el descubrimiento pero no prueban ni la posesión por parte del relay ni el control del autor. Cada evento obtenido sigue necesitando un recálculo del id y una verificación de firma.
+
+La forma de perfil en la [especificación de NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) es:
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) también define puentes HTML: una página que sirve un evento de Nostr puede poner su `naddr` en `<link rel="alternate">`, y un perfil puede poner un `nprofile` en `<link rel="me">` o `<link rel="author">`.
+
+### Renderizado de NIP-27 y etiquetas opcionales
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) se aplica al contenido legible de eventos, como notas de kind `1` y artículos de kind `30023`. Un compositor puede mostrar `@name`, pero publica `nostr:nprofile1...` en la cadena firmada. Un lector escanea la URI, decodifica su entidad NIP-19, obtiene el objetivo y puede renderizar un nombre, tarjeta, vista previa o enlace local. Si la decodificación falla, la URI permanece como texto ordinario. El contenido en bruto no debe reescribirse: cambiarlo cambia la serialización de NIP-01, el id y la firma.
+
+Las referencias de contenido y las etiquetas tienen trabajos relacionados pero distintos. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) describe las etiquetas opcionales `p` y `e` y la etiqueta `q` de [NIP-18](/es/topics/nip-18/). Un cliente puede mostrar una referencia sin crear una notificación ni una relación de hilo; el descubrimiento de citas debería escribir tanto la URI como una etiqueta `q`. La [implementación del 4 de septiembre de Zap Cooking](https://github.com/zapcooking/frontend/pull/665) sigue esa división conservando la URI mientras añade pistas de relays y una etiqueta `p` correspondiente. Añadir `p` o `q` no hace privada la URI, y NIP-27 no tiene un modo de mención oculta.
+
+El siguiente [evento de kind `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) se recuperó de `wss://nos.lol` y se verificó antes de su inclusión como referencia concreta de NIP-27. Su `content` contiene un `naddr` para un evento direccionable independiente de la versión. La decodificación produce kind `30402`, autor `91036d...310a`, el identificador `d` del libro de trabajo y una pista `wss://nos.lol/`. Las etiquetas `q`, `p`, `t`, `zap` y `client` son elecciones de la aplicación, no requisitos de NIP-27.
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Confianza, comportamiento ante fallos e implementaciones de clientes
+
+Un lector seguro encuentra un token `nostr:` completo, valida bech32, decodifica NIP-19, rechaza `nsec`, ignora los tipos TLV desconocidos y deja intacto el texto malformado o demasiado largo. `npub` y `nprofile` conducen a consultas de perfiles; `note` y `nevent` identifican eventos inmutables; `naddr` selecciona el evento direccionable válido más reciente para su kind, autor y etiqueta `d`. Las pistas de relays reducen la búsqueda pero no amplían la confianza. Según las [reglas de eventos de NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md), el cliente verifica el id de un `nevent` obtenido y comprueba la firma de cada candidato `naddr` antes de aplicar las reglas de reemplazo de eventos direccionables.
+
+Las vistas previas en línea son una decisión del cliente con costes de privacidad y de recursos. Obtener cada referencia revela los intereses del lector y puede crear una tormenta de consultas, por lo que los clientes pueden usar una caché, aplazar las obtenciones hasta que sean visibles, limitar la concurrencia y exigir un clic para medios desconocidos. Según [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md), una vista previa debe permanecer diferenciada del texto firmado del autor actual. El fallo debe ser visible como texto sin resolver o como una tarjeta no disponible, no tratado silenciosamente como contenido verificado.
+
+La confianza también cambia según el tipo de identificador. Un `nevent` nombra bytes inmutables, por lo que un cliente puede rechazar un evento obtenido cuyo id serializado difiera del id solicitado. Un `naddr` nombra una coordenada reemplazable, por lo que un cliente debe verificar cada candidato y aplicar las reglas de eventos direccionables antes de decidir qué versión mostrar. Una pista de relay es útil para la primera consulta en cualquiera de los casos, pero no es un respaldo del relay ni del contenido devuelto. La [definición TLV de NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) proporciona los datos necesarios para hacer esas comprobaciones explícitas.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) define un enlace portátil que puede abrirse desde fuera de Nostr, mientras que NIP-27 hace que ese mismo enlace sea duradero dentro del texto firmado. Un cliente que implementa solo NIP-21 puede abrir un URI pegado pero no renderizar referencias incrustadas. El soporte completo de NIP-27 añade escaneo, decodificación segura, política de obtención, renderizado local y una elección explícita sobre las etiquetas de notificación y cita. El URI compartido mantiene esas capas interoperables sin obligar a los clientes a presentarlas de forma idéntica. [Damus](https://github.com/damus-io/damus) modela las referencias en línea como menciones tipadas. Su [código de menciones](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) asigna `npub` y `nprofile` a referencias de perfil, `note` y `nevent` a referencias de eventos, y `naddr` a referencias de direcciones; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) las dirige al destino apropiado. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [analiza el esquema y las formas pegadas](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), valida bech32 y extrae las pistas de relays, y luego [asigna las referencias a modelos de contenido de notas](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) renderiza las mismas referencias en artículos, recetas, vistas previas del editor y vistas de impresión.
+
+---
+
+Envía un DM de NIP-17 para compartir un proyecto o una noticia a través del [proyecto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/es/topics/nip-a3.md
+++ b/content/es/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Objetivos de Pago"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 define una forma portátil para que una cuenta de Nostr publique direcciones de pago para múltiples redes y servicios. Un evento reemplazable de tipo `10133` transporta una o más etiquetas `payto`.
+
+## Cómo Funciona
+
+Cada etiqueta tiene la forma `["payto", "<type>", "<address>"]`. El tipo va en minúsculas, como `bitcoin`, `lightning` o `monero`. Los clientes pueden validar los formatos conocidos y generar un URI de pago nativo cuando existe uno; los tipos desconocidos recurren al esquema URI `payto:` del RFC 8905.
+
+El evento declara destinos, no un pago completado ni un zap de Nostr. Los clientes siguen decidiendo qué tipos de pago admiten, cómo validar una dirección y con qué claridad mostrar el destino antes de entregarlo a una billetera.
+
+## Implementaciones
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) ofrece una entrega de pago opcional cuando reconoce un objetivo compatible.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) asigna los tipos de objetivo permitidos a URIs de pago.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) valida los objetivos de Monero y consulta los relays del autor.
+
+---
+
+**Fuentes primarias:**
+- [Especificación de NIP-A3](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: El esquema URI payto](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Mencionado en:**
+- [Boletín #39: Los objetivos de pago de NIP-A3 llegan a tres clientes](/es/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Véase también:**
+- [NIP-47: Nostr Wallet Connect](/es/topics/nip-47/)

--- a/content/fr/newsletters/2026-09-09-newsletter.md
+++ b/content/fr/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,226 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 suit les flux git signés, la publication depuis le navigateur, les diffusions en direct auto-hébergées, le consentement des relais communautaires, les événements privés, les versions ciblées et le contrat de liens NIP-21/NIP-27."
+---
+
+Bienvenue dans [Nostr Compass](https://nostrcompass.org), votre guide hebdomadaire de Nostr.
+
+**Cette semaine :** [ngit et GitWorkshop](https://ngit.dev/v3) font passer les flux git signés sur Nostr et [Blossom](/fr/topics/blossom/), [nsite-clay](https://github.com/jooray/nsite-clay) rend la publication depuis le navigateur récupérable, et [Wingman App](https://github.com/OtherStuffAI/wm-app) réunit navigation, signature locale, authentification et fichiers. [Shosho et Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) connectent les flux auto-hébergés à Nostr, [Communitator](https://github.com/dyne/communitator) rend les modèles de relais inspectables avant signature, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) publie des créneaux de rendez-vous, et [Plektos](https://github.com/derekross/plektos/pull/16) chiffre les événements privés. Des versions étiquetées ajoutent un travail de récupération et de confidentialité dans [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) et [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). Le travail de développement couvre le rendu [NIP-27](/fr/topics/nip-27/), les préférences de relais signées dans [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), les cibles de paiement [NIP-A3](/fr/topics/nip-a3/) et les miroirs Blossom. Des modifications fusionnées dans le [dépôt NIPs](https://github.com/nostr-protocol/nips) clarifient les abonnements réservés au direct et les données d'application authentifiées. Notre analyse approfondie explique comment les liens [NIP-21](/fr/topics/nip-21/) et les références NIP-27 transportent les profils et événements Nostr entre les applications.
+
+## À la une
+
+### Les flux git signés font passer l'intégration continue, les dépôts privés et les versions sur Nostr
+
+Le [lancement v3 du 8 septembre](https://ngit.dev/v3) réunit ngit, GitWorkshop, ngit-grasp et ngit-ci dans un flux signé unique. [ngit](https://ngit.dev/ngit.git) transporte branches, correctifs et demandes de fusion sous forme d'événements [NIP-34](/fr/topics/nip-34/), tandis que [GitWorkshop](https://ngit.dev/gitworkshop.git) fournit l'interface de révision. Le lancement ajoute ngit-ci 0.1, un service d'intégration continue auto-hébergé dont les instructions et les résultats circulent sous forme d'événements Nostr signés, de sorte que les vérifications peuvent s'exécuter sur du matériel contrôlé par les mainteneurs, parallèlement à la révision du code.
+
+La même version offre à [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) des dépôts privés grâce à l'extension de dépôts privés GRASP-08 et rend explicite l'autorité des mainteneurs. Les enregistrements de version signés peuvent pointer vers des ressources dans [Blossom](/fr/topics/blossom/), gardant les métadonnées de version et les fichiers adressés par contenu en dehors d'une forge hébergée. Le [nouveau site de documentation](https://ngit.dev/v3) rassemble le client, les dépôts privés, l'intégration continue et les composants web.
+
+### nsite-clay rend la publication depuis le navigateur récupérable
+
+Une [correction des invites du signataire du 31 août](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), la [récupération de publication](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) et des [contrôles d'édition du 2 septembre](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) font de [nsite-clay](https://github.com/jooray/nsite-clay) un outil de publication dans le navigateur pour un site d'une seule page. L'utilisateur modifie le modèle objet du document sur place, sérialise le résultat, le téléverse sous forme de blob [Blossom](/fr/topics/blossom/) adressé par contenu, puis republie le manifeste [NIP-5A](/fr/topics/nip-5a/) du site. Aucune compilation locale ni serveur n'est requis.
+
+L'[outil de publication dans le navigateur](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) rend désormais une publication échouée récupérable et réduit les invites répétées du signataire, tandis que le [guide d'édition](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) documente la boucle. Le résultat reste un site NIP-5A ordinaire pour les passerelles existantes.
+
+### Wingman App réunit navigation, signature et fichiers
+
+Le travail de septembre ajoute des [sélecteurs de fichiers](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), la [publication de profil](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), un [signataire sûr et la restauration de session](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) et des [compilations mobiles testées](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac) à [Wingman App](https://github.com/OtherStuffAI/wm-app). Son enveloppe Flutter injecte un fournisseur [NIP-07](/fr/topics/nip-07/) dans les pages ouvertes au sein de l'application, tandis que Flight Deck et Drive, adossé à Tower, fournissent une surface de travail et un espace de fichiers à côté du navigateur.
+
+Wingman signe les requêtes HTTP authentifiées à l'aide de [NIP-98](/fr/topics/nip-98/). L'[implémentation des requêtes](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) construit l'événement qu'un serveur vérifie avant de répondre, offrant à une identité installée un chemin d'approbation cohérent pour les actions sur les relais, la signature dans les applications web et les fichiers.
+
+### Shosho prend en charge les flux auto-hébergés de Livelier
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) est sorti le 1er septembre avec la prise en charge de [Livelier](https://github.com/r0d8lsh0p/livelier), dont la [mise à jour d'attribution du 31 août](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) identifie le pont et la source Owncast dans les profils pontés. Livelier surveille le répertoire public d'Owncast, vérifie si un flux vidéo est en direct, puis publie un événement adressable `kind:30311` [NIP-53](/fr/topics/nip-53/). La découverte transite par Nostr tandis que la vidéo reste sur le serveur du diffuseur.
+
+Le chat traverse le pont sous forme d'événements `kind:1311`. La [conception du pont](https://github.com/r0d8lsh0p/livelier) n'ouvre une connexion côté source que lorsqu'un lecteur Nostr y est abonné, étiquette les identités dérivées et envoie le chat éphémère vers un relais qui le supprime au bout de trois heures. Le relais de découverte n'accepte les écritures d'événements en direct que depuis la clé du pont ; le relais de chat utilise l'[authentification NIP-42](/fr/topics/nip-42/) et les [indicateurs d'événements protégés NIP-70](/fr/topics/nip-70/).
+
+### Communitator rend les modèles de relais inspectables avant signature
+
+La [série de lancements du 31 août](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) offre à [Communitator](https://github.com/dyne/communitator) des modèles canoniques pour les listes de relais de kind `10002`, les serveurs Blossom de kind `10063` et les boîtes de réception de messages privés de kind `10050`. Avant qu'un signataire ne se connecte, l'application affiche les points de terminaison normalisés, les permissions de lecture et d'écriture, les kinds d'événements, les relais de publication fixes et les destinations.
+
+Le [flux de signature et de publication borné](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) sépare la connexion de l'application. Chaque événement est signé séparément, une exécution utilise au plus quatre connexions WebSocket, et une destination n'est comptabilisée qu'après un `OK` positif [NIP-01](/fr/topics/nip-01/). Les résultats distinguent les livraisons complètes, partielles, échouées et annulées. Les modèles partagés restent des recommandations non fiables ; la [surface de consentement](https://github.com/dyne/communitator#security-and-consent) explique l'observabilité des relais et du réseau.
+
+### cal.emre.xyz publie les disponibilités de rendez-vous via NIP-52
+
+Le dépôt public a été ouvert dans un [commit initial du 2 septembre](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743), suivi d'une [annonce signée du gestionnaire le 3 septembre](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) pour [cal.emre.xyz](https://cal.emre.xyz). Un hôte publie ses disponibilités sous forme d'événement `kind:31923` [NIP-52](/fr/topics/nip-52/) ; un invité publie un RSVP `kind:31925`.
+
+Il lit les événements des hôtes et les RSVP d'occupation acceptés depuis les relais, exclut les plages horaires qui se chevauchent et conserve les événements Nostr comme registre de planification sans les copier dans une base de données distincte. Les hôtes peuvent signer avec [NIP-07](/fr/topics/nip-07/), [NIP-46](/fr/topics/nip-46/) ou une clé locale ; les invités peuvent générer une clé séparée. Son [dépôt](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) expose également le `naddr` résultant et les liens de calendrier, l'email étant désactivé par défaut.
+
+### Plektos fait des événements privés un canal chiffré unique
+
+L'[implémentation des événements privés du 2 septembre](https://github.com/derekross/plektos/pull/12) fait de chaque rassemblement [Plektos](https://github.com/derekross/plektos) un canal privé au sein d'une communauté chiffrée [Concord](/fr/topics/concord-protocol/). La liste des invités, la liste des RSVP, le tableau d'inscription, le fil de discussion, les contributions, les images de couverture, les modifications et les suppressions sont chiffrés ensemble ; une invitation ne transporte que la clé de cet événement et aucun événement de calendrier en clair n'est publié.
+
+L'[audit du cycle de vie du 6 septembre](https://github.com/derekross/plektos/pull/14) ancre l'identifiant de définition d'événement pour une recherche directe lorsque plus de 500 enveloppes existent, tout en conservant une solution de repli paginée. Les paquets d'invitation expirent 30 jours après la fin d'un événement et peuvent être désactivés, mais quelqu'un qui a déjà obtenu une clé de canal peut la conserver. Une [réparation de sécurité du parseur](https://github.com/derekross/plektos/pull/16) distincte fait échouer les identifiants [NIP-19](/fr/topics/nip-19/) type-length-value (TLV) malformés au lieu de piéger le parseur.
+
+## Versions étiquetées
+
+### Vector 0.4.4 rend la récupération de communauté chiffrée plus sûre
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) est sorti le 31 août avec des correctifs de récupération de communauté, de rotation des clés, de modération et de routage des réponses. La refondation ferme une communauté pillée au chemin d'invitation utilisé par les attaquants ; l'appartenance de remplacement supplante l'état local obsolète ; et un membre injoignable ne fige plus la liste des membres. Les rotations vides sont rejetées, les promotions préservent les membres en ligne, et les opérations refusent de s'exécuter lorsque les membres requis ne peuvent pas être joints.
+
+La [version](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) persiste également les suppressions et bannissements des modérateurs, rechiffre le livre d'or après un changement de mot de passe, lie les réponses de notification à leur conversation après un redémarrage, et n'utilise que des chemins multijoueurs vérifiés. Il s'agit de contrôles de récupération, et non d'une révocation des clés déjà obtenues.
+
+### Primal Android 3.5.27 vérifie l'identité du signataire et du portefeuille
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) est sorti le 3 septembre après la fusion, le 31 août, de la [vérification de l'identité du signataire](https://github.com/PrimalHQ/primal-android-app/pull/1108) et de l'[authentification des requêtes de portefeuille](https://github.com/PrimalHQ/primal-android-app/pull/1105). La signature locale rejette une requête dont l'identité ne correspond pas au compte détenu, et les requêtes [NIP-47](/fr/topics/nip-47/) entrantes sont authentifiées avant traitement. Le routage des sondages à zaps envoie également les votes à l'auteur du sondage lorsque celui-ci apparaît dans une réponse.
+
+### GRAIN 0.8.0-rc2 corrige un chemin de type « acquitté mais non stocké »
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) est sorti le 7 septembre après qu'une défaillance de stockage a permis l'émission d'un `OK` avant que son moteur d'écriture asynchrone de base de données LMDB ne remarque que la capacité de stockage était pleine. Le relais avertit désormais à 80 et 95 pour cent, refuse les nouveaux événements à 97 pour cent tout en laissant de la place pour les suppressions, et signale les défaillances d'écriture survenant après l'acceptation. La rétention parcourt les événements du plus ancien au plus récent, la fermeture gère les messages tardifs, et les filtres invalides n'écartent plus leurs homologues valides.
+
+La [version](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) prend également en charge les annonces de moniteurs de kind `10166` et les rapports de relais de kind `30166`, expulse les rapports obsolètes, conserve les relais configurés comme solution de repli, et rapporte les limites en vigueur et l'authentification dans [NIP-11](/fr/topics/nip-11/) au lieu de zéros statiques.
+
+### LibreNostr 0.5.0–0.5.2 fait échouer le routage Tor en mode sécurisé
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) est sorti le 7 septembre avec un mode Orbot qui fait passer les relais, les zaps, les téléversements, les médias, la lecture et les aperçus par un seul port SOCKS, ainsi qu'une réparation d'un plantage du panneau de zaps. Si Orbot ou le proxy est indisponible, les connexions s'arrêtent au lieu de fuiter vers une route directe. La [version 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) empêche les recherches [NIP-50](/fr/topics/nip-50/) lentes de retarder les résultats locaux ; la [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) remplace la mise en page récursive des fils de discussion et répare leur ordonnancement.
+
+Le [comportement d'échec sécurisé](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) s'applique à chaque surface réseau répertoriée par la version, et un redémarrage est nécessaire car ces clients ont une longue durée de vie. Les versions correctives préservent ce choix tout en limitant les défaillances sans lien concernant la recherche, la profondeur de pile et la mise en page.
+
+### SkateSpots ajoute un chemin de relais embarqué
+
+La [version Zapstore signée du 8 septembre](https://zapstore.dev/apps/org.skatespots.app) ajoute un relais Citrine optionnel à SkateSpots. Les spots, les crews, les messages et les données cartographiques peuvent se charger localement ; les publications sont mises en file d'attente hors ligne ; et le téléphone conserve une copie locale. Les contenus de stash et de messages existants restent chiffrés de bout en bout. Les vérifications de paiement exigent les montants des factures et des reçus de zap émis par le fournisseur avant d'accorder l'accès ou de comptabiliser les contributions.
+
+Le [relais local](https://zapstore.dev/apps/org.skatespots.app) est une option de stockage et de continuité, et non un remplacement de chaque relais distant. Il permet à un skateur de continuer à travailler pendant une période de déconnexion, puis de réconcilier plus tard l'activité signée, tandis que les changements de paiement empêchent un reçu auto-rédigé de devenir une preuve de règlement.
+
+### Whistle 1.8.15 répare la récupération du cycle de vie des groupes chiffrés
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) est sorti le 3 septembre après qu'une réparation du cycle de vie Android a empêché les détenteurs d'état au niveau des routes de détruire les abonnements aux relais et les mises à jour de localisation à l'échelle de l'application. Ses notes de version décrivent également un état de connexion rafraîchi après un verrouillage ou une mise en veille, ainsi qu'un arriéré de 501 événements récupéré dans le cas observé.
+
+Le [bogue](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) liait la propriété d'un service à longue durée de vie à un écran à courte durée de vie. Garder en vie l'instance à portée d'activité et vérifier le socket avant une lecture ponctuelle rend la navigation Android ordinaire et la suspension en arrière-plan moins susceptibles de ressembler à un groupe vide.
+
+### TWENTY ONE Companion 1.12.0 sépare les DM chiffrés du chat historique
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) est sorti le 5 septembre avec les DM emballés-cadeau de [NIP-17](/fr/topics/nip-17/). La boîte de réception chiffrée est séparée de l'ancien chat d'espaces, qui reste distinct car ces messages n'ont jamais été chiffrés et ne peuvent pas être migrés. Les PDF et les vidéos sont pris en charge sous réserve de la politique des relais, et les masquages personnels se synchronisent sans devenir des bannissements de modérateur.
+
+La [séparation visible](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) fait partie du modèle de sécurité. Qualifier l'ancien historique de boîte de réception sécurisée dénaturerait sa provenance, tandis qu'une migration silencieuse suggérerait un chiffrement qui n'existait pas au moment de son écriture.
+
+### ZapStore 1.1.2 valide les identifiants d'événements et la rotation des certificats
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) est sorti le 4 septembre avec la validation des identifiants d'événements NIP-01 : le client recalcule l'id d'un événement entrant et rejette les non-concordances avant de l'utiliser. La version identifie également les paquets installés en dehors de ZapStore. Côté serveur, la [rétention des empreintes de certificats](https://github.com/zapstore/relay/pull/8) préserve les balises `apk_certificate_hash` répétées afin que la rotation des clés de signature Android puisse conserver une lignée approuvée.
+
+La [vérification de l'identifiant d'événement](https://github.com/zapstore/zapstore/releases/tag/1.1.2) empêche un relais ou un cache de modifier les balises ou le contenu tout en conservant l'ancien id. L'indicateur de source d'installation fournit une provenance distincte lorsqu'un paquet Android portant le même identifiant d'application provient d'un autre canal.
+
+### Amber 6.6.1 garde les réponses du signataire attribuables
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) est sorti le 4 septembre après que l'analyse des permissions a été corrigée pour tolérer un `kind` optionnel manquant, et que les demandes de signature rejetées ont commencé à renvoyer leur identifiant de demande d'origine. Les applications appelantes peuvent associer un rejet à l'opération soumise. La version met également à jour les valeurs par défaut du signataire distant et ajoute un relais indexeur.
+
+Ensemble, ces [corrections](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) préservent l'attribution dans les deux sens : un enregistrement de permission reste utilisable lorsqu'un champ optionnel est absent, et un refus reste lié à la demande qui l'a provoqué. Les changements de relais par défaut affectent la découverte, mais ils ne remplacent pas la décision d'autorisation locale du signataire.
+
+## En développement
+
+### Zap Cooking affiche les références NIP-27 avec indications de relais
+
+[La fusion du 4 septembre](https://github.com/zapcooking/frontend/pull/665) permet à [Zap Cooking](https://github.com/zapcooking/frontend) d'afficher les références `nostr:npub` et `nostr:nprofile` dans les articles, les recettes, les aperçus de l'éditeur et les vues d'impression. Les identifiants invalides restent du texte, la résolution est non bloquante, et l'éditeur affiche un aperçu du Markdown qui sera signé. Lorsqu'une information de relais existe, un `npub` seul devient un `nprofile` avec les relais outbox et une balise `p` correspondante.
+
+La même semaine a corrigé [les lectures du kind `30023` limitées à l'auteur](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7), ajouté [des relais de recherche NIP-50 vérifiés](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea) avec déduplication et protections contre les requêtes obsolètes, et réparé [les appels de portefeuille NIP-47](https://github.com/zapcooking/frontend/pull/705) après que des changements de dépendances ont cassé les soldes et l'historique.
+
+### Conduit réconcilie les préférences signées de relais et Blossom
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) a fusionné [l'édition des préférences Blossom](https://github.com/Conduit-BTC/conduit-mono/pull/374) le 2 septembre et [la réconciliation des préférences signées](https://github.com/Conduit-BTC/conduit-mono/pull/397) le 7 septembre. Market et Merchant conservent la dernière liste de relais kind `10002` valide et la déclaration de boîte de réception kind `10050`, préservent une liste signée utilisable lorsqu'un événement plus récent est malformé, distinguent une liste explicitement vide d'une recherche indisponible, et ne remplacent pas les relais déclarés en échec par des valeurs par défaut codées en dur.
+
+[L'éditeur de kind `10063`](https://github.com/Conduit-BTC/conduit-mono/pull/374) permet à un utilisateur de charger, réordonner, vérifier, signer en externe, publier et relire une liste ordonnée de serveurs multimédias HTTPS sans contacter ces serveurs ni insérer de valeur par défaut non déclarée.
+
+### Les cibles de paiement NIP-A3 atteignent trois clients
+
+Du 1er au 3 septembre, [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) et [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) ont implémenté les cibles de paiement NIP-A3 de kind `10133`. Amethyst propose une passation opt-in uniquement lorsqu'une cible compatible existe et ne la transforme pas en zap ; Grimoire utilise un registre fixe avant de construire les URI de portefeuille ; Pollerama valide les adresses Monero et récupère la liste de relais de l'auteur avant d'interroger les cibles. Chaque client a toujours besoin d'une méthode de paiement autorisée, d'une route de relais et d'un affichage exact.
+
+### Ditto étend le repli Blossom et les intégrations en direct
+
+[Ditto](https://github.com/soapbox-pub/ditto) a fusionné [un repli et une mise en miroir Blossom étendus](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) le 6 septembre. Les avatars, badges, bannières, images de communauté, emoji personnalisés et icônes d'application essaient désormais les serveurs déclarés avec le même hachage de blob ; les téléversements miroirs utilisent un jeton d'autorisation BUD-11 standard. Un [changement du 4 septembre](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) a ajouté des intégrations compactes de diffusions en direct `kind:30311`.
+
+## Travaux sur le protocole et les spécifications
+
+### Nostr Implementation Possibilities
+
+[NIP-01](/fr/topics/nip-01/) clarifie désormais [le filtre `limit: 0`](https://github.com/nostr-protocol/nips/pull/2460), fusionné le 4 septembre. Un relais DOIT ne retourner aucun événement stocké, DOIT envoyer `EOSE` lorsque les requêtes initiales sont terminées, et DOIT maintenir l'abonnement actif pour les nouveaux événements correspondants. Les clients peuvent ouvrir un abonnement réservé au direct avec un seul champ de filtre tout en conservant l'historique local. La clarification consigne un comportement compatible entre plusieurs implémentations de relais et relais publics.
+
+[NIP-78](/fr/topics/nip-78/) a gagné une [exigence d'authentification pour les données d'application](https://github.com/nostr-protocol/nips/pull/2458), fusionnée le 3 septembre. Les relais DEVRAIENT exiger une authentification [NIP-42](/fr/topics/nip-42/) pour les kinds `78` et `30078` et DEVRAIENT ne les servir qu'à l'auteur authentifié de l'événement. Il s'agit d'un DEVRAIT, et non d'une garantie de confidentialité : les clients ne peuvent pas considérer des relais arbitraires comme un stockage privé. La fusion décourage également les kinds de données d'application personnalisés comme format d'échange public générique.
+
+[NIP-AC](/fr/topics/nip-ac/) a été ouvert le 4 septembre comme une [proposition de signalisation WebRTC](https://github.com/nostr-protocol/nips/pull/2461) explicitement ouverte. Il utilise des kinds éphémères provisoires pour le ping, les demandes de connexion, les offres, les réponses et les candidats ICE, adressés avec `p` et regroupés par une balise de session `e` ; le kind `30600` prend en charge la découverte. Les relais DEVRAIENT diffuser et ne DOIVENT PAS stocker ces événements de signalisation pendant que les pairs se connectent directement. Les numéros restent provisoires, les clients DEVRAIENT utiliser [les listes de relais NIP-65](/fr/topics/nip-65/), et les applications nécessitant la confidentialité DEVRAIENT chiffrer le contenu des offres, des réponses et des candidats avec [NIP-44](/fr/topics/nip-44/).
+
+## Analyse approfondie d'un NIP : liens URI et références dans le texte des événements
+
+Un identifiant Nostr a besoin d'une signification transportable avant qu'une autre application puisse l'ouvrir. [NIP-21](/fr/topics/nip-21/) place un identifiant [NIP-19](/fr/topics/nip-19/) après le schéma d'URI `nostr:`, offrant aux navigateurs, systèmes d'exploitation et applications une forme unique et distribuable. [NIP-27](/fr/topics/nip-27/) définit ce que ce même URI signifie à l'intérieur du `content` lisible d'un événement. NIP-21 franchit une frontière applicative ; NIP-27 conserve une référence de profil ou d'événement dans une prose signée. Aucun des deux ne crée un kind d'événement ni ne modifie les messages de relais ; les [deux spécifications](https://github.com/nostr-protocol/nips/tree/master) définissent uniquement le comportement de liaison et d'affichage.
+
+### Routage des URI et sémantique de NIP-19
+
+[La grammaire de NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) se compose de `nostr:` suivi d’une entité bech32 NIP-19. `nsec` est exclu, car il encode une clé privée. Il n’y a aucun composant d’autorité, de chemin ou de requête. Un lien conforme est donc `nostr:npub1...`, et non `nostr://npub1...`. Une plateforme ou un client peut s’enregistrer comme gestionnaire. La spécification ne choisit pas l’application installée et ne définit pas de solution de repli vers le Web.
+
+Le préfixe indique au client ce qu’il doit décoder. `npub` contient une clé publique et `note` un identifiant d’événement. `nprofile` ajoute à un profil des indications facultatives de relais. `nevent` ajoute des relais, un auteur et un kind à un identifiant d’événement. Enfin, `naddr` contient l’auteur, le kind et l’identifiant `d` d’un événement adressable, avec des relais facultatifs. Ces formats utilisent les [champs type-longueur-valeur de NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md). Les indications facilitent la recherche, mais ne prouvent ni que le relais possède l’événement ni que l’auteur le contrôle. Pour chaque événement récupéré, il faut toujours recalculer l’identifiant et vérifier la signature.
+
+Le format de profil donné dans la [spécification NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) est le suivant :
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) définit également des passerelles HTML : une page qui fournit un événement Nostr peut placer son `naddr` dans `<link rel="alternate">`, tandis qu’un profil peut placer un `nprofile` dans `<link rel="me">` ou `<link rel="author">`.
+
+### Affichage selon NIP-27 et tags facultatifs
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) s’applique au contenu lisible des événements, comme les notes de kind `1` et les articles de kind `30023`. Un outil de rédaction peut afficher `@name`, mais publie `nostr:nprofile1...` dans la chaîne signée. Un lecteur analyse l’URI, décode son entité NIP-19, récupère la cible et peut afficher un nom, une carte, un aperçu ou un lien local. Si le décodage échoue, l’URI reste du texte ordinaire. Le contenu brut ne doit pas être réécrit : toute modification change la sérialisation NIP-01, l’identifiant et la signature.
+
+Les références dans le contenu et les tags remplissent des fonctions liées, mais distinctes. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) décrit les tags facultatifs `p` et `e`, ainsi que le tag `q` de [NIP-18](/fr/topics/nip-18/). Un client peut afficher une référence sans créer de notification ni de relation de fil de discussion. Pour permettre la découverte d’une citation, il convient d’écrire à la fois l’URI et un tag `q`. [L’implémentation de Zap Cooking du 4 septembre](https://github.com/zapcooking/frontend/pull/665) suit cette distinction en conservant l’URI tout en ajoutant des indications de relais et un tag `p` correspondant. L’ajout de `p` ou de `q` ne rend pas l’URI privée, et NIP-27 ne prévoit aucun mode de mention masquée.
+
+L’[événement de kind `1` suivant](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) a été récupéré depuis `wss://nos.lol` et vérifié avant d’être inclus comme exemple concret de référence NIP-27. Son `content` contient un `naddr` correspondant à un événement adressable indépendant de sa version. Le décodage donne le kind `30402`, l’auteur `91036d...310a`, l’identifiant `d` du cahier d’exercices et une indication `wss://nos.lol/`. Les tags `q`, `p`, `t`, `zap` et `client` relèvent de choix applicatifs et ne sont pas exigés par NIP-27.
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Confiance, comportement en cas d'échec et implémentations clientes
+
+Un lecteur sûr repère un jeton `nostr:` complet, valide bech32, décode NIP-19, rejette `nsec`, ignore les types TLV inconnus et laisse inchangé tout texte mal formé ou trop volumineux. `npub` et `nprofile` conduisent à des requêtes de profils ; `note` et `nevent` identifient des événements immuables ; `naddr` sélectionne le dernier événement adressable valide pour son kind, son auteur et son tag `d`. Les indications de relais réduisent le champ de recherche, mais n'étendent pas la confiance. Selon les [règles de NIP-01 relatives aux événements](https://github.com/nostr-protocol/nips/blob/master/01.md), le client vérifie l'id d'un `nevent` récupéré et contrôle la signature de chaque candidat `naddr` avant d'appliquer les règles de remplacement des événements adressables.
+
+L'affichage d'aperçus intégrés relève du choix du client et a un coût en matière de confidentialité et de ressources. Récupérer chaque référence révèle les centres d'intérêt du lecteur et peut provoquer une avalanche de requêtes. Les clients peuvent donc utiliser un cache, différer les récupérations jusqu'à ce que les références soient visibles, limiter les accès simultanés et exiger un clic pour les médias inconnus. Selon [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md), un aperçu doit rester distinct du texte signé par l'auteur actuel. Un échec doit apparaître comme du texte non résolu ou une carte indisponible, et non être silencieusement traité comme du contenu vérifié.
+
+La confiance varie également selon le type d'identifiant. Un `nevent` désigne des octets immuables, de sorte qu'un client peut rejeter un événement récupéré dont l'id sérialisé diffère de l'id demandé. Un `naddr` désigne une coordonnée remplaçable. Le client doit donc vérifier chaque candidat et appliquer les règles relatives aux événements adressables avant de décider quelle version afficher. Une indication de relais est utile pour la première requête dans les deux cas, mais elle ne constitue pas une approbation du relais ni du contenu renvoyé. La [définition TLV de NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) fournit les données nécessaires pour rendre ces vérifications explicites.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) définit un lien portable qui peut être ouvert depuis l'extérieur de Nostr, tandis que NIP-27 rend ce même lien durable au sein d'un texte signé. Un client qui implémente uniquement NIP-21 peut ouvrir un URI collé, mais ne peut pas afficher les références intégrées. Une prise en charge complète de NIP-27 ajoute la détection, le décodage sécurisé, une politique de récupération, le rendu local et un choix explicite concernant les tags de notification et de citation. L'URI commun assure l'interopérabilité de ces différentes couches sans obliger les clients à les présenter de manière identique.[Damus](https://github.com/damus-io/damus) représente les références intégrées sous forme de mentions typées. Son [code de gestion des mentions](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) associe `npub` et `nprofile` à des références de profils, `note` et `nevent` à des références d'événements, et `naddr` à des références d'adresses ; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) les dirige vers la destination appropriée. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [analyse le protocole et les formes collées](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), valide bech32 et extrait les indications de relais, puis [associe les références à des modèles de contenu de note](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) affiche les mêmes références dans les articles, les recettes, les aperçus de l'éditeur et les vues d'impression.
+
+---
+
+Envoyez un DM NIP-17 pour partager un projet ou une actualité par l'intermédiaire du [projet Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/fr/topics/nip-a3.md
+++ b/content/fr/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Cibles de paiement"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 définit un moyen portable permettant à un compte Nostr de publier des adresses de paiement pour plusieurs réseaux et services. Un événement remplaçable de kind `10133` contient une ou plusieurs balises `payto`.
+
+## Fonctionnement
+
+Chaque balise prend la forme `["payto", "<type>", "<address>"]`. Le type est en minuscules, par exemple `bitcoin`, `lightning` ou `monero`. Les clients peuvent valider les formats connus et générer un URI de paiement natif lorsqu’il en existe un. Pour les types inconnus, ils utilisent par défaut le schéma d’URI `payto:` défini par la RFC 8905.
+
+L’événement déclare des destinations, et non un paiement effectué ou un zap Nostr. Les clients décident toujours des types de paiement qu’ils prennent en charge, de la manière de valider une adresse et de la clarté avec laquelle afficher la destination avant de la transmettre à un portefeuille.
+
+## Implémentations
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) propose un transfert facultatif vers le paiement lorsqu’il reconnaît une cible compatible.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) associe les types de cibles autorisés à des URI de paiement.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) valide les cibles Monero et interroge les relais de l’auteur.
+
+---
+
+**Sources principales :**
+- [Spécification NIP-A3](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905 : le schéma d’URI payto](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Mentionné dans :**
+- [Newsletter nº 39 : les cibles de paiement NIP-A3 sont prises en charge par trois clients](/fr/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Voir aussi :**
+- [NIP-47 : Nostr Wallet Connect](/fr/topics/nip-47/)

--- a/content/it/newsletters/2026-09-09-newsletter.md
+++ b/content/it/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,225 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 segue i flussi di lavoro git firmati, la pubblicazione dal browser, gli streaming in diretta self-hosted, il consenso sui relay delle comunità, gli eventi privati, le release mirate e il contratto dei link NIP-21/NIP-27."
+---
+
+Bentornati su [Nostr Compass](https://nostrcompass.org), la vostra guida settimanale a Nostr.
+
+**Questa settimana:** [ngit e GitWorkshop](https://ngit.dev/v3) portano i flussi di lavoro git firmati su Nostr e [Blossom](/it/topics/blossom/), [nsite-clay](https://github.com/jooray/nsite-clay) rende recuperabile la pubblicazione dal browser e [Wingman App](https://github.com/OtherStuffAI/wm-app) riunisce navigazione, firma locale, autenticazione e file. [Shosho e Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) collegano gli streaming self-hosted a Nostr, [Communitator](https://github.com/dyne/communitator) rende ispezionabili i modelli dei relay prima della firma, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) pubblica le fasce orarie per gli appuntamenti e [Plektos](https://github.com/derekross/plektos/pull/16) cifra gli eventi privati. Le release con tag aggiungono interventi per il recupero e la privacy in [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) e [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). Il lavoro di sviluppo comprende il rendering di [NIP-27](/it/topics/nip-27/), le preferenze dei relay firmate in [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), le destinazioni di pagamento [NIP-A3](/it/topics/nip-a3/) e i mirror Blossom. Le modifiche integrate nel [repository delle NIP](https://github.com/nostr-protocol/nips) chiariscono le sottoscrizioni riservate alle dirette e i dati applicativi autenticati. Il nostro approfondimento spiega come i link [NIP-21](/it/topics/nip-21/) e i riferimenti NIP-27 trasportano profili ed eventi Nostr tra le applicazioni.
+
+## Notizie principali
+
+### I flussi di lavoro git firmati portano CI, repository privati e release su Nostr
+
+Il [lancio della v3 dell'8 settembre](https://ngit.dev/v3) riunisce ngit, GitWorkshop, ngit-grasp e ngit-ci in un unico flusso di lavoro firmato. [ngit](https://ngit.dev/ngit.git) trasporta branch, patch e richieste di pull come eventi [NIP-34](/it/topics/nip-34/), mentre [GitWorkshop](https://ngit.dev/gitworkshop.git) fornisce l'interfaccia per la revisione. Il lancio aggiunge ngit-ci 0.1, un servizio self-hosted di integrazione continua le cui istruzioni e i cui risultati viaggiano come eventi Nostr firmati, consentendo l'esecuzione dei controlli su hardware gestito dai manutentori insieme alla revisione del codice.
+
+La stessa release dota [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) di repository privati tramite l'estensione GRASP-08 per i repository privati e rende esplicita l'autorità dei manutentori. I registri firmati delle release possono puntare agli asset in [Blossom](/it/topics/blossom/), mantenendo sia i metadati delle release sia i file indirizzati per contenuto al di fuori di una forge ospitata. Il [nuovo sito della documentazione](https://ngit.dev/v3) riunisce i componenti relativi al client, ai repository privati, alla CI e al web.
+
+### nsite-clay rende recuperabile la pubblicazione dal browser
+
+Una [correzione del 31 agosto per le richieste del firmatario](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), il [recupero della pubblicazione](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) e i [controlli di modifica del 2 settembre](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) rendono [nsite-clay](https://github.com/jooray/nsite-clay) uno strumento di pubblicazione dal browser per un sito a pagina singola. L'utente modifica direttamente il modello a oggetti del documento, serializza il risultato, lo carica come blob [Blossom](/it/topics/blossom/) indirizzato per contenuto e ripubblica il manifest [NIP-5A](/it/topics/nip-5a/) del sito. Non sono necessari una build locale né un server.
+
+Lo [strumento di pubblicazione dal browser](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) consente ora di recuperare una pubblicazione non riuscita e riduce le richieste ripetute del firmatario, mentre la [guida alla modifica](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) documenta il ciclo operativo. Il risultato rimane un normale sito NIP-5A per i gateway esistenti.
+
+### Wingman App riunisce navigazione, firma e file
+
+Il lavoro di settembre aggiunge a [Wingman App](https://github.com/OtherStuffAI/wm-app) [selettori di file](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), la [pubblicazione del profilo](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), il [ripristino sicuro del firmatario e della sessione](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) e [build mobili testate](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac). La sua shell Flutter inserisce un provider [NIP-07](/it/topics/nip-07/) nelle pagine aperte all'interno dell'app, mentre Flight Deck e Drive, supportato da Tower, offrono un'area di lavoro e uno spazio per i file accanto al browser.
+
+Wingman firma le richieste HTTP autenticate usando [NIP-98](/it/topics/nip-98/). L'[implementazione delle richieste](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) costruisce l'evento che un server verifica prima di rispondere, offrendo a un'unica identità installata un percorso di approvazione coerente per le azioni sui relay, la firma nelle applicazioni web e i file.
+
+### Shosho integra gli stream self-hosted di Livelier
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) è stato pubblicato il 1° settembre con il supporto a [Livelier](https://github.com/r0d8lsh0p/livelier), il cui [aggiornamento delle attribuzioni del 31 agosto](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) identifica il bridge e la sorgente Owncast nei profili collegati tramite bridge. Livelier monitora la directory pubblica di Owncast, verifica se uno stream video è in diretta e pubblica quindi un evento indirizzabile `kind:30311` [NIP-53](/it/topics/nip-53/). La scoperta avviene tramite Nostr, mentre il video rimane sul server di chi trasmette.
+
+La chat attraversa il bridge sotto forma di eventi `kind:1311`. La [struttura del bridge](https://github.com/r0d8lsh0p/livelier) apre una connessione sul lato della sorgente solo mentre un lettore Nostr è iscritto, contrassegna le identità derivate e invia la chat transitoria a un relay che la elimina dopo tre ore. Il relay di scoperta accetta la scrittura di eventi live soltanto dalla chiave del bridge; il relay della chat utilizza l'[autenticazione NIP-42](/it/topics/nip-42/) e i [contrassegni per eventi protetti NIP-70](/it/topics/nip-70/).
+
+### Communitator rende ispezionabili i modelli dei relay prima della firma
+
+La [serie di aggiornamenti di lancio del 31 agosto](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) fornisce a [Communitator](https://github.com/dyne/communitator) modelli canonici per gli elenchi di relay kind `10002`, i server Blossom kind `10063` e le caselle di posta dei messaggi privati kind `10050`. Prima che un firmatario si connetta, l'applicazione mostra endpoint normalizzati, autorizzazioni di lettura e scrittura, event kind, relay di pubblicazione fissi e destinazioni.
+
+Il [flusso limitato di firma e pubblicazione](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) separa la connessione dall'applicazione. Ogni evento viene firmato separatamente, una singola esecuzione utilizza al massimo quattro connessioni WebSocket e una destinazione viene conteggiata solo dopo un `OK` positivo secondo [NIP-01](/it/topics/nip-01/). I risultati distinguono tra consegna completa, parziale, non riuscita e annullata. I modelli condivisi rimangono raccomandazioni non attendibili; l'[interfaccia per il consenso](https://github.com/dyne/communitator#security-and-consent) illustra l'osservabilità dei relay e della rete.
+
+### cal.emre.xyz pubblica la disponibilità per gli appuntamenti tramite NIP-52
+
+Il repository pubblico è stato aperto con un [commit iniziale del 2 settembre](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743), seguito il 3 settembre da un [annuncio firmato dell'handler](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) per [cal.emre.xyz](https://cal.emre.xyz). Un host pubblica la propria disponibilità come evento `kind:31923` [NIP-52](/it/topics/nip-52/); un ospite pubblica una conferma RSVP `kind:31925`.
+
+Il servizio legge dai relay gli eventi dell'host e le conferme RSVP accettate che indicano periodi occupati, esclude gli intervalli temporali sovrapposti e mantiene gli eventi Nostr come registro della pianificazione senza copiarli in un database separato. Gli host possono firmare con [NIP-07](/it/topics/nip-07/), [NIP-46](/it/topics/nip-46/) o una chiave locale; gli ospiti possono generare una chiave separata. Il suo [repository](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) rende inoltre disponibili il relativo `naddr` e i link al calendario, con l'email disabilitata per impostazione predefinita.
+
+### Plektos riunisce gli eventi privati in un unico canale cifrato
+
+L'[implementazione degli eventi privati del 2 settembre](https://github.com/derekross/plektos/pull/12) trasforma ogni incontro di [Plektos](https://github.com/derekross/plektos) in un canale privato all'interno di una comunità cifrata [Concord](/it/topics/concord-protocol/). L'elenco degli invitati, l'elenco delle conferme RSVP, la bacheca delle iscrizioni, la discussione, i contributi, le immagini di copertina, le modifiche e le eliminazioni vengono cifrati insieme; un invito contiene soltanto la chiave di quell'evento e non viene pubblicato alcun evento di calendario in chiaro.
+
+L'[audit del ciclo di vita del 6 settembre](https://github.com/derekross/plektos/pull/14) usa come riferimento l'id della definizione dell'evento per consentire una ricerca diretta quando esistono più di 500 wrap, mantenendo al contempo un sistema di ripiego paginato. I pacchetti di invito scadono 30 giorni dopo la conclusione di un evento e possono essere disabilitati, ma chi ha già ottenuto la chiave di un canale può conservarla. Una [correzione separata per la sicurezza del parser](https://github.com/derekross/plektos/pull/16) fa sì che gli identificatori type-length-value (TLV) [NIP-19](/it/topics/nip-19/) malformati restituiscano un errore anziché bloccare il parser.
+
+## Release con tag
+
+### Vector 0.4.4 rende più sicuro il recupero delle comunità cifrate
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) è stato pubblicato il 31 agosto con correzioni per il recupero delle comunità, la rotazione delle chiavi, la moderazione e l'instradamento delle risposte. La rifondazione impedisce a una comunità attaccata di utilizzare il percorso di invito sfruttato dagli aggressori; la nuova appartenenza sostituisce lo stato locale obsoleto; inoltre, un singolo membro non raggiungibile non blocca più l'elenco dei membri. Le rotazioni vuote vengono rifiutate, le promozioni mantengono i membri online e le operazioni non vengono eseguite quando i membri necessari non sono raggiungibili.
+
+La [release](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) rende inoltre persistenti le eliminazioni e i ban applicati dai moderatori, cifra nuovamente il registro degli ospiti dopo una modifica della password, ricollega le risposte alle notifiche alla rispettiva conversazione dopo un riavvio e utilizza esclusivamente percorsi multiplayer verificati. Si tratta di controlli per il recupero, non della revoca di chiavi già ottenute.
+
+### Primal Android 3.5.27 verifica l'identità del firmatario e del wallet
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) è stato pubblicato il 3 settembre, dopo l'integrazione, il 31 agosto, della [verifica dell'identità del firmatario](https://github.com/PrimalHQ/primal-android-app/pull/1108) e dell'[autenticazione delle richieste del wallet](https://github.com/PrimalHQ/primal-android-app/pull/1105). La firma locale rifiuta una richiesta la cui identità non corrisponde all'account in uso, mentre le richieste [NIP-47](/it/topics/nip-47/) in arrivo vengono autenticate prima dell'elaborazione. L'instradamento degli zap-poll invia inoltre i voti all'autore del sondaggio quando quest'ultimo compare in una risposta.
+
+### GRAIN 0.8.0-rc2 chiude un percorso con conferma ma senza archiviazione
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) è stato pubblicato il 7 settembre dopo che un errore di archiviazione aveva consentito l'invio di `OK` prima che il writer asincrono del database LMDB rilevasse l'esaurimento dello spazio disponibile. Ora il relay avvisa all'80 e al 95 percento, rifiuta nuovi eventi al 97 percento lasciando spazio per le eliminazioni e segnala gli errori del writer successivi all'accettazione. La procedura di conservazione parte dagli elementi più vecchi, la fase di arresto gestisce i messaggi tardivi e i filtri non validi non causano più l'eliminazione di quelli validi associati.
+
+La [release](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) verifica inoltre gli annunci di monitoraggio di kind `10166` e i rapporti sui relay di kind `30166`, elimina i rapporti obsoleti, mantiene i relay configurati come opzione di riserva e riporta limiti e autenticazione effettivi in [NIP-11](/it/topics/nip-11/) anziché valori zero statici.
+
+### LibreNostr 0.5.0–0.5.2 interrompe le connessioni se l'instradamento Tor non è disponibile
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) è stato pubblicato il 7 settembre con una modalità Orbot che instrada relay, zap, caricamenti, contenuti multimediali, riproduzione e anteprime attraverso un'unica porta SOCKS, oltre a una correzione per un arresto anomalo della schermata degli zap. Se Orbot o il proxy non sono disponibili, le connessioni vengono interrotte anziché passare inavvertitamente a un percorso diretto. La [versione 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) impedisce che le ricerche [NIP-50](/it/topics/nip-50/) lente ritardino i risultati locali; la [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) sostituisce il layout ricorsivo dei thread e ne corregge l'ordinamento.
+
+Il [comportamento con interruzione in caso di errore](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) si applica a ogni interfaccia di rete elencata nella release ed è necessario un riavvio perché questi client rimangono attivi a lungo. Le release correttive mantengono questa scelta, limitando al contempo errori non correlati relativi alla ricerca, alla profondità dello stack e al layout.
+
+### SkateSpots aggiunge un percorso verso un relay sul dispositivo
+
+La [release firmata dell'8 settembre su Zapstore](https://zapstore.dev/apps/org.skatespots.app) aggiunge a SkateSpots un relay Citrine opzionale. Spot, crew, messaggi e dati delle mappe possono essere caricati localmente; i post vengono messi in coda offline e il telefono ne conserva una copia locale. I contenuti esistenti delle raccolte e dei messaggi rimangono crittografati end-to-end. Le verifiche dei pagamenti richiedono gli importi delle fatture e le ricevute degli zap emesse dal provider prima di concedere l'accesso o conteggiare i contributi.
+
+Il [relay locale](https://zapstore.dev/apps/org.skatespots.app) è un'opzione per l'archiviazione e la continuità, non un sostituto di ogni relay remoto. Consente a uno skater di continuare a operare durante un periodo senza connessione e di sincronizzare in seguito l'attività firmata, mentre le modifiche ai pagamenti impediscono che una ricevuta creata dallo stesso utente diventi una prova dell'avvenuto pagamento.
+
+### Whistle 1.8.15 corregge il ripristino del ciclo di vita dei gruppi crittografati
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) è stato pubblicato il 3 settembre dopo che una correzione del ciclo di vita su Android ha impedito ai gestori dello stato a livello di route di terminare le sottoscrizioni ai relay e gli aggiornamenti della posizione validi per l'intera applicazione. Le note di rilascio descrivono inoltre l'aggiornamento dello stato della connessione dopo il blocco o la modalità doze e, nel caso osservato, il recupero di un arretrato di 501 eventi.
+
+Il [bug](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) legava la gestione di un servizio di lunga durata a una schermata di breve durata. Mantenere attiva l'istanza associata all'activity e controllare il socket prima di una lettura singola riduce la probabilità che la normale navigazione su Android e la sospensione in background facciano apparire vuoto un gruppo.
+
+### TWENTY ONE Companion 1.12.0 separa i DM crittografati dalla chat precedente
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) è stato pubblicato il 5 settembre con DM crittografati in modalità gift-wrap secondo [NIP-17](/it/topics/nip-17/). La casella dei messaggi crittografati è separata dalla precedente chat dello spazio, che resta distinta perché quei messaggi non sono mai stati crittografati e non possono essere migrati. PDF e video sono supportati nel rispetto delle politiche dei relay e i contenuti nascosti a livello personale vengono sincronizzati senza diventare esclusioni imposte dai moderatori.
+
+La [separazione visibile](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) fa parte del modello di sicurezza. Definire la cronologia precedente una casella dei messaggi sicura ne rappresenterebbe in modo errato la provenienza, mentre migrarla silenziosamente farebbe supporre l'esistenza di una crittografia che non era presente quando è stata scritta.
+
+### ZapStore 1.1.2 convalida gli id degli eventi e la rotazione dei certificati
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) è stato pubblicato il 4 settembre con la convalida degli id degli eventi secondo NIP-01: il client ricalcola l'id di un evento in entrata e rifiuta eventuali discrepanze prima di utilizzarlo. La release identifica inoltre i pacchetti installati al di fuori di ZapStore. Sul server, la [conservazione degli hash dei certificati](https://github.com/zapstore/relay/pull/8) mantiene i tag `apk_certificate_hash` ripetuti, così la rotazione delle chiavi di firma Android può preservare una catena approvata.
+
+La [verifica dell'id dell'evento](https://github.com/zapstore/zapstore/releases/tag/1.1.2) impedisce a un relay o a una cache di modificare tag o contenuto mantenendo il vecchio id. L'indicatore della fonte di installazione fornisce informazioni distinte sulla provenienza quando un pacchetto Android con lo stesso id applicazione proviene da un altro canale.
+
+### Amber 6.6.1 mantiene attribuibili le risposte del firmatario
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) è stato pubblicato il 4 settembre dopo che l'analisi dei permessi è stata corretta per tollerare l'assenza del campo opzionale `kind` e le richieste di firma rifiutate hanno iniziato a restituire l'id della richiesta originale. Le applicazioni chiamanti possono associare un rifiuto all'operazione inviata. La release aggiorna inoltre le impostazioni predefinite del firmatario remoto e aggiunge un relay di indicizzazione.
+
+Nel loro insieme, queste [correzioni](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) preservano l'attribuzione in entrambe le direzioni: un record di autorizzazione rimane utilizzabile quando manca un campo opzionale e un rifiuto resta associato alla richiesta che lo ha provocato. Le modifiche ai relay predefiniti influiscono sulla scoperta, ma non sostituiscono la decisione di autorizzazione locale del firmatario.
+
+## In fase di sviluppo
+
+### Zap Cooking visualizza i riferimenti NIP-27 con indicazioni sui relay
+
+[Il merge del 4 settembre](https://github.com/zapcooking/frontend/pull/665) consente a [Zap Cooking](https://github.com/zapcooking/frontend) di visualizzare i riferimenti `nostr:npub` e `nostr:nprofile` in articoli, ricette, anteprime dell'editor e viste di stampa. Gli identificatori non validi restano testo, la risoluzione non è bloccante e l'editor mostra l'anteprima del Markdown che verrà firmato. Quando sono disponibili informazioni sui relay, un semplice `npub` diventa un `nprofile` con relay outbox e un tag `p` corrispondente.
+
+Nella stessa settimana sono state corrette le [letture del kind `30023` limitate all'autore](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7), sono stati aggiunti [relay di ricerca NIP-50 verificati](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea), con deduplicazione e protezioni contro le query obsolete, e sono state riparate le [chiamate ai wallet NIP-47](https://github.com/zapcooking/frontend/pull/705), dopo che modifiche alle dipendenze avevano compromesso saldi e cronologia.
+
+### Conduit riconcilia le preferenze firmate per relay e Blossom
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) ha integrato la [modifica delle preferenze Blossom](https://github.com/Conduit-BTC/conduit-mono/pull/374) il 2 settembre e la [riconciliazione delle preferenze firmate](https://github.com/Conduit-BTC/conduit-mono/pull/397) il 7 settembre. Market e Merchant conservano l'elenco di relay kind `10002` valido più recente e la dichiarazione inbox kind `10050`, mantengono un elenco firmato utilizzabile quando un evento più recente è malformato, distinguono un elenco esplicitamente vuoto da una ricerca non disponibile e non sostituiscono i relay dichiarati che non funzionano con i valori predefiniti del codice.
+
+[L'editor del kind `10063`](https://github.com/Conduit-BTC/conduit-mono/pull/374) consente a un utente di caricare, riordinare, esaminare, firmare esternamente, pubblicare e rileggere un elenco ordinato di server multimediali HTTPS senza contattare tali server né inserire un valore predefinito non dichiarato.
+
+### I destinatari di pagamento NIP-A3 arrivano in tre client
+
+Dal 1° al 3 settembre, [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) e [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) hanno implementato i destinatari di pagamento NIP-A3 kind `10133`. Amethyst offre un passaggio facoltativo solo quando esiste un destinatario compatibile e non lo trasforma in uno zap; Grimoire usa un registro fisso prima di creare gli URI del wallet; Pollerama convalida gli indirizzi Monero e recupera l'elenco di relay dell'autore prima di interrogare i destinatari. Ogni client necessita comunque di un metodo di pagamento consentito, di un percorso tramite relay e di una visualizzazione accurata.
+
+### Ditto amplia il fallback Blossom e gli incorporamenti live
+
+[Ditto](https://github.com/soapbox-pub/ditto) ha integrato un [fallback Blossom esteso e il mirroring](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) il 6 settembre. Avatar, badge, banner, immagini delle comunità, emoji personalizzate e icone delle applicazioni ora vengono cercati sui server dichiarati usando lo stesso hash del blob; i caricamenti per il mirroring usano un token di autorizzazione BUD-11 standard. Una [modifica del 4 settembre](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) ha aggiunto incorporamenti compatti per le dirette `kind:30311`.
+
+## Lavori sul protocollo e sulle specifiche
+
+### Possibilità di implementazione Nostr
+
+[NIP-01](/it/topics/nip-01/) ora chiarisce [il filtro `limit: 0`](https://github.com/nostr-protocol/nips/pull/2460), integrato il 4 settembre. Un relay DEVE restituire zero eventi archiviati, DEVE inviare `EOSE` al completamento delle query iniziali e DEVE mantenere attiva la sottoscrizione per i nuovi eventi corrispondenti. I client possono aprire una sottoscrizione riservata ai nuovi eventi con un solo campo di filtro, mantenendo al contempo la cronologia locale. Il chiarimento documenta un comportamento compatibile tra diverse implementazioni di relay e relay pubblici.
+
+[NIP-78](/it/topics/nip-78/) ha ricevuto un [requisito di autenticazione per i dati delle applicazioni](https://github.com/nostr-protocol/nips/pull/2458), integrato il 3 settembre. I relay DOVREBBERO richiedere l'autenticazione [NIP-42](/it/topics/nip-42/) per i kind `78` e `30078` e DOVREBBERO fornirli soltanto all'autore autenticato dell'evento. Si tratta di un DOVREBBERO, non di una garanzia di riservatezza: i client non possono considerare relay arbitrari come archivi privati. Il merge sconsiglia inoltre l'uso di kind personalizzati per i dati delle applicazioni come formato generico di scambio pubblico.
+
+[NIP-AC](/it/topics/nip-ac/) è stata aperta il 4 settembre come [proposta di segnalazione WebRTC](https://github.com/nostr-protocol/nips/pull/2461) esplicitamente aperta. Usa kind effimeri provvisori per ping, richieste di connessione, offerte, risposte e candidati ICE, indirizzati tramite `p` e raggruppati mediante un tag di sessione `e`; il kind `30600` supporta il rilevamento. I relay DOVREBBERO trasmettere e NON DEVONO archiviare tali eventi di segnalazione mentre i peer si connettono direttamente. I numeri restano provvisori, i client DOVREBBERO usare gli [elenchi di relay NIP-65](/it/topics/nip-65/) e le applicazioni che richiedono riservatezza DOVREBBERO cifrare il contenuto di offerte, risposte e candidati con [NIP-44](/it/topics/nip-44/).
+
+## Approfondimento NIP: link URI e riferimenti nel testo degli eventi
+
+Un identificatore Nostr necessita di un significato trasportabile prima che un'altra applicazione possa aprirlo. [NIP-21](/it/topics/nip-21/) inserisce un identificatore [NIP-19](/it/topics/nip-19/) dopo lo schema URI `nostr:`, fornendo a browser, sistemi operativi e applicazioni un unico formato instradabile. [NIP-27](/it/topics/nip-27/) definisce il significato dello stesso URI all'interno del `content` leggibile di un evento. NIP-21 attraversa il confine di un'applicazione; NIP-27 mantiene un riferimento a un profilo o a un evento all'interno di un testo firmato. Nessuna delle due crea un event kind né modifica i messaggi dei relay; le [due specifiche](https://github.com/nostr-protocol/nips/tree/master) definiscono soltanto il comportamento relativo ai collegamenti e alla visualizzazione.
+
+### Instradamento degli URI e semantica di NIP-19
+
+[La grammatica di NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) è composta da `nostr:` seguito da una singola entità bech32 NIP-19. `nsec` è escluso perché codifica una chiave privata. Non sono presenti componenti di autorità, percorso o query, quindi un link conforme è `nostr:npub1...`, non `nostr://npub1...`. Una piattaforma o un client può registrarsi come gestore; la specifica non sceglie l'applicazione installata né definisce un'alternativa web.
+
+Il prefisso indica al client cosa decodificare. `npub` contiene una chiave pubblica e `note` un id evento. `nprofile` aggiunge suggerimenti facoltativi sui relay a un profilo; `nevent` aggiunge relay, autore e kind a un id evento; `naddr` contiene invece l'autore, il kind e l'identificatore `d` di un evento indirizzabile, con relay facoltativi. Questi formati utilizzano i [campi tipo-lunghezza-valore di NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md). I suggerimenti restringono la ricerca, ma non dimostrano né che il relay disponga dell'evento né il controllo da parte dell'autore. Per ogni evento recuperato è comunque necessario ricalcolare l'id e verificare la firma.
+
+Il formato per i profili nella [specifica NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) è:
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definisce anche bridge HTML: una pagina che presenta un evento Nostr può inserire il relativo `naddr` in `<link rel="alternate">`, mentre un profilo può inserire un `nprofile` in `<link rel="me">` o `<link rel="author">`.
+
+### Rendering di NIP-27 e tag facoltativi
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) si applica a contenuti leggibili degli eventi, come le note di kind `1` e gli articoli di kind `30023`. Un editor può mostrare `@name`, ma pubblica `nostr:nprofile1...` nella stringa firmata. Un lettore analizza l'URI, decodifica la relativa entità NIP-19, recupera la destinazione e può visualizzare un nome, una scheda, un'anteprima o un link locale. Se la decodifica non riesce, l'URI rimane testo normale. Il contenuto grezzo non deve essere riscritto: modificarlo cambia la serializzazione NIP-01, l'id e la firma.
+
+I riferimenti nei contenuti e i tag svolgono funzioni correlate ma distinte. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) descrive i tag facoltativi `p` ed `e` e il tag `q` di [NIP-18](/it/topics/nip-18/). Un client può mostrare un riferimento senza creare una notifica o una relazione nel thread; per consentire di individuare una citazione, è opportuno inserire sia l'URI sia un tag `q`. [L'implementazione di Zap Cooking del 4 settembre](https://github.com/zapcooking/frontend/pull/665) segue questa distinzione, mantenendo l'URI e aggiungendo al contempo suggerimenti sui relay e un tag `p` corrispondente. L'aggiunta di `p` o `q` non rende privato l'URI e NIP-27 non prevede una modalità per le menzioni nascoste.
+
+Il seguente [evento di kind `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) è stato recuperato da `wss://nos.lol` e verificato prima di essere incluso come riferimento concreto a NIP-27. Il suo `content` contiene un `naddr` per un evento indirizzabile indipendente dalla versione. La decodifica restituisce il kind `30402`, l'autore `91036d...310a`, l'identificatore `d` del quaderno di lavoro e un suggerimento `wss://nos.lol/`. I tag `q`, `p`, `t`, `zap` e `client` sono scelte dell'applicazione, non requisiti di NIP-27.```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Fiducia, comportamento in caso di errore e implementazioni dei client
+
+Un lettore sicuro individua un token `nostr:` completo, convalida bech32, decodifica NIP-19, rifiuta `nsec`, ignora i tipi TLV sconosciuti e lascia invariato il testo malformato o di dimensioni eccessive. `npub` e `nprofile` portano a query sui profili; `note` e `nevent` identificano eventi immutabili; `naddr` seleziona l'evento indirizzabile valido più recente per il relativo kind, autore e tag `d`. I suggerimenti sui relay riducono l'ambito della ricerca, ma non estendono la fiducia. In base alle [regole sugli eventi di NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md), il client verifica l'id di un `nevent` recuperato e controlla la firma di ogni candidato `naddr` prima di applicare le regole di sostituzione degli eventi indirizzabili.
+
+Le anteprime in linea sono una scelta del client che comporta costi in termini di privacy e risorse. Recuperare ogni riferimento rivela gli interessi del lettore e può generare una raffica di richieste, quindi i client possono usare una cache, rinviare il recupero finché il riferimento non diventa visibile, limitare le richieste simultanee e richiedere un clic per i contenuti multimediali non riconosciuti. In base a [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md), un'anteprima deve rimanere distinta dal testo firmato dell'autore corrente. Un errore deve essere visibile sotto forma di testo non risolto o di scheda non disponibile, senza essere trattato silenziosamente come contenuto verificato.
+
+Anche la fiducia varia in base al tipo di identificatore. Un `nevent` identifica byte immutabili, quindi un client può rifiutare un evento recuperato il cui id serializzato differisce da quello richiesto. Un `naddr` identifica una coordinata sostituibile, quindi un client deve verificare ogni candidato e applicare le regole per gli eventi indirizzabili prima di decidere quale versione mostrare. In entrambi i casi, un suggerimento sul relay è utile per la prima query, ma non costituisce un'approvazione del relay o del contenuto restituito. La [definizione TLV di NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) fornisce i dati necessari per rendere espliciti questi controlli.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definisce un link portabile che può essere aperto dall'esterno di Nostr, mentre NIP-27 rende lo stesso link persistente all'interno del testo firmato. Un client che implementa soltanto NIP-21 può aprire un URI incollato, ma non visualizzare i riferimenti incorporati. Il supporto completo per NIP-27 aggiunge la scansione, la decodifica sicura, i criteri di recupero, la visualizzazione locale e una scelta esplicita relativa ai tag di notifica e citazione. L'URI condiviso mantiene interoperabili questi livelli senza obbligare i client a presentarli nello stesso modo.[Damus](https://github.com/damus-io/damus) rappresenta i riferimenti in linea come menzioni tipizzate. Il suo [codice per le menzioni](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) associa `npub` e `nprofile` ai riferimenti ai profili, `note` e `nevent` ai riferimenti agli eventi e `naddr` ai riferimenti agli indirizzi; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) li indirizza alla destinazione appropriata. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [analizza lo schema e i formati incollati](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), convalida bech32 ed estrae i suggerimenti sui relay, quindi [associa i riferimenti ai modelli del contenuto delle note](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) visualizza gli stessi riferimenti negli articoli, nelle ricette, nelle anteprime dell'editor e nelle viste di stampa.
+
+---
+
+Invia un DM NIP-17 per condividere un progetto o una notizia tramite il [progetto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/it/topics/nip-a3.md
+++ b/content/it/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Destinazioni di pagamento"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 definisce un metodo portabile con cui un account Nostr può pubblicare indirizzi di pagamento per più reti e servizi. Un evento sostituibile di kind `10133` contiene uno o più tag `payto`.
+
+## Come funziona
+
+Ogni tag ha la forma `["payto", "<type>", "<address>"]`. Il tipo è in minuscolo, come `bitcoin`, `lightning` o `monero`. I client possono convalidare i formati noti e generare un URI di pagamento nativo, laddove ne esista uno; per i tipi sconosciuti viene usato come ripiego lo schema URI `payto:` definito nella RFC 8905.
+
+L'evento dichiara le destinazioni, non un pagamento completato né uno zap Nostr. I client decidono comunque quali tipi di pagamento supportare, come convalidare un indirizzo e con quanta chiarezza mostrare la destinazione prima di passarla a un wallet.
+
+## Implementazioni
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) offre, su richiesta, il passaggio del pagamento quando riconosce una destinazione compatibile.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) associa i tipi di destinazione consentiti agli URI di pagamento.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) convalida le destinazioni Monero e interroga i relay dell'autore.
+
+---
+
+**Fonti primarie:**
+- [Specifica NIP-A3](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: lo schema URI payto](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Menzionato in:**
+- [Newsletter n. 39: le destinazioni di pagamento NIP-A3 arrivano su tre client](/it/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Vedi anche:**
+- [NIP-47: Nostr Wallet Connect](/it/topics/nip-47/)

--- a/content/ja/newsletters/2026-09-09-newsletter.md
+++ b/content/ja/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39では、署名付きgitワークフロー、ブラウザからの公開、セルフホスト型ライブ配信、コミュニティリレーへの同意、非公開イベント、目的を絞ったリリース、NIP-21とNIP-27のリンク規約を取り上げます。"
+---
+
+Nostrの週刊ガイド、[Nostr Compass](https://nostrcompass.org)へようこそ。
+
+**今週の内容:** [ngitとGitWorkshop](https://ngit.dev/v3)は、署名付きgitワークフローをNostrと[Blossom](/ja/topics/blossom/)上に移し、[nsite-clay](https://github.com/jooray/nsite-clay)はブラウザからの公開を復旧可能にし、[Wingman App](https://github.com/OtherStuffAI/wm-app)はブラウジング、ローカル署名、認証、ファイルを統合します。[ShoshoとLivelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0)はセルフホスト型配信をNostrに接続し、[Communitator](https://github.com/dyne/communitator)は署名前にリレーテンプレートを確認できるようにし、[cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)は予約枠を公開し、[Plektos](https://github.com/derekross/plektos/pull/16)は非公開イベントを暗号化します。タグ付きリリースでは、[Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)、[Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27)、[LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)、[SkateSpots](https://zapstore.dev/apps/org.skatespots.app)に復旧機能やプライバシー関連の改善が加わりました。開発作業は、[NIP-27](/ja/topics/nip-27/)のレンダリング、[Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397)における署名付きリレー設定、[NIP-A3](/ja/topics/nip-a3/)の支払先、Blossomミラーに及んでいます。[NIPsリポジトリ](https://github.com/nostr-protocol/nips)にマージされた変更では、ライブ限定サブスクリプションと認証済みアプリケーションデータが明確化されました。詳細解説では、[NIP-21](/ja/topics/nip-21/)リンクとNIP-27参照が、Nostrのプロフィールやイベントをアプリケーション間でどのように受け渡すかを説明します。
+
+## トップニュース
+
+### 署名付きgitワークフローがCI、非公開リポジトリ、リリースをNostr上に移行
+
+[9月8日のv3公開](https://ngit.dev/v3)により、ngit、GitWorkshop、ngit-grasp、ngit-ciが1つの署名付きワークフローに統合されました。[ngit](https://ngit.dev/ngit.git)はブランチ、パッチ、プルリクエストを[NIP-34](/ja/topics/nip-34/)イベントとして扱い、[GitWorkshop](https://ngit.dev/gitworkshop.git)はレビュー用インターフェースを提供します。今回の公開では、セルフホスト型継続的インテグレーションサービスであるngit-ci 0.1も追加されました。その指示と結果は署名付きNostrイベントとしてやり取りされるため、コードレビューと併せて、メンテナーが管理するハードウェア上でチェックを実行できます。
+
+同じリリースでは、[ngit-grasp v3](https://ngit.dev/ngit-grasp.git)がGRASP-08プライベートリポジトリ拡張を通じて非公開リポジトリに対応し、メンテナーの権限も明示されるようになりました。署名付きリリース記録から[Blossom](/ja/topics/blossom/)上のアセットを参照できるため、リリースのメタデータとコンテンツアドレス指定されたファイルの両方を、ホスト型forgeの外部に保持できます。[新しいドキュメントサイト](https://ngit.dev/v3)には、クライアント、非公開リポジトリ、CI、ウェブコンポーネントに関する情報がまとめられています。
+
+### nsite-clayがブラウザからの公開を復旧可能に
+
+[8月31日の署名ツールのプロンプト修正](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8)、[公開処理の復旧機能](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0)、[9月2日の編集コントロール](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7)により、[nsite-clay](https://github.com/jooray/nsite-clay)は単一ページサイト向けのブラウザ公開ツールになりました。ユーザーはドキュメントオブジェクトモデルをその場で編集し、結果をシリアライズして、コンテンツアドレス指定された[Blossom](/ja/topics/blossom/) blobとしてアップロードし、サイトの[NIP-5A](/ja/topics/nip-5a/)マニフェストを再公開します。ローカルでのビルドやサーバーは必要ありません。
+
+[ブラウザ公開ツール](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html)では、失敗した公開処理を復旧できるようになり、署名ツールのプロンプトが繰り返し表示される回数も減りました。[編集ガイド](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html)には、この一連の手順が記載されています。生成されるサイトは引き続き、既存のゲートウェイで利用できる通常のNIP-5Aサイトです。
+
+### Wingman Appがブラウジング、署名、ファイルを統合
+
+9月の開発では、[ファイルピッカー](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec)、[プロフィール公開](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704)、[安全な署名ツールとセッション復元](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6)、[テスト済みモバイルビルド](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac)が[Wingman App](https://github.com/OtherStuffAI/wm-app)に追加されました。Flutterシェルは、アプリ内で開いたページに[NIP-07](/ja/topics/nip-07/)プロバイダーを注入します。一方、Flight DeckとTowerを基盤とするDriveは、ブラウザの隣に作業画面とファイル用ワークスペースを提供します。
+
+Wingmanは[NIP-98](/ja/topics/nip-98/)を使用して、認証付きHTTPリクエストに署名します。[リクエストの実装](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs)は、サーバーが応答前に検証するイベントを構築します。これにより、端末に設定された1つのIDから、リレー操作、ウェブアプリでの署名、ファイルに対して一貫した承認手順を利用できます。
+
+### ShoshoがLivelierのセルフホスト型ストリームに対応
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0)は9月1日にリリースされ、[Livelier](https://github.com/r0d8lsh0p/livelier)への対応が追加されました。Livelierの[8月31日の帰属情報更新](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc)では、ブリッジされたプロフィールにブリッジとOwncastのソースが明記されるようになりました。LivelierはOwncastの公開ディレクトリを監視し、動画ストリームがライブ配信中かどうかを確認したうえで、アドレス指定可能な`kind:30311`の[NIP-53](/ja/topics/nip-53/)イベントを公開します。検出情報はNostr経由で配信されますが、動画は引き続き配信者のサーバーから提供されます。
+
+チャットは`kind:1311`イベントとしてブリッジを通過します。[ブリッジの設計](https://github.com/r0d8lsh0p/livelier)では、Nostrリーダーが購読している間だけソース側への接続を開き、派生したアイデンティティーにラベルを付け、一時的なチャットを3時間後に削除するリレーへ送信します。検出用リレーはブリッジキーからのライブイベント書き込みだけを受け入れ、チャットリレーは[NIP-42認証](/ja/topics/nip-42/)と[NIP-70の保護イベントフラグ](/ja/topics/nip-70/)を使用します。
+
+### Communitator、署名前にリレーテンプレートを確認可能に
+
+[8月31日に開始された一連の実装](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c)により、[Communitator](https://github.com/dyne/communitator)にkind `10002`のリレーリスト、kind `10063`のBlossomサーバー、kind `10050`のプライベートメッセージ受信箱向けの標準テンプレートが追加されました。署名者が接続する前に、アプリケーションは正規化されたエンドポイント、読み取り・書き込み権限、イベントkind、固定された公開先リレー、送信先を表示します。
+
+[範囲を制限した署名・公開フロー](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501)では、接続と適用が分離されています。各イベントは個別に署名され、1回の実行で使用するWebSocket接続は最大4つです。また、肯定的な[NIP-01](/ja/topics/nip-01/)の`OK`を受信した場合にのみ、その送信先への配信が成功として数えられます。結果は、完全、部分的、失敗、キャンセル済みの配信を区別します。共有テンプレートは信頼されていない推奨設定として扱われ、[同意画面](https://github.com/dyne/communitator#security-and-consent)では、リレーおよびネットワーク上で観測可能な情報について説明しています。
+
+### cal.emre.xyzがNIP-52の予約可能時間を公開
+
+公開リポジトリは[9月2日の最初のコミット](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)で開設され、その後、[cal.emre.xyz](https://cal.emre.xyz)について署名済みの[9月3日のハンドラー告知](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac)が公開されました。主催者は予約可能時間を`kind:31923`の[NIP-52](/ja/topics/nip-52/)イベントとして公開し、参加者は`kind:31925`のRSVPを公開します。
+
+リレーから主催者のイベントと承諾済みの予定ありRSVPを読み取り、重複する時間帯を除外します。Nostrイベントを別のデータベースへコピーせず、そのまま予定調整の記録として使用します。主催者は[NIP-07](/ja/topics/nip-07/)、[NIP-46](/ja/topics/nip-46/)、またはローカルキーで署名でき、参加者は別のキーを生成できます。この[リポジトリ](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)では、生成された`naddr`とカレンダーリンクも提供されており、メールはデフォルトで無効になっています。
+
+### Plektos、プライベートイベントを単一の暗号化チャンネルに統合
+
+[9月2日のプライベートイベント実装](https://github.com/derekross/plektos/pull/12)により、[Plektos](https://github.com/derekross/plektos)の各集まりが、[Concord](/ja/topics/concord-protocol/)暗号化コミュニティー内のプライベートチャンネルとして扱われるようになりました。招待客リスト、RSVP名簿、参加登録ボード、スレッド、寄付、カバー画像、編集、削除がまとめて暗号化されます。招待にはそのイベントのキーだけが含まれ、平文のカレンダーイベントは公開されません。
+
+[9月6日のライフサイクル監査](https://github.com/derekross/plektos/pull/14)では、500件を超えるラップが存在する場合でも直接検索できるよう、イベント定義IDを基準として固定しつつ、ページ分割されたフォールバックも維持しています。招待バンドルはイベント終了から30日後に期限切れとなり、無効化することもできます。ただし、すでにチャンネルキーを取得した人は、そのキーを保持できます。これとは別の[パーサーのセキュリティー修正](https://github.com/derekross/plektos/pull/16)では、不正な型・長さ・値（TLV）形式の[NIP-19](/ja/topics/nip-19/)識別子を受け取った際、パーサーが停止するのではなく処理を失敗させるようになりました。
+
+## タグ付きリリース
+
+### Vector 0.4.4、暗号化コミュニティーの復旧をより安全に
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)は8月31日にリリースされ、コミュニティーの復旧、キーローテーション、モデレーション、返信ルーティングに関する修正が加えられました。再創設時には、攻撃者が使用した招待経路に対して襲撃されたコミュニティーを閉鎖します。置き換え後のメンバーシップは古いローカル状態より優先され、1人のメンバーに到達できないだけで名簿全体が停止することもなくなりました。空のローテーションは拒否され、昇格時にはオンラインのメンバーが維持されます。また、必要なメンバーに到達できない場合、操作は実行されません。
+
+この[リリース](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)では、モデレーターによる削除と禁止が永続化され、パスワード変更後にゲストブックが再暗号化されるようになりました。また、再起動後も通知への返信が対応する会話に関連付けられ、検証済みのマルチプレイヤーパスだけが使用されます。これらは復旧のための制御であり、すでに取得されたキーを失効させるものではありません。
+
+### Primal Android 3.5.27、署名者とウォレットのアイデンティティーを確認
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27)は、[署名者のアイデンティティー確認](https://github.com/PrimalHQ/primal-android-app/pull/1108)と[ウォレットリクエスト認証](https://github.com/PrimalHQ/primal-android-app/pull/1105)が8月31日にマージされた後、9月3日にリリースされました。ローカル署名では、リクエストのアイデンティティーが保持しているアカウントと一致しない場合、そのリクエストを拒否します。また、受信した[NIP-47](/ja/topics/nip-47/)リクエストは処理前に認証されます。Zap投票のルーティングでは、投票が返信内に表示される場合も、投票先をその投票の作成者へ送信します。
+
+### GRAIN 0.8.0-rc2、保存されていないのに受理応答される経路を塞ぐ
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2)は9月7日にリリースされた。ストレージ障害により、非同期のLMDBデータベースライターが容量不足を検知する前に`OK`を返せる問題があった。リレーは容量使用率が80％と95％に達した時点で警告し、削除用の空きを残すため97％で新規イベントの受け入れを拒否するようになったほか、受理後に発生したライターの失敗も報告する。保持処理は古いものから順に走査し、終了処理は遅れて到着したメッセージを扱い、無効なフィルターが同列の有効なフィルターまで破棄することもなくなった。
+
+この[リリース](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2)では、kind `10166`のモニター告知とkind `30166`のリレーレポートも照合し、古くなったレポートを削除し、設定済みリレーをフォールバックとして維持する。また、静的なゼロ値ではなく、実際の制限値と認証情報を[NIP-11](/ja/topics/nip-11/)で報告する。
+
+### LibreNostr 0.5.0～0.5.2、Torルーティングをフェイルクローズ化
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)は9月7日にリリースされた。リレー、ザップ、アップロード、メディア、再生、プレビューを単一のSOCKSポート経由でルーティングするOrbotモードに加え、ザップシートのクラッシュ修正が含まれる。Orbotまたはプロキシが利用できない場合、直接接続に漏れることなく接続を停止する。[Version 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1)では、低速な[NIP-50](/ja/topics/nip-50/)検索がローカル結果の表示を遅らせる問題を解消した。[0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2)では、再帰的なスレッドレイアウトを置き換え、スレッドの順序を修正した。
+
+この[フェイルクローズ動作](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)は、リリースに記載されたすべてのネットワーク接続箇所に適用される。これらのクライアントは長時間存続するため、再起動が必要になる。パッチリリースでもこの方針は維持されており、同時に、無関係な検索、スタック深度、レイアウトの不具合を抑えている。
+
+### SkateSpots、端末内リレー経路を追加
+
+署名済みの[9月8日付Zapstoreリリース](https://zapstore.dev/apps/org.skatespots.app)では、SkateSpotsにオプションのCitrineリレーが追加された。スポット、クルー、メッセージ、地図データをローカルで読み込めるほか、投稿はオフライン時にキューへ格納され、端末内にもローカルコピーが保持される。既存の保管データとメッセージ内容は、引き続きエンドツーエンドで暗号化される。決済確認では、アクセスを許可したり貢献額として計上したりする前に、インボイス金額とプロバイダー発行のザップ領収書を要求する。
+
+この[ローカルリレー](https://zapstore.dev/apps/org.skatespots.app)は、保存と継続性のための選択肢であり、すべてのリモートリレーを置き換えるものではない。スケーターは接続が途切れている間も作業を続け、後から署名済みのアクティビティを同期できる。一方、決済まわりの変更により、自分で作成した領収書が決済完了の証明として扱われることを防ぐ。
+
+### Whistle 1.8.15、暗号化グループのライフサイクル復旧を修正
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15)は9月3日にリリースされた。Androidのライフサイクルに関する修正により、ルート単位の状態保持オブジェクトが、アプリケーション全体のリレー購読や位置情報の更新を破棄することがなくなった。リリースノートでは、ロックやDozeからの復帰後に接続状態が更新され、確認された事例では未処理だった501件のイベントが復旧したことも説明されている。
+
+この[バグ](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15)では、長時間存続するサービスの所有権が、短時間しか存続しない画面に結び付けられていた。Activityスコープのインスタンスを存続させ、単発の読み取り前にソケットを確認することで、通常のAndroid画面遷移やバックグラウンドでの休止によって、グループが空であるかのように見える可能性が低くなる。
+
+### TWENTY ONE Companion 1.12.0、暗号化DMを従来のチャットから分離
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0)は9月5日にリリースされ、[NIP-17](/ja/topics/nip-17/)のギフトラップDMに対応した。暗号化受信箱は従来のスペースチャットから分離されている。従来のメッセージは一度も暗号化されておらず、移行できないため、両者は明確に区別されたままとなる。PDFと動画はリレーのポリシーが許す範囲でサポートされ、個人の非表示設定はモデレーターによる禁止措置にはならずに同期される。
+
+この[視覚的な区別](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0)は、セキュリティモデルの一部である。古い履歴を安全な受信箱と呼べば、その来歴を誤って伝えることになる。一方、黙って移行すれば、作成時には存在しなかった暗号化が施されていたかのような印象を与える。
+
+### ZapStore 1.1.2、イベントidと証明書ローテーションを検証
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2)は9月4日にリリースされ、NIP-01のイベントid検証が導入された。クライアントは受信イベントの`id`を再計算し、一致しない場合は使用前に拒否する。このリリースでは、ZapStore以外からインストールされたパッケージも識別できる。サーバー側では、[証明書ハッシュの保持](https://github.com/zapstore/relay/pull/8)により、複数の`apk_certificate_hash`タグが保持されるため、Androidの署名鍵をローテーションしても、承認済みの鍵系統を維持できる。
+
+この[イベントid検証](https://github.com/zapstore/zapstore/releases/tag/1.1.2)により、リレーやキャッシュが古いidを維持したままタグや内容を変更することを防ぐ。インストール元の表示は、同じアプリケーションidを持つAndroidパッケージが別の配布経路から取得された場合に、その出所を別途示す。
+
+### Amber 6.6.1、署名者の応答をリクエストに対応付け可能に
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1)は9月4日にリリースされた。権限の解析処理が修正され、任意項目の`kind`が欠けていても処理できるようになったほか、拒否された署名リクエストが元のリクエストidを返すようになった。これにより、呼び出し元のアプリケーションは拒否応答を送信済みの操作と対応付けられる。このリリースでは、リモート署名者のデフォルト設定も更新され、インデクサーリレーが追加された。
+
+これらの[修正](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1)により、双方向の対応関係が維持される。任意項目が欠けていても権限レコードを使用でき、拒否応答も原因となったリクエストに結び付いたままとなる。リレーのデフォルト設定変更は検出に影響するが、署名者によるローカルの認可判断を置き換えるものではない。
+
+## 開発中
+
+### Zap Cookingがリレーヒント付きのNIP-27参照を表示
+
+[9月4日のマージ](https://github.com/zapcooking/frontend/pull/665)により、[Zap Cooking](https://github.com/zapcooking/frontend)は記事、レシピ、エディタープレビュー、印刷表示で`nostr:npub`および`nostr:nprofile`参照を表示するようになりました。無効な識別子はテキストのまま残り、解決処理はノンブロッキングで行われ、エディターでは署名対象となるMarkdownがプレビューされます。リレー情報が存在する場合、単独の`npub`はoutboxリレーと対応する`p`タグを含む`nprofile`になります。
+
+同じ週には、[著者でスコープされたkind `30023`の読み取り](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7)が修正され、重複排除と古いクエリに対するガードを備えた[検証済みNIP-50検索リレー](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea)が追加されました。また、依存関係の変更によって残高と履歴が機能しなくなったことを受け、[NIP-47ウォレット呼び出し](https://github.com/zapcooking/frontend/pull/705)が修復されました。
+
+### Conduitが署名済みのリレー設定とBlossom設定を整合
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono)は、9月2日に[Blossom設定の編集機能](https://github.com/Conduit-BTC/conduit-mono/pull/374)を、9月7日に[署名済み設定の整合処理](https://github.com/Conduit-BTC/conduit-mono/pull/397)をマージしました。MarketとMerchantは、最新の有効なkind `10002`リレーリストとkind `10050` inbox宣言を保持し、より新しいイベントが不正な形式の場合でも使用可能な署名済みリストを維持します。また、明示的な空のリストと取得不能な検索結果を区別し、宣言されたリレーへの接続に失敗してもコード内のデフォルト値で置き換えません。
+
+[kind `10063`エディター](https://github.com/Conduit-BTC/conduit-mono/pull/374)では、それらのサーバーに接続したり、宣言されていないデフォルトを挿入したりすることなく、順序付きHTTPSメディアサーバーリストの読み込み、並べ替え、確認、外部署名、公開、再読み込みが可能です。
+
+### NIP-A3の支払い先が3つのクライアントに導入
+
+9月1日から3日にかけて、[Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041)、[Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851)、[Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98)がNIP-A3のkind `10133`支払い先を実装しました。Amethystは、互換性のある支払い先が存在する場合にのみオプトイン方式の引き渡しを提供し、それをzapには変換しません。Grimoireは、ウォレットURIを構築する前に固定レジストリを使用します。PolleramaはMoneroアドレスを検証し、支払い先を照会する前に著者のリレーリストを取得します。各クライアントには引き続き、許可された支払い方法、リレールート、正確な表示が必要です。
+
+### DittoがBlossomフォールバックとライブ埋め込みを拡張
+
+[Ditto](https://github.com/soapbox-pub/ditto)は9月6日、[広範なBlossomフォールバックおよびミラーリング](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07)をマージしました。アバター、バッジ、バナー、コミュニティ画像、カスタム絵文字、アプリケーションアイコンは、同一のblobハッシュを使って宣言済みサーバーからの取得を試みるようになりました。ミラーへのアップロードには、標準のBUD-11認可トークンが使用されます。[9月4日の変更](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa)では、コンパクトな`kind:30311`ライブストリーム埋め込みが追加されました。
+
+## プロトコルと仕様に関する作業
+
+### Nostr実装の可能性
+
+[NIP-01](/ja/topics/nip-01/)では、9月4日にマージされた[`limit: 0`フィルターの明確化](https://github.com/nostr-protocol/nips/pull/2460)が行われました。リレーは保存済みイベントを返してはならず、初期クエリの完了時に`EOSE`を送信しなければならず、新たに一致するイベントを受け取るために購読を有効なまま維持しなければなりません。クライアントはローカル履歴を保持しつつ、1つのフィルターフィールドでライブイベント専用の購読を開けます。この明確化では、複数のリレー実装および公開リレーで互換性のある動作が記録されています。
+
+[NIP-78](/ja/topics/nip-78/)には、9月3日にマージされた[認証済みアプリデータの要件](https://github.com/nostr-protocol/nips/pull/2458)が追加されました。リレーはkind `78`および`30078`に対して[NIP-42](/ja/topics/nip-42/)認証を要求することが推奨され、認証されたイベント著者にのみそれらを提供することが推奨されます。これはSHOULDであり、機密性を保証するものではありません。クライアントは、任意のリレーをプライベートストレージとして扱うことはできません。このマージでは、カスタムのアプリデータkindを汎用的な公開データ交換に使用することも非推奨とされています。
+
+[NIP-AC](/ja/topics/nip-ac/)は9月4日、明示的にオープンな[WebRTCシグナリング提案](https://github.com/nostr-protocol/nips/pull/2461)として提出されました。ping、接続要求、offer、answer、ICE candidateには暫定的なephemeral kindを使用し、`p`で宛先を指定し、セッションの`e`タグでグループ化します。kind `30600`は検出をサポートします。ピア同士が直接接続する間、リレーはこれらのシグナリングイベントを配信することが推奨され、保存してはなりません。番号は引き続き暫定的であり、クライアントは[NIP-65リレーリスト](/ja/topics/nip-65/)を使用することが推奨されます。また、機密性を必要とするアプリケーションは、offer、answer、candidateのcontentを[NIP-44](/ja/topics/nip-44/)で暗号化することが推奨されます。
+
+## NIP詳細解説：イベントテキスト内のURIリンクと参照
+
+Nostr識別子を別のアプリケーションで開くには、移送可能な意味を持たせる必要があります。[NIP-21](/ja/topics/nip-21/)は、`nostr:` URIスキームの後に[NIP-19](/ja/topics/nip-19/)識別子を置くことで、ブラウザー、オペレーティングシステム、アプリケーションが処理先を判断できる統一形式を提供します。[NIP-27](/ja/topics/nip-27/)は、読み取り可能なイベントの`content`内で同じURIが何を意味するかを定義します。NIP-21はアプリケーションの境界を越えるためのものであり、NIP-27は署名済みの文章内にプロフィールまたはイベントへの参照を保持するためのものです。どちらもイベントkindを作成したり、リレーメッセージを変更したりするものではありません。[2つの仕様](https://github.com/nostr-protocol/nips/tree/master)が定義するのは、リンクと表示の動作だけです。
+
+### URI ディスパッチと NIP-19 のセマンティクス
+
+[NIP-21 の文法](https://github.com/nostr-protocol/nips/blob/master/21.md)は、`nostr:` の後に NIP-19 の bech32 エンティティを1つ続けたものです。`nsec` は秘密鍵をエンコードするため除外されます。オーソリティ、パス、クエリの各コンポーネントは存在しないため、準拠するリンクは `nostr://npub1...` ではなく `nostr:npub1...` です。プラットフォームやクライアントはハンドラーとして登録できますが、仕様では、インストール済みのどのアプリケーションを使用するかは選択せず、ウェブへのフォールバックも定義していません。
+
+プレフィックスは、何をデコードすべきかをクライアントに示します。`npub` は公開鍵を、`note` はイベント ID を格納します。`nprofile` はプロフィールに任意のリレーヒントを追加し、`nevent` はイベント ID にリレー、作者、kind を追加します。`naddr` は、アドレス指定可能なイベントの作者、kind、`d` 識別子を格納し、任意でリレーも含めます。これらの形式では、[NIP-19 の型・長さ・値フィールド](https://github.com/nostr-protocol/nips/blob/master/19.md)を使用します。ヒントは探索範囲を絞り込みますが、リレーがイベントを保有していることも、作者がそれを管理していることも証明しません。取得したすべてのイベントについて、引き続き ID の再計算と署名の検証が必要です。
+
+[NIP-21 仕様](https://github.com/nostr-protocol/nips/blob/master/21.md)に示されているプロフィール形式は次のとおりです。
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md)は HTML ブリッジも定義しています。Nostr イベントを提供するページは、その `naddr` を `<link rel="alternate">` に設定でき、プロフィールは `nprofile` を `<link rel="me">` または `<link rel="author">` に設定できます。
+
+### NIP-27 のレンダリングと任意タグ
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)は、kind `1` のノートや kind `30023` の記事など、人が読めるイベントコンテンツに適用されます。投稿作成画面では `@name` と表示できますが、署名対象の文字列には `nostr:nprofile1...` を含めて公開します。閲覧側は URI を走査し、その NIP-19 エンティティをデコードして対象を取得し、名前、カード、プレビュー、ローカルリンクなどを表示できます。デコードに失敗した場合、URI は通常のテキストとして残ります。生のコンテンツを書き換えてはいけません。変更すると NIP-01 のシリアライズ結果、ID、署名が変わるためです。
+
+コンテンツ内の参照とタグには、互いに関連するものの異なる役割があります。[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)では、任意の `p` タグと `e` タグ、および [NIP-18](/ja/topics/nip-18/) の `q` タグについて説明しています。クライアントは、通知やスレッド関係を作成せずに参照を表示できます。引用を探索できるようにするには、URI と `q` タグの両方を記述する必要があります。[Zap Cooking が9月4日に行った実装](https://github.com/zapcooking/frontend/pull/665)では、この区別に従い、URI を保持したままリレーヒントと対応する `p` タグを追加しています。`p` または `q` を追加しても URI が非公開になるわけではなく、NIP-27 に非表示メンションのモードはありません。
+
+以下の [kind `1` イベント](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a)は `wss://nos.lol` から復元され、NIP-27 の具体的な参照例として掲載する前に検証されています。その `content` には、バージョンに依存しないアドレス指定可能なイベントの `naddr` が含まれています。デコードすると、kind `30402`、作者 `91036d...310a`、ワークブックの `d` 識別子、および `wss://nos.lol/` ヒントが得られます。`q`、`p`、`t`、`zap`、`client` の各タグはアプリケーション側の選択であり、NIP-27 の要件ではありません。
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### 信頼性、障害時の挙動、クライアント実装
+
+安全なリーダーは、完全な `nostr:` トークンを見つけ、bech32 を検証し、NIP-19 をデコードして、`nsec` を拒否し、未知の TLV 型を無視します。また、不正な形式やサイズ超過のテキストは変更せず、そのまま残します。`npub` と `nprofile` はプロフィールの問い合わせに使用され、`note` と `nevent` は不変イベントを識別します。`naddr` は、kind、作成者、`d` タグに対応する最新の有効なアドレス指定可能イベントを選択します。リレーのヒントは検索範囲を狭めますが、信頼範囲を広げるものではありません。[NIP-01 のイベント規則](https://github.com/nostr-protocol/nips/blob/master/01.md)に従い、クライアントは取得した `nevent` の id を検証し、アドレス指定可能イベントの置換規則を適用する前に、すべての `naddr` 候補の署名を確認します。
+
+インラインプレビューを表示するかどうかはクライアントの選択であり、プライバシーとリソースのコストを伴います。すべての参照を取得すると読者の関心が明らかになり、大量の問い合わせが発生する可能性があります。そのため、クライアントはキャッシュを使用し、参照が表示範囲に入るまで取得を遅らせ、並行処理数に上限を設け、見慣れないメディアについてはクリックを必須にできます。[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)に従い、プレビューは現在の作成者が署名したテキストとは明確に区別されなければなりません。取得に失敗した場合は、未解決のテキストまたは利用できないカードとして明示し、検証済みコンテンツとして暗黙に扱ってはいけません。
+
+信頼性の扱いは識別子の種類によっても変わります。`nevent` は不変のバイト列を指定するため、取得したイベントのシリアライズ済み id が要求された id と異なる場合、クライアントはそのイベントを拒否できます。`naddr` は置換可能な座標を指定するため、クライアントは表示するバージョンを決定する前に、各候補を検証し、アドレス指定可能イベントの規則を適用する必要があります。どちらの場合も、リレーのヒントは最初の問い合わせに役立ちますが、そのリレーや返されたコンテンツを承認するものではありません。[NIP-19 の TLV 定義](https://github.com/nostr-protocol/nips/blob/master/19.md)は、これらの検証を明示的に行うために必要なデータを提供します。
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md)は Nostr の外部から開ける移植可能なリンクを定義し、NIP-27 は同じリンクを署名済みテキスト内で永続的に利用できるようにします。NIP-21 のみを実装したクライアントは、貼り付けられた URI を開けますが、埋め込まれた参照を表示できません。NIP-27 を完全にサポートするには、走査、安全なデコード、取得ポリシー、ローカルでの表示に加え、通知タグと引用タグをどう扱うかについての明示的な選択が必要です。共通の URI により、クライアントに同一の表示方法を強制することなく、これらの層の相互運用性が維持されます。[Damus](https://github.com/damus-io/damus)は、インライン参照を型付きメンションとしてモデル化しています。その[メンション用コード](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift)は、`npub` と `nprofile` をプロフィール参照に、`note` と `nevent` をイベント参照に、`naddr` をアドレス参照に対応付けます。[NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift)は、それらを適切な参照先へ振り分けます。[Primal Android](https://github.com/PrimalHQ/primal-android-app)は、[スキーム付き形式と貼り付けられた形式を解析](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt)し、bech32 を検証してリレーのヒントを抽出したうえで、[参照をノートコンテンツのモデルへ対応付けます](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt)。[Zap Cooking](https://github.com/zapcooking/frontend/pull/665)は、記事、レシピ、エディターのプレビュー、印刷表示で同じ参照を表示します。
+
+---
+
+プロジェクトやニュース項目を共有するには、[Nostr Compass プロジェクト](https://github.com/andotherstuff/nostr-compass)を通じて NIP-17 DM を送信してください。

--- a/content/ja/topics/nip-a3.md
+++ b/content/ja/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: 支払い先"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3は、Nostrアカウントが複数のネットワークやサービス向けの支払いアドレスを公開するための、移植可能な方法を定義します。置換可能なkind `10133`イベントには、1つ以上の`payto`タグが含まれます。
+
+## 仕組み
+
+各タグは`["payto", "<type>", "<address>"]`という形式です。typeは`bitcoin`、`lightning`、`monero`などの小文字です。クライアントは既知の形式を検証し、ネイティブの支払いURIが存在する場合はそれを表示できます。未知のtypeについては、RFC 8905の`payto:` URIスキームにフォールバックします。
+
+このイベントが示すのは支払い先であり、完了した支払いやNostr zapではありません。どの支払いタイプをサポートするか、アドレスをどのように検証するか、ウォレットに渡す前に支払い先をどれだけ明確に表示するかは、引き続きクライアントが決定します。
+
+## 実装
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041)は、互換性のある支払い先を認識した場合に、オプトイン方式で支払い処理をウォレットへ引き渡します。
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851)は、許可された支払い先のtypeを支払いURIに対応付けます。
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98)は、Moneroの支払い先を検証し、投稿者のリレーに問い合わせます。
+
+---
+
+**一次情報:**
+- [NIP-A3仕様](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: payto URIスキーム](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**掲載号:**
+- [ニュースレター第39号: NIP-A3の支払い先が3つのクライアントに対応](/ja/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**関連項目:**
+- [NIP-47: Nostr Wallet Connect](/ja/topics/nip-47/)

--- a/content/ko/newsletters/2026-09-09-newsletter.md
+++ b/content/ko/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39에서는 서명된 git 워크플로, 브라우저 게시, 자체 호스팅 라이브 스트림, 커뮤니티 릴레이 동의, 비공개 이벤트, 주요 릴리스, 그리고 NIP-21/NIP-27 링크 규약을 살펴봅니다."
+---
+
+Nostr 주간 안내서 [Nostr Compass](https://nostrcompass.org)에 다시 오신 것을 환영합니다.
+
+**이번 주:** [ngit과 GitWorkshop](https://ngit.dev/v3)은 서명된 git 워크플로를 Nostr와 [Blossom](/ko/topics/blossom/)으로 옮기고, [nsite-clay](https://github.com/jooray/nsite-clay)는 브라우저 게시를 복구 가능하게 만들며, [Wingman App](https://github.com/OtherStuffAI/wm-app)은 탐색, 로컬 서명, 인증, 파일을 하나로 결합합니다. [Shosho와 Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0)는 자체 호스팅 스트림을 Nostr에 연결하고, [Communitator](https://github.com/dyne/communitator)는 서명 전에 릴레이 템플릿을 검토할 수 있게 하며, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)는 예약 가능 시간대를 게시하고, [Plektos](https://github.com/derekross/plektos/pull/16)는 비공개 이벤트를 암호화합니다. 태그가 지정된 릴리스에서는 [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0), [SkateSpots](https://zapstore.dev/apps/org.skatespots.app)에 복구 및 개인정보 보호 관련 작업이 추가되었습니다. 개발 작업은 [NIP-27](/ko/topics/nip-27/) 렌더링, [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397)의 서명된 릴레이 환경설정, [NIP-A3](/ko/topics/nip-a3/) 결제 대상, Blossom 미러에 걸쳐 진행되었습니다. [NIPs 저장소](https://github.com/nostr-protocol/nips)에 병합된 변경 사항은 라이브 전용 구독과 인증된 애플리케이션 데이터를 명확히 설명합니다. 심층 분석에서는 [NIP-21](/ko/topics/nip-21/) 링크와 NIP-27 참조가 Nostr 프로필과 이벤트를 애플리케이션 간에 전달하는 방식을 설명합니다.
+
+## 주요 소식
+
+### 서명된 git 워크플로가 CI, 비공개 저장소, 릴리스를 Nostr로 옮기다
+
+[9월 8일 v3 출시](https://ngit.dev/v3)는 ngit, GitWorkshop, ngit-grasp, ngit-ci를 하나의 서명된 워크플로로 통합합니다. [ngit](https://ngit.dev/ngit.git)은 브랜치, 패치, pull request를 [NIP-34](/ko/topics/nip-34/) 이벤트로 전달하고, [GitWorkshop](https://ngit.dev/gitworkshop.git)은 검토 인터페이스를 제공합니다. 이번 출시에는 자체 호스팅 지속적 통합 서비스인 ngit-ci 0.1도 추가되었습니다. 이 서비스의 지시와 결과는 서명된 Nostr 이벤트로 전달되므로, 유지관리자가 제어하는 하드웨어에서 코드 검토와 함께 검사를 실행할 수 있습니다.
+
+같은 릴리스에서 [ngit-grasp v3](https://ngit.dev/ngit-grasp.git)는 GRASP-08 비공개 저장소 확장을 통해 비공개 저장소를 지원하고 유지관리자의 권한을 명시적으로 나타냅니다. 서명된 릴리스 기록은 [Blossom](/ko/topics/blossom/)의 자산을 가리킬 수 있으므로, 릴리스 메타데이터와 콘텐츠 주소 기반 파일을 모두 호스팅형 포지 외부에 보관할 수 있습니다. [새 문서 사이트](https://ngit.dev/v3)는 클라이언트, 비공개 저장소, CI, 웹 구성요소를 한곳에 모았습니다.
+
+### nsite-clay가 브라우저 게시를 복구 가능하게 만들다
+
+[8월 31일 서명자 프롬프트 수정](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), [게시 복구](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0), [9월 2일 편집 제어 기능](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7)을 통해 [nsite-clay](https://github.com/jooray/nsite-clay)는 단일 페이지 사이트를 위한 브라우저 게시 도구가 되었습니다. 사용자는 문서 객체 모델을 그 자리에서 편집하고 결과를 직렬화한 뒤, 콘텐츠 주소 기반 [Blossom](/ko/topics/blossom/) blob으로 업로드하고 사이트의 [NIP-5A](/ko/topics/nip-5a/) manifest를 다시 게시합니다. 로컬 빌드나 서버는 필요하지 않습니다.
+
+이제 [브라우저 게시 도구](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html)는 게시 실패 시 복구를 지원하고 반복되는 서명자 프롬프트를 줄이며, [편집 안내서](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html)는 이 과정을 설명합니다. 결과물은 기존 게이트웨이에서 사용할 수 있는 일반적인 NIP-5A 사이트로 유지됩니다.
+
+### Wingman App이 탐색, 서명, 파일을 결합하다
+
+9월 작업에서는 [파일 선택기](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), [프로필 게시](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), [안전한 서명자 및 세션 복원](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6), [테스트를 거친 모바일 빌드](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac)가 [Wingman App](https://github.com/OtherStuffAI/wm-app)에 추가되었습니다. Flutter 셸은 앱 내부에서 열린 페이지에 [NIP-07](/ko/topics/nip-07/) provider를 주입하며, Flight Deck과 Tower 기반 Drive는 브라우저 옆에 작업 공간과 파일 작업 영역을 제공합니다.
+
+Wingman은 [NIP-98](/ko/topics/nip-98/)을 사용해 인증된 HTTP 요청에 서명합니다. [요청 구현](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs)은 서버가 응답하기 전에 검증하는 이벤트를 생성하여, 설치된 하나의 신원이 릴레이 작업, 웹 앱 서명, 파일에 대해 일관된 승인 경로를 사용하도록 합니다.
+
+### Shosho, Livelier의 자체 호스팅 스트림 지원
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0)은 9월 1일 [Livelier](https://github.com/r0d8lsh0p/livelier) 지원과 함께 출시되었다. Livelier의 [8월 31일 출처 표시 업데이트](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc)는 브리지된 프로필에 브리지와 Owncast 출처를 표시한다. Livelier는 Owncast의 공개 디렉터리를 모니터링하고 동영상 스트림의 라이브 여부를 확인한 다음, 주소 지정이 가능한 `kind:30311` [NIP-53](/ko/topics/nip-53/) 이벤트를 게시한다. 탐색은 Nostr를 통해 이루어지지만 동영상은 스트리머의 서버에 남는다.
+
+채팅은 `kind:1311` 이벤트로 브리지를 통과한다. [브리지 설계](https://github.com/r0d8lsh0p/livelier)는 Nostr 리더가 구독 중일 때만 소스 측 연결을 열고, 파생된 신원에 라벨을 지정하며, 임시 채팅을 3시간 후 삭제하는 릴레이로 전송한다. 탐색 릴레이는 브리지 키에서 전송된 라이브 이벤트 쓰기만 허용하며, 채팅 릴레이는 [NIP-42 인증](/ko/topics/nip-42/)과 [NIP-70 보호 이벤트 플래그](/ko/topics/nip-70/)를 사용한다.
+
+### Communitator, 서명 전에 릴레이 템플릿을 검토할 수 있도록 개선
+
+[8월 31일 출시 시리즈](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c)를 통해 [Communitator](https://github.com/dyne/communitator)에 kind `10002` 릴레이 목록, kind `10063` Blossom 서버, kind `10050` 비공개 메시지 수신함을 위한 정규 템플릿이 추가되었다. 서명자가 연결되기 전에 애플리케이션은 정규화된 엔드포인트, 읽기/쓰기 권한, 이벤트 kind, 고정 게시 릴레이, 목적지를 보여준다.
+
+[범위가 제한된 서명 및 게시 흐름](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501)은 연결과 적용을 분리한다. 각 이벤트는 개별적으로 서명되며, 한 번의 실행에서 WebSocket 연결은 최대 4개까지만 사용하고, 긍정적인 [NIP-01](/ko/topics/nip-01/) `OK`를 받은 경우에만 목적지 전송으로 집계한다. 결과는 완전 전송, 부분 전송, 실패, 취소로 구분된다. 공유 템플릿은 신뢰할 수 없는 권고 사항으로 취급되며, [동의 화면](https://github.com/dyne/communitator#security-and-consent)은 릴레이와 네트워크에서 관찰 가능한 정보를 설명한다.
+
+### cal.emre.xyz, NIP-52 약속 가능 시간 게시
+
+공개 저장소는 [9월 2일 최초 커밋](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)으로 개설되었으며, 이어서 [cal.emre.xyz](https://cal.emre.xyz)를 위한 서명된 [9월 3일 핸들러 발표](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac)가 게시되었다. 호스트는 가능한 시간을 `kind:31923` [NIP-52](/ko/topics/nip-52/) 이벤트로 게시하고, 게스트는 `kind:31925` RSVP를 게시한다.
+
+이 서비스는 릴레이에서 호스트 이벤트와 수락된 일정 중복 RSVP를 읽고, 겹치는 시간대를 제외하며, Nostr 이벤트를 별도 데이터베이스에 복사하지 않고 일정 기록으로 유지한다. 호스트는 [NIP-07](/ko/topics/nip-07/), [NIP-46](/ko/topics/nip-46/), 또는 로컬 키로 서명할 수 있으며, 게스트는 별도의 키를 생성할 수 있다. [저장소](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)에서는 생성된 `naddr`와 캘린더 링크도 제공하며, 이메일은 기본적으로 비활성화되어 있다.
+
+### Plektos, 비공개 이벤트 전체를 하나의 암호화 채널로 구성
+
+[9월 2일 비공개 이벤트 구현](https://github.com/derekross/plektos/pull/12)은 각 [Plektos](https://github.com/derekross/plektos) 모임을 [Concord](/ko/topics/concord-protocol/) 암호화 커뮤니티 내부의 비공개 채널로 만든다. 게스트 목록, RSVP 명단, 신청 게시판, 스레드, 기여 내역, 표지 이미지, 수정 사항, 삭제 사항이 함께 암호화된다. 초대에는 해당 이벤트의 키만 포함되며, 평문 캘린더 이벤트는 게시되지 않는다.
+
+[9월 6일 수명 주기 감사](https://github.com/derekross/plektos/pull/14)는 wrap이 500개를 초과할 때 직접 조회할 수 있도록 이벤트 정의 id를 기준점으로 사용하면서, 페이지 단위 대체 조회 방식도 유지한다. 초대 번들은 이벤트 종료 30일 후 만료되며 비활성화할 수도 있지만, 이미 채널 키를 획득한 사람은 이를 계속 보유할 수 있다. 별도의 [파서 보안 수정](https://github.com/derekross/plektos/pull/16)은 잘못된 type-length-value (TLV) [NIP-19](/ko/topics/nip-19/) 식별자가 파서를 중단시키는 대신 처리 실패로 끝나도록 한다.
+
+## 태그된 릴리스
+
+### Vector 0.4.4, 암호화 커뮤니티 복구 안전성 개선
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)는 커뮤니티 복구, 키 교체, 관리, 답글 라우팅 수정과 함께 8월 31일 출시되었다. 재창립은 습격당한 커뮤니티에서 공격자가 사용한 초대 경로를 차단한다. 대체 멤버십은 오래된 로컬 상태를 무효화하며, 한 명의 멤버에게 연결할 수 없더라도 더 이상 명단 전체가 멈추지 않는다. 비어 있는 키 교체는 거부되고, 승격 과정에서 온라인 멤버가 유지되며, 필수 멤버에게 연결할 수 없으면 작업이 실행되지 않는다.
+
+이 [릴리스](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)는 관리자 삭제 및 차단 내역을 영구 저장하고, 비밀번호 변경 후 방명록을 다시 암호화하며, 재시작 후에도 알림 답글을 해당 대화에 연결하고, 검증된 멀티플레이어 경로만 사용한다. 이는 복구 제어 기능이며, 이미 획득한 키를 폐기하는 기능은 아니다.
+
+### Primal Android 3.5.27, 서명자와 지갑 신원 확인
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27)은 [서명자 신원 확인](https://github.com/PrimalHQ/primal-android-app/pull/1108)과 [지갑 요청 인증](https://github.com/PrimalHQ/primal-android-app/pull/1105)이 8월 31일 병합된 후 9월 3일 출시되었다. 로컬 서명은 요청의 신원이 현재 보유한 계정과 일치하지 않으면 요청을 거부하며, 수신된 [NIP-47](/ko/topics/nip-47/) 요청은 처리 전에 인증된다. Zap 투표 라우팅은 투표가 답글에 표시되는 경우에도 표를 투표 작성자에게 전송한다.
+
+### GRAIN 0.8.0-rc2, 확인 응답은 보냈지만 저장되지 않는 경로 차단
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2)는 비동기 LMDB 데이터베이스 기록기가 저장 공간이 가득 찬 것을 감지하기 전에 저장 실패 상황에서도 `OK`를 반환할 수 있었던 문제를 수정해 9월 7일 출시되었습니다. 이제 릴레이는 사용량이 80%와 95%에 도달하면 경고하고, 삭제에 필요한 공간을 남기기 위해 97%부터 새 이벤트를 거부하며, 수락 후 발생한 기록 실패를 보고합니다. 보존 처리는 가장 오래된 항목부터 순회하고, 종료 과정에서는 늦게 도착한 메시지를 처리하며, 유효하지 않은 필터가 더 이상 함께 있는 유효한 필터까지 폐기하지 않습니다.
+
+이 [릴리스](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2)는 또한 kind `10166` 모니터 공지와 kind `30166` 릴레이 보고서를 대조 확인하고, 오래된 보고서를 제거하며, 설정된 릴레이를 대체 경로로 유지합니다. 또한 정적인 0 대신 실제 제한과 인증 정보를 [NIP-11](/ko/topics/nip-11/)에 보고합니다.
+
+### LibreNostr 0.5.0–0.5.2, Tor 라우팅 장애 시 연결 차단
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)은 릴레이, zap, 업로드, 미디어, 재생, 미리보기를 하나의 SOCKS 포트를 통해 라우팅하는 Orbot 모드와 zap 시트 충돌 수정 사항을 포함해 9월 7일 출시되었습니다. Orbot이나 프록시를 사용할 수 없으면 직접 경로로 트래픽이 유출되지 않도록 연결을 중단합니다. [Version 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1)은 느린 [NIP-50](/ko/topics/nip-50/) 검색 때문에 로컬 결과가 지연되지 않도록 했으며, [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2)는 재귀적인 스레드 레이아웃을 교체하고 스레드 순서를 수정했습니다.
+
+이 [장애 시 차단 동작](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)은 릴리스에 명시된 모든 네트워크 접점에 적용되며, 해당 클라이언트가 장시간 유지되므로 재시작이 필요합니다. 패치 릴리스는 이 방식을 유지하면서 관련 없는 검색, 스택 깊이, 레이아웃 오류를 제한합니다.
+
+### SkateSpots, 기기 내 릴레이 경로 추가
+
+서명된 [9월 8일 Zapstore 릴리스](https://zapstore.dev/apps/org.skatespots.app)는 SkateSpots에 선택 사항인 Citrine 릴레이를 추가했습니다. 스팟, 크루, 메시지, 지도 데이터를 로컬에서 불러올 수 있고, 게시물은 오프라인 상태에서 대기열에 들어가며, 휴대전화에 로컬 사본이 보관됩니다. 기존 stash와 메시지 콘텐츠는 계속 종단간 암호화됩니다. 결제 확인에서는 접근 권한을 부여하거나 기여 금액을 집계하기 전에 인보이스 금액과 제공업체가 발급한 zap 영수증을 요구합니다.
+
+[로컬 릴레이](https://zapstore.dev/apps/org.skatespots.app)는 저장과 연속성을 위한 선택 사항이며, 모든 원격 릴레이를 대체하는 것은 아닙니다. 스케이터는 연결이 끊긴 동안에도 계속 작업한 뒤 나중에 서명된 활동을 동기화할 수 있습니다. 결제 변경 사항은 사용자가 직접 작성한 영수증이 결제 완료 증명으로 사용되는 것을 막습니다.
+
+### Whistle 1.8.15, 암호화 그룹의 수명 주기 복구 수정
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15)는 경로 수준 상태 보유자가 애플리케이션 전체의 릴레이 구독과 위치 업데이트를 종료하지 않도록 Android 수명 주기 문제를 수정한 뒤 9월 3일 출시되었습니다. 릴리스 노트에는 잠금 또는 doze 상태 이후 연결 상태가 새로 고쳐지고, 관찰된 사례에서 501개 이벤트의 적체가 복구되었다는 내용도 있습니다.
+
+이 [버그](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15)는 장시간 유지되는 서비스의 소유권을 수명이 짧은 화면에 연결한 데서 발생했습니다. activity 범위의 인스턴스를 계속 유지하고 일회성 읽기 전에 소켓을 확인함으로써, 일반적인 Android 화면 이동과 백그라운드 일시 중지가 빈 그룹처럼 보일 가능성을 줄였습니다.
+
+### TWENTY ONE Companion 1.12.0, 암호화 DM과 기존 채팅 분리
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0)은 [NIP-17](/ko/topics/nip-17/) gift-wrapped DM을 포함해 9월 5일 출시되었습니다. 암호화된 받은편지함은 이전의 space 채팅과 분리되어 있습니다. 해당 메시지는 애초에 암호화되지 않았고 이전할 수 없으므로 기존 채팅은 별도로 유지됩니다. 릴레이 정책이 허용하는 범위에서 PDF와 동영상을 지원하며, 개인 숨김 설정은 운영자 차단으로 바뀌지 않은 채 동기화됩니다.
+
+이처럼 [명확히 구분하는 방식](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0)은 보안 모델의 일부입니다. 이전 기록을 보안 받은편지함이라고 부르면 그 출처를 잘못 나타내게 되며, 이를 알리지 않고 이전하면 작성 당시에는 존재하지 않았던 암호화가 적용된 것처럼 보일 수 있습니다.
+
+### ZapStore 1.1.2, 이벤트 id와 인증서 교체 검증
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2)는 NIP-01 이벤트 id 검증 기능과 함께 9월 4일 출시되었습니다. 클라이언트는 수신 이벤트의 id를 다시 계산하고, 일치하지 않으면 사용하기 전에 거부합니다. 이 릴리스는 ZapStore 외부에서 설치된 패키지도 식별합니다. 서버에서는 [인증서 해시 보존](https://github.com/zapstore/relay/pull/8)을 통해 반복된 `apk_certificate_hash` 태그를 유지하므로, Android 서명 키를 교체할 때 승인된 계보를 보존할 수 있습니다.
+
+[이벤트 id 검사](https://github.com/zapstore/zapstore/releases/tag/1.1.2)는 릴레이나 캐시가 기존 id를 유지한 채 태그 또는 콘텐츠를 변경하지 못하게 합니다. 설치 출처 표시는 동일한 애플리케이션 id를 가진 Android 패키지가 다른 경로에서 설치되었을 때 별도의 출처 정보를 제공합니다.
+
+### Amber 6.6.1, 서명자 응답의 귀속 관계 유지
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1)은 선택 사항인 `kind`가 누락되어도 허용하도록 권한 구문 분석을 수정하고, 거부된 서명 요청이 원래 요청 id를 반환하도록 한 뒤 9월 4일 출시되었습니다. 호출한 애플리케이션은 거부 응답을 제출한 작업과 연결할 수 있습니다. 이 릴리스는 원격 서명자 기본값도 갱신하고 인덱서 릴레이를 추가했습니다.
+
+이러한 [수정 사항](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1)은 양방향의 귀속 관계를 유지합니다. 선택 사항인 필드가 없어도 권한 기록을 계속 사용할 수 있으며, 거부 응답도 이를 유발한 요청과 연결된 상태로 유지됩니다. 릴레이 기본값 변경은 검색에 영향을 주지만, 서명자의 로컬 승인 결정을 대체하지는 않습니다.
+
+## 개발 중
+
+### Zap Cooking, 릴레이 힌트가 포함된 NIP-27 참조 렌더링
+
+[9월 4일 병합된 변경 사항](https://github.com/zapcooking/frontend/pull/665)을 통해 [Zap Cooking](https://github.com/zapcooking/frontend)은 이제 글, 레시피, 에디터 미리보기, 인쇄 화면에서 `nostr:npub` 및 `nostr:nprofile` 참조를 렌더링한다. 유효하지 않은 식별자는 텍스트로 남고, 확인 과정은 작업을 차단하지 않으며, 에디터는 실제로 서명될 Markdown을 미리 보여준다. 릴레이 정보가 있으면 단순 `npub`은 아웃박스 릴레이와 그에 맞는 `p` 태그가 포함된 `nprofile`이 된다.
+
+같은 주에는 [작성자 범위로 제한된 kind `30023` 조회](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7)를 수정하고, 중복 제거 및 오래된 쿼리 방지 기능과 함께 [검증된 NIP-50 검색 릴레이](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea)를 추가했으며, 의존성 변경으로 잔액과 거래 내역이 작동하지 않게 된 후 [NIP-47 지갑 호출](https://github.com/zapcooking/frontend/pull/705)을 복구했다.
+
+### Conduit, 서명된 릴레이 및 Blossom 설정 조정
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono)는 9월 2일 [Blossom 설정 편집](https://github.com/Conduit-BTC/conduit-mono/pull/374)을, 9월 7일 [서명된 설정 조정](https://github.com/Conduit-BTC/conduit-mono/pull/397)을 병합했다. Market과 Merchant는 유효한 최신 kind `10002` 릴레이 목록과 kind `10050` 인박스 선언을 유지하고, 더 새로운 이벤트가 잘못된 형식이더라도 사용 가능한 서명 목록을 보존하며, 명시적으로 비어 있는 목록과 조회할 수 없는 목록을 구분한다. 또한 선언된 릴레이에 연결하지 못하더라도 이를 코드의 기본값으로 대체하지 않는다.
+
+[kind `10063` 편집기](https://github.com/Conduit-BTC/conduit-mono/pull/374)를 사용하면 해당 서버에 접속하거나 선언되지 않은 기본 서버를 삽입하지 않고도 순서가 지정된 HTTPS 미디어 서버 목록을 불러오고, 순서를 변경하고, 검토하고, 외부에서 서명하고, 게시한 뒤 다시 읽을 수 있다.
+
+### 세 클라이언트에 도입된 NIP-A3 결제 대상
+
+9월 1일부터 3일까지 [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851), [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98)는 NIP-A3 kind `10133` 결제 대상을 구현했다. Amethyst는 호환되는 대상이 있을 때만 사용자가 선택적으로 결제 앱으로 넘길 수 있도록 하며 이를 zap으로 바꾸지 않는다. Grimoire는 지갑 URI를 만들기 전에 고정 레지스트리를 사용한다. Pollerama는 Monero 주소를 검증하고 대상을 조회하기 전에 작성자의 릴레이 목록을 가져온다. 각 클라이언트에는 여전히 허용된 결제 방식, 릴레이 경로, 정확한 표시가 필요하다.
+
+### Ditto, Blossom 대체 경로와 라이브 임베드 확장
+
+[Ditto](https://github.com/soapbox-pub/ditto)는 9월 6일 [광범위한 Blossom 대체 경로 및 미러링](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07)을 병합했다. 이제 아바타, 배지, 배너, 커뮤니티 이미지, 사용자 지정 이모지, 애플리케이션 아이콘은 동일한 blob 해시를 사용해 선언된 서버에서 가져오기를 시도한다. 미러 업로드에는 표준 BUD-11 인증 토큰을 사용한다. [9월 4일 변경 사항](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa)에서는 간결한 `kind:30311` 라이브 스트림 임베드를 추가했다.
+
+## 프로토콜 및 명세 작업
+
+### Nostr 구현 가능성
+
+[NIP-01](/ko/topics/nip-01/)에는 9월 4일 병합된 [`limit: 0` 필터에 관한 설명](https://github.com/nostr-protocol/nips/pull/2460)이 추가됐다. 릴레이는 저장된 이벤트를 하나도 반환하지 않아야 하고, 초기 쿼리가 완료되면 반드시 `EOSE`를 전송해야 하며, 새롭게 일치하는 이벤트를 받을 수 있도록 구독을 활성 상태로 유지해야 한다. 클라이언트는 로컬 기록을 유지하면서 필터 필드 하나만으로 실시간 전용 구독을 열 수 있다. 이 설명에는 여러 릴레이 구현체와 공개 릴레이에서 호환되는 동작이 기록되어 있다.
+
+[NIP-78](/ko/topics/nip-78/)에는 9월 3일 병합된 [인증된 앱 데이터 요구 사항](https://github.com/nostr-protocol/nips/pull/2458)이 추가됐다. 릴레이는 kinds `78` 및 `30078`에 대해 [NIP-42](/ko/topics/nip-42/) 인증을 요구하는 것이 권장되며, 인증된 이벤트 작성자에게만 이를 제공하는 것이 권장된다. 이는 권고 사항일 뿐 기밀성을 보장하지 않는다. 클라이언트는 임의의 릴레이를 비공개 저장소로 간주할 수 없다. 또한 이 병합에서는 사용자 지정 앱 데이터 kind를 범용 공개 교환 형식으로 사용하는 것을 권장하지 않는다.
+
+[NIP-AC](/ko/topics/nip-ac/)는 명시적으로 논의가 열려 있는 [WebRTC 시그널링 제안](https://github.com/nostr-protocol/nips/pull/2461)으로 9월 4일 공개됐다. 이 제안은 ping, 연결 요청, offer, answer, ICE candidate에 임시 ephemeral kinds를 사용하며, `p`로 수신자를 지정하고 세션 `e` 태그로 그룹화한다. kind `30600`은 검색을 지원한다. 릴레이는 해당 시그널링 이벤트를 브로드캐스트하는 것이 권장되며 이를 저장해서는 안 되고, 피어는 직접 연결된다. 번호는 아직 잠정적이며, 클라이언트는 [NIP-65 릴레이 목록](/ko/topics/nip-65/)을 사용하는 것이 권장된다. 기밀성이 필요한 애플리케이션은 offer, answer, candidate 콘텐츠를 [NIP-44](/ko/topics/nip-44/)로 암호화하는 것이 권장된다.
+
+## NIP 심층 분석: 이벤트 텍스트의 URI 링크와 참조
+
+다른 애플리케이션에서 Nostr 식별자를 열려면 먼저 애플리케이션 간에 전달 가능한 의미가 있어야 한다. [NIP-21](/ko/topics/nip-21/)은 `nostr:` URI 스킴 뒤에 [NIP-19](/ko/topics/nip-19/) 식별자를 배치해 브라우저, 운영 체제, 애플리케이션이 처리할 수 있는 단일 형식을 제공한다. [NIP-27](/ko/topics/nip-27/)은 읽을 수 있는 이벤트 `content` 안에서 동일한 URI가 무엇을 의미하는지 정의한다. NIP-21은 애플리케이션 경계를 넘고, NIP-27은 서명된 글 안에 프로필이나 이벤트 참조를 유지한다. 어느 쪽도 이벤트 kind를 만들거나 릴레이 메시지를 변경하지 않는다. [두 명세](https://github.com/nostr-protocol/nips/tree/master)는 링크 및 렌더링 동작만 정의한다.
+
+### URI 디스패치와 NIP-19 의미론
+
+[NIP-21의 문법](https://github.com/nostr-protocol/nips/blob/master/21.md)은 `nostr:` 뒤에 하나의 NIP-19 bech32 엔티티가 오는 형식이다. `nsec`은 개인 키를 인코딩하므로 제외된다. 권한, 경로 또는 쿼리 구성 요소가 없으므로 규격을 준수하는 링크는 `nostr://npub1...`이 아니라 `nostr:npub1...`이다. 플랫폼이나 클라이언트가 핸들러로 등록할 수 있지만, 사양은 설치된 애플리케이션을 선택하거나 웹 대체 동작을 정의하지 않는다.
+
+접두사는 클라이언트가 무엇을 디코딩해야 하는지 알려준다. `npub`에는 공개 키가, `note`에는 이벤트 id가 담긴다. `nprofile`은 프로필에 선택적 릴레이 힌트를 추가하고, `nevent`는 이벤트 id에 릴레이, 작성자, kind를 추가하며, `naddr`에는 주소 지정 가능 이벤트의 작성자, kind, `d` 식별자와 선택적 릴레이가 담긴다. 이러한 형식은 [NIP-19 type-length-value 필드](https://github.com/nostr-protocol/nips/blob/master/19.md)를 사용한다. 힌트는 검색 범위를 좁히지만, 릴레이가 이벤트를 보유하고 있는지 또는 작성자가 통제권을 갖고 있는지를 입증하지는 않는다. 가져온 모든 이벤트는 여전히 id를 다시 계산하고 서명을 확인해야 한다.
+
+[NIP-21 사양](https://github.com/nostr-protocol/nips/blob/master/21.md)의 프로필 형식은 다음과 같다.
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md)은 HTML 브리지도 정의한다. Nostr 이벤트를 제공하는 페이지는 `<link rel="alternate">`에 해당 이벤트의 `naddr`를 넣을 수 있고, 프로필은 `<link rel="me">` 또는 `<link rel="author">`에 `nprofile`을 넣을 수 있다.
+
+### NIP-27 렌더링과 선택적 태그
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)은 kind `1` 노트와 kind `30023` 글처럼 사람이 읽을 수 있는 이벤트 콘텐츠에 적용된다. 작성기는 `@name`을 표시할 수 있지만, 서명되는 문자열에는 `nostr:nprofile1...`을 게시한다. 리더는 URI를 검색하고 해당 NIP-19 엔티티를 디코딩한 뒤 대상을 가져오며, 이름, 카드, 미리보기 또는 로컬 링크를 렌더링할 수 있다. 디코딩에 실패하면 URI는 일반 텍스트로 남는다. 원본 콘텐츠는 다시 작성해서는 안 된다. 이를 변경하면 NIP-01 직렬화, id, 서명이 바뀐다.
+
+콘텐츠 참조와 태그는 서로 관련되어 있지만 역할은 구분된다. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)은 선택적 `p` 및 `e` 태그와 [NIP-18](/ko/topics/nip-18/)의 `q` 태그를 설명한다. 클라이언트는 알림이나 스레드 관계를 만들지 않고 참조를 표시할 수 있다. 인용을 검색할 수 있게 하려면 URI와 `q` 태그를 모두 기록해야 한다. [Zap Cooking의 9월 4일 구현](https://github.com/zapcooking/frontend/pull/665)은 URI를 유지하면서 릴레이 힌트와 일치하는 `p` 태그를 추가해 이러한 구분을 따른다. `p` 또는 `q`를 추가해도 URI가 비공개로 바뀌지는 않으며, NIP-27에는 숨겨진 멘션 모드가 없다.
+
+다음 [kind `1` 이벤트](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a)는 `wss://nos.lol`에서 복구되었으며, 구체적인 NIP-27 참조로 포함하기 전에 검증되었다. 이 이벤트의 `content`에는 버전에 독립적인 주소 지정 가능 이벤트를 가리키는 `naddr`가 들어 있다. 이를 디코딩하면 kind `30402`, 작성자 `91036d...310a`, 워크북의 `d` 식별자, `wss://nos.lol/` 힌트를 얻는다. `q`, `p`, `t`, `zap`, `client` 태그는 애플리케이션이 선택한 것이며 NIP-27의 요구 사항이 아니다.
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### 신뢰, 실패 동작 및 클라이언트 구현
+
+안전한 리더는 완전한 `nostr:` 토큰을 찾고, bech32를 검증하며, NIP-19를 디코딩하고, `nsec`을 거부하며, 알 수 없는 TLV 유형을 무시하고, 잘못된 형식이거나 지나치게 큰 텍스트는 그대로 둔다. `npub`과 `nprofile`은 프로필 쿼리로 이어지고, `note`와 `nevent`는 변경 불가능한 이벤트를 식별하며, `naddr`는 해당 kind, 작성자 및 `d` 태그에 맞는 최신 유효 주소 지정 가능 이벤트를 선택한다. 릴레이 힌트는 검색 범위를 줄이지만 신뢰 범위를 넓히지는 않는다. [NIP-01 이벤트 규칙](https://github.com/nostr-protocol/nips/blob/master/01.md)에 따라 클라이언트는 가져온 `nevent`의 id를 검증하고, 주소 지정 가능 이벤트의 교체 규칙을 적용하기 전에 모든 `naddr` 후보의 서명을 확인한다.
+
+인라인 미리보기는 개인정보 보호와 리소스 비용을 고려해 클라이언트가 선택할 사항이다. 모든 참조를 가져오면 독자의 관심사가 드러나고 조회 요청이 폭증할 수 있으므로, 클라이언트는 캐시를 사용하고, 화면에 표시될 때까지 가져오기를 미루며, 동시 요청 수를 제한하고, 익숙하지 않은 미디어는 클릭해야 불러오도록 할 수 있다. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)에 따라 미리보기는 현재 작성자가 서명한 텍스트와 명확히 구분되어야 한다. 실패한 경우 검증된 콘텐츠로 조용히 처리해서는 안 되며, 해석되지 않은 텍스트나 이용할 수 없는 카드로 표시해야 한다.
+
+식별자 유형에 따라서도 신뢰 방식이 달라진다. `nevent`는 변경 불가능한 바이트를 가리키므로, 클라이언트는 직렬화된 id가 요청한 id와 다른 이벤트를 거부할 수 있다. `naddr`는 교체 가능한 좌표를 가리키므로, 클라이언트는 표시할 버전을 결정하기 전에 각 후보를 검증하고 주소 지정 가능 이벤트 규칙을 적용해야 한다. 어느 경우든 릴레이 힌트는 첫 번째 쿼리에 유용하지만, 해당 릴레이나 반환된 콘텐츠를 보증하지는 않는다. [NIP-19의 TLV 정의](https://github.com/nostr-protocol/nips/blob/master/19.md)는 이러한 검사를 명시적으로 수행하는 데 필요한 데이터를 제공한다.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md)은 Nostr 외부에서 열 수 있는 이식 가능한 링크를 정의하고, NIP-27은 동일한 링크가 서명된 텍스트 안에서 지속적으로 유지되도록 한다. NIP-21만 구현한 클라이언트는 붙여넣은 URI를 열 수 있지만 내장된 참조를 렌더링할 수는 없다. NIP-27을 완전히 지원하려면 스캔, 안전한 디코딩, 가져오기 정책, 로컬 렌더링, 알림 및 인용 태그에 관한 명시적인 선택이 추가로 필요하다. 공통 URI를 사용하면 클라이언트가 이러한 계층을 동일하게 표시하도록 강제하지 않으면서도 상호 운용성을 유지할 수 있다. [Damus](https://github.com/damus-io/damus)는 인라인 참조를 유형이 지정된 멘션으로 모델링한다. Damus의 [멘션 코드](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift)는 `npub`과 `nprofile`을 프로필 참조에, `note`와 `nevent`를 이벤트 참조에, `naddr`를 주소 참조에 매핑하며, [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift)는 이를 적절한 대상으로 연결한다. [Primal Android](https://github.com/PrimalHQ/primal-android-app)는 [스킴과 붙여넣은 형식을 파싱하고](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), bech32를 검증하며 릴레이 힌트를 추출한 다음, [참조를 노트 콘텐츠 모델에 매핑한다](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665)은 기사, 레시피, 편집기 미리보기 및 인쇄 보기에서 동일한 참조를 렌더링한다.
+
+---
+
+프로젝트나 뉴스 항목을 공유하려면 [Nostr Compass 프로젝트](https://github.com/andotherstuff/nostr-compass)를 통해 NIP-17 DM을 보내면 된다.

--- a/content/ko/topics/nip-a3.md
+++ b/content/ko/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: 결제 대상"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3는 Nostr 계정이 여러 네트워크와 서비스의 결제 주소를 게시할 수 있는 이식성 있는 방식을 정의합니다. 교체 가능한 kind `10133` 이벤트에는 하나 이상의 `payto` 태그가 포함됩니다.
+
+## 작동 방식
+
+각 태그의 형식은 `["payto", "<type>", "<address>"]`입니다. type은 `bitcoin`, `lightning`, `monero`처럼 소문자로 표기합니다. 클라이언트는 알려진 형식을 검증하고 해당 형식의 네이티브 결제 URI가 있는 경우 이를 표시할 수 있습니다. 알 수 없는 type에는 RFC 8905의 `payto:` URI 스킴을 사용합니다.
+
+이 이벤트는 결제 목적지를 선언하며, 완료된 결제나 Nostr zap을 나타내지는 않습니다. 어떤 결제 type을 지원할지, 주소를 어떻게 검증할지, 지갑으로 넘기기 전에 목적지를 얼마나 명확하게 표시할지는 여전히 클라이언트가 결정합니다.
+
+## 구현
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041)는 호환되는 대상을 인식하면 사용자가 선택할 수 있는 결제 전달 기능을 제공합니다.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851)는 허용된 대상 type을 결제 URI에 매핑합니다.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98)는 Monero 대상을 검증하고 작성자의 relay를 조회합니다.
+
+---
+
+**주요 출처:**
+- [NIP-A3 명세](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: payto URI 스킴](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**언급된 뉴스레터:**
+- [뉴스레터 #39: NIP-A3 결제 대상을 지원하는 클라이언트가 3개로 증가](/ko/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**함께 보기:**
+- [NIP-47: Nostr Wallet Connect](/ko/topics/nip-47/)

--- a/content/nl/newsletters/2026-09-09-newsletter.md
+++ b/content/nl/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 volgt ondertekende git-workflows, publiceren vanuit de browser, zelfgehoste livestreams, toestemming voor communityrelays, privé-events, gerichte releases en het linkcontract van NIP-21/NIP-27."
+---
+
+Welkom terug bij [Nostr Compass](https://nostrcompass.org), je wekelijkse gids voor Nostr.
+
+**Deze week:** [ngit en GitWorkshop](https://ngit.dev/v3) brengen ondertekende git-workflows naar Nostr en [Blossom](/nl/topics/blossom/), [nsite-clay](https://github.com/jooray/nsite-clay) maakt publiceren vanuit de browser herstelbaar en [Wingman App](https://github.com/OtherStuffAI/wm-app) brengt browsen, lokaal ondertekenen, authenticatie en bestanden samen. [Shosho en Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) verbinden zelfgehoste streams met Nostr, [Communitator](https://github.com/dyne/communitator) maakt relay-sjablonen vóór ondertekening inspecteerbaar, [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) publiceert tijdvakken voor afspraken en [Plektos](https://github.com/derekross/plektos/pull/16) versleutelt privé-events. Releases met tags voegen herstel- en privacywerk toe in [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) en [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). Het ontwikkelwerk omvat weergave volgens [NIP-27](/nl/topics/nip-27/), ondertekende relayvoorkeuren in [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), betalingsdoelen volgens [NIP-A3](/nl/topics/nip-a3/) en Blossom-mirrors. Samengevoegde wijzigingen in de [NIPs-repository](https://github.com/nostr-protocol/nips) verduidelijken uitsluitend live gebruikte abonnementen en geauthenticeerde applicatiegegevens. In onze diepgaande bespreking leggen we uit hoe links volgens [NIP-21](/nl/topics/nip-21/) en verwijzingen volgens NIP-27 Nostr-profielen en -events tussen applicaties overbrengen.
+
+## Belangrijkste verhalen
+
+### Ondertekende git-workflows brengen CI, privérepository's en releases naar Nostr
+
+De [lancering van v3 op 8 september](https://ngit.dev/v3) brengt ngit, GitWorkshop, ngit-grasp en ngit-ci samen in één ondertekende workflow. [ngit](https://ngit.dev/ngit.git) verwerkt branches, patches en pull requests als events volgens [NIP-34](/nl/topics/nip-34/), terwijl [GitWorkshop](https://ngit.dev/gitworkshop.git) de beoordelingsinterface biedt. De lancering voegt ngit-ci 0.1 toe, een zelfgehoste dienst voor continue integratie waarvan de instructies en resultaten als ondertekende Nostr-events worden uitgewisseld. Daardoor kunnen controles naast de codebeoordeling worden uitgevoerd op hardware die door beheerders wordt gecontroleerd.
+
+Dezelfde release biedt [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) privérepository's via de GRASP-08-extensie voor privérepository's en maakt de bevoegdheid van beheerders expliciet. Ondertekende releasegegevens kunnen verwijzen naar bestanden in [Blossom](/nl/topics/blossom/), zodat zowel de releasemetadata als de inhoudsgeadresseerde bestanden buiten een gehoste forge blijven. De [nieuwe documentatiesite](https://ngit.dev/v3) brengt de onderdelen voor de client, privérepository's, CI en het web samen.
+
+### nsite-clay maakt publiceren vanuit de browser herstelbaar
+
+Een [oplossing van 31 augustus voor signer-prompts](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), [herstel van publicaties](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) en [bewerkingsfuncties van 2 september](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) maken van [nsite-clay](https://github.com/jooray/nsite-clay) een browsertool voor het publiceren van een site met één pagina. Een gebruiker bewerkt het document object model direct, serialiseert het resultaat, uploadt het als een inhoudsgeadresseerde [Blossom](/nl/topics/blossom/)-blob en publiceert het [NIP-5A](/nl/topics/nip-5a/)-manifest van de site opnieuw. Er is geen lokale build of server nodig.
+
+De [browserpublisher](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) maakt herstel na een mislukte publicatie nu mogelijk en vermindert het aantal herhaalde signer-prompts, terwijl de [bewerkingsgids](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) de cyclus documenteert. Het resultaat blijft een reguliere NIP-5A-site voor bestaande gateways.
+
+### Wingman App brengt browsen, ondertekenen en bestanden samen
+
+Het werk in september voegt [bestandskiezers](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), [profielpublicatie](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), [veilig herstel van signer en sessie](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) en [geteste mobiele builds](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac) toe aan [Wingman App](https://github.com/OtherStuffAI/wm-app). De Flutter-shell injecteert een [NIP-07](/nl/topics/nip-07/)-provider in pagina's die binnen de app worden geopend, terwijl Flight Deck en de door Tower ondersteunde Drive naast de browser een werkoppervlak en bestandswerkruimte bieden.
+
+Wingman ondertekent geauthenticeerde HTTP-verzoeken met [NIP-98](/nl/topics/nip-98/). De [implementatie van verzoeken](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) stelt het event samen dat een server controleert voordat die antwoordt. Zo krijgt één geïnstalleerde identiteit een consistent goedkeuringsproces voor relayacties, het ondertekenen vanuit webapps en bestanden.
+
+### Shosho brengt zelfgehoste streams van Livelier
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) verscheen op 1 september met ondersteuning voor [Livelier](https://github.com/r0d8lsh0p/livelier), waarvan de [update van de bronvermelding van 31 augustus](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) de bridge en de Owncast-bron vermeldt in gekoppelde profielen. Livelier volgt de openbare directory van Owncast, controleert of een videostream live is en publiceert vervolgens een adresseerbaar `kind:30311`-[NIP-53](/nl/topics/nip-53/)-event. Ontdekking verloopt via Nostr, terwijl de video op de server van de streamer blijft.
+
+Chat gaat via de bridge als `kind:1311`-events. Het [bridgeontwerp](https://github.com/r0d8lsh0p/livelier) opent alleen een verbinding aan de bronzijde zolang een Nostr-lezer geabonneerd is, labelt afgeleide identiteiten en stuurt tijdelijke chatberichten naar een relay die ze na drie uur verwijdert. De relay voor ontdekking accepteert schrijfacties voor live-events uitsluitend van de bridgesleutel. De chatrelay gebruikt [NIP-42-authenticatie](/nl/topics/nip-42/) en [NIP-70-vlaggen voor beschermde events](/nl/topics/nip-70/).
+
+### Communitator maakt relaytemplates vóór ondertekening inspecteerbaar
+
+De [reeks lanceringen van 31 augustus](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) voorziet [Communitator](https://github.com/dyne/communitator) van canonieke templates voor relaylijsten van kind `10002`, Blossom-servers van kind `10063` en inboxen voor privéberichten van kind `10050`. Voordat een ondertekenaar verbinding maakt, toont de applicatie genormaliseerde eindpunten, lees- en schrijfrechten, event kinds, vaste publicatierelays en bestemmingen.
+
+De [begrensde procedure voor ondertekening en publicatie](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) scheidt het verbinden van het toepassen. Elk event wordt afzonderlijk ondertekend, één uitvoering gebruikt maximaal vier WebSocket-verbindingen en een bestemming telt pas mee na een positieve [NIP-01](/nl/topics/nip-01/) `OK`. De resultaten maken onderscheid tussen volledige, gedeeltelijke, mislukte en geannuleerde bezorging. Gedeelde templates blijven niet-vertrouwde aanbevelingen. Het [toestemmingsscherm](https://github.com/dyne/communitator#security-and-consent) legt uit in hoeverre relays en netwerkactiviteit waarneembaar zijn.
+
+### cal.emre.xyz publiceert beschikbaarheid voor afspraken via NIP-52
+
+De openbare repository werd geopend met een [eerste commit op 2 september](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743), gevolgd door een ondertekende [aankondiging van de handler op 3 september](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) voor [cal.emre.xyz](https://cal.emre.xyz). Een organisator publiceert beschikbaarheid als een `kind:31923`-[NIP-52](/nl/topics/nip-52/)-event. Een gast publiceert een `kind:31925`-RSVP.
+
+De toepassing leest events van de organisator en geaccepteerde bezette RSVP's uit relays, sluit overlappende tijdsperioden uit en behoudt Nostr-events als het planningsregister zonder ze naar een afzonderlijke database te kopiëren. Organisatoren kunnen ondertekenen met [NIP-07](/nl/topics/nip-07/), [NIP-46](/nl/topics/nip-46/) of een lokale sleutel. Gasten kunnen een afzonderlijke sleutel genereren. De [repository](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) stelt ook de resulterende `naddr` en agendalinks beschikbaar, waarbij e-mail standaard is uitgeschakeld.
+
+### Plektos maakt van privé-events één versleuteld kanaal
+
+De [implementatie van privé-events van 2 september](https://github.com/derekross/plektos/pull/12) maakt van elke bijeenkomst in [Plektos](https://github.com/derekross/plektos) een privékanaal binnen een versleutelde [Concord](/nl/topics/concord-protocol/)-community. De gastenlijst, het RSVP-overzicht, het inschrijfbord, de thread, bijdragen, omslagafbeeldingen, bewerkingen en verwijderingen worden samen versleuteld. Een uitnodiging bevat alleen de sleutel van dat event en er wordt geen agenda-event in platte tekst gepubliceerd.
+
+De [levenscycluscontrole van 6 september](https://github.com/derekross/plektos/pull/14) verankert de id van de eventdefinitie voor directe opzoeking wanneer er meer dan 500 wraps bestaan, met behoud van een gepagineerde terugvaloptie. Uitnodigingsbundels verlopen 30 dagen nadat een event eindigt en kunnen worden uitgeschakeld, maar iemand die al een kanaalsleutel heeft verkregen, kan die behouden. Een afzonderlijke [reparatie voor parserbeveiliging](https://github.com/derekross/plektos/pull/16) zorgt ervoor dat onjuist gevormde type-length-value (TLV)-[NIP-19](/nl/topics/nip-19/)-identifiers mislukken in plaats van de parser vast te laten lopen.
+
+## Getagde releases
+
+### Vector 0.4.4 maakt herstel van versleutelde communities veiliger
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) verscheen op 31 augustus met oplossingen voor communityherstel, sleutelrotatie, moderatie en de routering van antwoorden. Bij heroprichting wordt een aangevallen community afgesloten voor het uitnodigingspad dat door aanvallers werd gebruikt. Vervangend lidmaatschap heeft voorrang op verouderde lokale status en één onbereikbaar lid bevriest niet langer het ledenoverzicht. Lege rotaties worden geweigerd, promoties behouden online leden en bewerkingen worden niet uitgevoerd wanneer vereiste leden niet bereikbaar zijn.
+
+De [release](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) bewaart ook verwijderingen en verbanningen door moderators, versleutelt het gastenboek opnieuw na een wachtwoordwijziging, koppelt antwoorden op meldingen na een herstart aan de bijbehorende conversatie en gebruikt uitsluitend geverifieerde multiplayerpaden. Dit zijn herstelmaatregelen, geen intrekking van reeds verkregen sleutels.
+
+### Primal Android 3.5.27 controleert de identiteit van ondertekenaar en wallet
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) verscheen op 3 september nadat [de identiteitscontrole van de ondertekenaar](https://github.com/PrimalHQ/primal-android-app/pull/1108) en [authenticatie van walletverzoeken](https://github.com/PrimalHQ/primal-android-app/pull/1105) op 31 augustus waren samengevoegd. Lokale ondertekening weigert een verzoek waarvan de identiteit niet overeenkomt met het beheerde account, en inkomende [NIP-47](/nl/topics/nip-47/)-verzoeken worden vóór verwerking geauthenticeerd. De routering van zappeilingen stuurt stemmen ook naar de auteur van de peiling wanneer de peiling in een antwoord voorkomt.
+
+### GRAIN 0.8.0-rc2 sluit een pad af waarbij gebeurtenissen wel werden bevestigd maar niet opgeslagen
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) verscheen op 7 september nadat een opslagfout ervoor had gezorgd dat `OK` kon worden gegeven voordat de asynchrone LMDB-databaseschrijver merkte dat de opslagcapaciteit vol was. De relay waarschuwt nu bij 80 en 95 procent, weigert bij 97 procent nieuwe gebeurtenissen maar laat ruimte over voor verwijdering, en meldt fouten van de schrijver die na acceptatie optreden. Het retentieproces werkt van oud naar nieuw, het afsluitproces verwerkt laat binnenkomende berichten en ongeldige filters leiden er niet langer toe dat geldige filters uit dezelfde groep worden genegeerd.
+
+De [release](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) bevestigt ook monitoraankondigingen van kind `10166` en relayrapporten van kind `30166`, verwijdert verouderde rapporten, behoudt geconfigureerde relays als terugvaloptie en vermeldt actuele limieten en authenticatie in [NIP-11](/nl/topics/nip-11/) in plaats van statische nullen.
+
+### LibreNostr 0.5.0–0.5.2 laat Tor-routering veilig stoppen bij fouten
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) verscheen op 7 september met een Orbot-modus die relays, zaps, uploads, media, afspelen en voorbeelden via één SOCKS-poort routeert, plus een oplossing voor een crash van het zapvenster. Als Orbot of de proxy niet beschikbaar is, worden verbindingen gestopt in plaats van ongemerkt over te schakelen op een directe route. [Versie 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) voorkomt dat trage [NIP-50](/nl/topics/nip-50/)-zoekopdrachten lokale resultaten vertragen; [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) vervangt de recursieve threadindeling en herstelt de volgorde van threads.
+
+Het [veilig stoppende gedrag bij fouten](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) geldt voor elk netwerkoppervlak dat in de release wordt genoemd. Een herstart is vereist omdat deze clients lang actief blijven. De patchreleases behouden die keuze en beperken tegelijkertijd niet-gerelateerde problemen met zoeken, stackdiepte en indeling.
+
+### SkateSpots voegt een relaypad op het apparaat toe
+
+De ondertekende [Zapstore-release van 8 september](https://zapstore.dev/apps/org.skatespots.app) voegt een optionele Citrine-relay toe aan SkateSpots. Spots, crews, berichten en kaartgegevens kunnen lokaal worden geladen, berichten worden offline in een wachtrij geplaatst en de telefoon bewaart een lokale kopie. Bestaande inhoud in de stash en berichten blijft end-to-end versleuteld. Betalingscontroles vereisen factuurbedragen en door de provider uitgegeven zap-ontvangstbewijzen voordat toegang wordt verleend of bijdragen worden meegeteld.
+
+De [lokale relay](https://zapstore.dev/apps/org.skatespots.app) is een optie voor opslag en continuïteit, geen vervanging voor elke externe relay. Hiermee kan een skater tijdens een periode zonder verbinding blijven werken en de ondertekende activiteit later synchroniseren. Tegelijkertijd voorkomen de betalingswijzigingen dat een zelf opgesteld ontvangstbewijs als bewijs van betaling kan dienen.
+
+### Whistle 1.8.15 herstelt het lifecycle-herstel van versleutelde groepen
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) verscheen op 3 september nadat een Android-lifecycle-oplossing had voorkomen dat statusobjecten op routeniveau relay-abonnementen en locatie-updates voor de hele applicatie beëindigden. De release notes beschrijven ook een vernieuwde verbindingsstatus na vergrendeling of sluimerstand en, in het waargenomen geval, het herstel van een achterstand van 501 gebeurtenissen.
+
+De [bug](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) koppelde het eigenaarschap van een langlevende service aan een kortlevend scherm. Door de aan de activity gebonden instantie actief te houden en de socket te controleren vóór een eenmalige leesactie, is de kans kleiner dat normale Android-navigatie en opschorting op de achtergrond eruitzien als een lege groep.
+
+### TWENTY ONE Companion 1.12.0 scheidt versleutelde DM's van oudere chat
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) verscheen op 5 september met in gift wraps verpakte DM's volgens [NIP-17](/nl/topics/nip-17/). De versleutelde inbox staat los van de oudere space-chat, die afzonderlijk blijft omdat die berichten nooit zijn versleuteld en niet kunnen worden gemigreerd. PDF's en video's worden ondersteund voor zover het relaybeleid dit toestaat, en persoonlijke verbergingen worden gesynchroniseerd zonder moderatorblokkades te worden.
+
+De [zichtbare scheiding](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) maakt deel uit van het beveiligingsmodel. De oude geschiedenis een beveiligde inbox noemen zou de herkomst ervan verkeerd voorstellen, terwijl een geruisloze migratie zou suggereren dat er versleuteling bestond toen de berichten werden geschreven.
+
+### ZapStore 1.1.2 valideert event-id's en certificaatrotatie
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) verscheen op 4 september met validatie van event-id's volgens NIP-01: de client berekent de id van een inkomende gebeurtenis opnieuw en weigert de gebeurtenis bij een afwijking voordat deze wordt gebruikt. De release identificeert ook pakketten die buiten ZapStore zijn geïnstalleerd. Op de server zorgt [behoud van certificaathashes](https://github.com/zapstore/relay/pull/8) ervoor dat herhaalde `apk_certificate_hash`-tags behouden blijven, zodat bij rotatie van Android-ondertekeningssleutels een goedgekeurde afstammingslijn in stand kan blijven.
+
+De [controle van de event-id](https://github.com/zapstore/zapstore/releases/tag/1.1.2) voorkomt dat een relay of cache tags of inhoud wijzigt en daarbij de oude id behoudt. De indicator voor de installatiebron biedt afzonderlijke informatie over de herkomst wanneer een Android-pakket met dezelfde applicatie-id via een ander kanaal afkomstig is.
+
+### Amber 6.6.1 houdt antwoorden van de ondertekenaar herleidbaar
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) verscheen op 4 september nadat de verwerking van toestemmingen was aangepast om een ontbrekende optionele `kind` te accepteren, en afgewezen ondertekeningsverzoeken hun oorspronkelijke verzoek-id begonnen terug te sturen. Aanroepende applicaties kunnen een afwijzing zo koppelen aan de ingediende bewerking. De release werkt ook de standaardinstellingen voor externe ondertekenaars bij en voegt een indexer-relay toe.
+
+Samen behouden deze [oplossingen](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) de herleidbaarheid in beide richtingen: een toestemmingsrecord blijft bruikbaar wanneer een optioneel veld ontbreekt, en een weigering blijft gekoppeld aan het verzoek dat deze veroorzaakte. De wijzigingen aan de standaardrelays beïnvloeden de vindbaarheid, maar vervangen de lokale autorisatiebeslissing van de ondertekenaar niet.
+
+## In ontwikkeling
+
+### Zap Cooking geeft NIP-27-verwijzingen met relayhints weer
+
+[De merge van 4 september](https://github.com/zapcooking/frontend/pull/665) zorgt ervoor dat [Zap Cooking](https://github.com/zapcooking/frontend) verwijzingen naar `nostr:npub` en `nostr:nprofile` weergeeft in artikelen, recepten, editorvoorbeelden en afdrukweergaven. Ongeldige identifiers blijven als tekst staan, het opzoeken is niet-blokkerend en de editor toont een voorbeeld van de Markdown die zal worden ondertekend. Wanneer relayinformatie beschikbaar is, wordt een losse `npub` omgezet in een `nprofile` met outbox-relays en een overeenkomende `p`-tag.
+
+In dezelfde week werden [auteursgebonden uitlezingen van kind `30023`](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7) hersteld, [geverifieerde NIP-50-zoekrelays](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea) toegevoegd met deduplicatie en controles op verouderde zoekopdrachten, en [NIP-47-walletaanroepen](https://github.com/zapcooking/frontend/pull/705) gerepareerd nadat wijzigingen in afhankelijkheden saldi en geschiedenis onbruikbaar hadden gemaakt.
+
+### Conduit brengt ondertekende relay- en Blossom-voorkeuren met elkaar in overeenstemming
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) heeft op 2 september [bewerking van Blossom-voorkeuren](https://github.com/Conduit-BTC/conduit-mono/pull/374) en op 7 september [afstemming van ondertekende voorkeuren](https://github.com/Conduit-BTC/conduit-mono/pull/397) gemerged. Market en Merchant behouden de recentste geldige relaylijst van kind `10002` en inboxverklaring van kind `10050`, bewaren een bruikbare ondertekende lijst wanneer een nieuwere event ongeldig is, maken onderscheid tussen een expliciet lege lijst en een niet-beschikbare opzoekactie, en vervangen mislukte opgegeven relays niet door standaardwaarden uit de code.
+
+Met [de editor voor kind `10063`](https://github.com/Conduit-BTC/conduit-mono/pull/374) kan een gebruiker een geordende lijst met HTTPS-mediaservers laden, herschikken, controleren, extern ondertekenen, publiceren en opnieuw uitlezen, zonder contact met die servers op te nemen of een niet-opgegeven standaardserver toe te voegen.
+
+### NIP-A3-betaaldoelen bereiken drie clients
+
+Van 1 tot en met 3 september implementeerden [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) en [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) NIP-A3-betaaldoelen van kind `10133`. Amethyst biedt alleen na expliciete toestemming een overdracht aan wanneer er een compatibel doel bestaat en maakt daar geen zap van; Grimoire gebruikt een vast register voordat wallet-URI's worden opgebouwd; Pollerama valideert Monero-adressen en haalt de relaylijst van de auteur op voordat doelen worden opgevraagd. Elke client heeft nog steeds een toegestane betaalmethode, een relayroute en een correcte weergave nodig.
+
+### Ditto breidt Blossom-fallback en live-embeds uit
+
+[Ditto](https://github.com/soapbox-pub/ditto) heeft op 6 september [brede Blossom-fallback en mirroring](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) gemerged. Avatars, badges, banners, communityafbeeldingen, aangepaste emoji en applicatiepictogrammen proberen nu opgegeven servers met dezelfde blobhash; mirroruploads gebruiken een standaard BUD-11-autorisatietoken. Een [wijziging van 4 september](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) voegde compacte livestream-embeds van `kind:30311` toe.
+
+## Werk aan protocol en specificaties
+
+### Mogelijkheden voor Nostr-implementaties
+
+[NIP-01](/nl/topics/nip-01/) verduidelijkt nu [het filter `limit: 0`](https://github.com/nostr-protocol/nips/pull/2460), dat op 4 september werd gemerged. Een relay MOET geen opgeslagen events retourneren, MOET `EOSE` verzenden wanneer de initiële query's zijn voltooid en MOET het abonnement actief houden voor nieuwe overeenkomende events. Clients kunnen met één filterveld een uitsluitend live werkend abonnement openen en tegelijk de lokale geschiedenis behouden. De verduidelijking beschrijft compatibel gedrag van verschillende relayimplementaties en openbare relays.
+
+Aan [NIP-78](/nl/topics/nip-78/) werd een [vereiste voor geauthenticeerde appgegevens](https://github.com/nostr-protocol/nips/pull/2458) toegevoegd, die op 3 september werd gemerged. Relays ZOUDEN [NIP-42](/nl/topics/nip-42/)-authenticatie moeten vereisen voor kinds `78` en `30078` en ZOUDEN deze alleen aan de geauthenticeerde auteur van de event moeten aanbieden. Dat is een aanbeveling, geen garantie van vertrouwelijkheid: clients kunnen willekeurige relays niet als privéopslag behandelen. De merge raadt ook af om aangepaste kinds voor appgegevens te gebruiken als algemene openbare uitwisselingsmethode.
+
+[NIP-AC](/nl/topics/nip-ac/) werd op 4 september geopend als een expliciet open [voorstel voor WebRTC-signalering](https://github.com/nostr-protocol/nips/pull/2461). Het gebruikt voorlopige efemere kinds voor ping, verbindingsverzoeken, offers, answers en ICE candidates, geadresseerd met `p` en gegroepeerd via een sessiegebonden `e`-tag; kind `30600` ondersteunt ontdekking. Relays ZOUDEN die signaleringsevents moeten uitzenden en MOGEN ze NIET opslaan terwijl peers rechtstreeks verbinding maken. De nummers blijven voorlopig, clients ZOUDEN [NIP-65-relaylijsten](/nl/topics/nip-65/) moeten gebruiken en applicaties die vertrouwelijkheid nodig hebben ZOUDEN de inhoud van offers, answers en candidates met [NIP-44](/nl/topics/nip-44/) moeten versleutelen.
+
+## Uitgelichte NIP: URI-links en verwijzingen in eventtekst
+
+Een Nostr-identifier heeft een overdraagbare betekenis nodig voordat een andere applicatie deze kan openen. [NIP-21](/nl/topics/nip-21/) plaatst een [NIP-19](/nl/topics/nip-19/)-identifier achter het URI-schema `nostr:`, waardoor browsers, besturingssystemen en applicaties één vorm krijgen die kan worden doorgestuurd. [NIP-27](/nl/topics/nip-27/) definieert wat diezelfde URI betekent binnen leesbare event-`content`. NIP-21 overschrijdt de grens van een applicatie; NIP-27 behoudt een profiel- of eventverwijzing in ondertekende tekst. Geen van beide creëert een event kind of wijzigt relayberichten; de [twee specificaties](https://github.com/nostr-protocol/nips/tree/master) definiëren uitsluitend het gedrag voor links en weergave.
+
+### URI-dispatch en NIP-19-semantiek
+
+[De grammatica van NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) bestaat uit `nostr:`, gevolgd door één NIP-19 bech32-entiteit. `nsec` is uitgesloten omdat het een privésleutel codeert. Er is geen autoriteits-, pad- of querycomponent, dus een conforme link is `nostr:npub1...`, niet `nostr://npub1...`. Een platform of client kan zich als handler registreren. De specificatie kiest niet welke geïnstalleerde applicatie wordt gebruikt en definieert geen webalternatief.
+
+Het voorvoegsel vertelt een client wat die moet decoderen. `npub` bevat een publieke sleutel en `note` een event-id. `nprofile` voegt optionele relayhints toe aan een profiel, `nevent` voegt relays, auteur en kind toe aan een event-id, en `naddr` bevat de auteur, kind en `d`-identifier van een adresseerbaar event, met optionele relays. Deze vormen gebruiken [NIP-19-velden van het type type-length-value](https://github.com/nostr-protocol/nips/blob/master/19.md). Hints verfijnen het zoeken, maar bewijzen niet dat een relay het event bezit of dat de auteur er controle over heeft. Voor elk opgehaald event moeten nog steeds de id opnieuw worden berekend en de handtekening worden gecontroleerd.
+
+De profielvorm in de [NIP-21-specificatie](https://github.com/nostr-protocol/nips/blob/master/21.md) is:
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definieert ook HTML-bruggen: een pagina die een Nostr-event aanbiedt, kan de bijbehorende `naddr` in `<link rel="alternate">` plaatsen, en een profiel kan een `nprofile` in `<link rel="me">` of `<link rel="author">` plaatsen.
+
+### NIP-27-weergave en optionele tags
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) is van toepassing op leesbare eventinhoud, zoals notities van kind `1` en artikelen van kind `30023`. Een editor kan `@name` weergeven, maar publiceert `nostr:nprofile1...` in de ondertekende tekenreeks. Een reader scant de URI, decodeert de NIP-19-entiteit, haalt het doel op en kan een naam, kaart, voorbeeldweergave of lokale link tonen. Als het decoderen mislukt, blijft de URI gewone tekst. De onbewerkte inhoud mag niet worden herschreven: een wijziging verandert de NIP-01-serialisatie, id en handtekening.
+
+Inhoudsverwijzingen en tags hebben verwante maar verschillende functies. [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) beschrijft optionele `p`- en `e`-tags en de `q`-tag uit [NIP-18](/nl/topics/nip-18/). Een client kan een verwijzing tonen zonder een notificatie of threadrelatie te creëren. Voor het vindbaar maken van citaten moeten zowel de URI als een `q`-tag worden opgenomen. [De implementatie van Zap Cooking van 4 september](https://github.com/zapcooking/frontend/pull/665) volgt die scheiding door de URI te behouden en tegelijk relayhints en een overeenkomende `p`-tag toe te voegen. Het toevoegen van `p` of `q` maakt de URI niet privé, en NIP-27 kent geen modus voor verborgen vermeldingen.
+
+Het volgende [event van kind `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) is teruggevonden via `wss://nos.lol` en vóór opname geverifieerd als concreet NIP-27-referentievoorbeeld. De `content` bevat een `naddr` voor een versie-onafhankelijk adresseerbaar event. Decodering levert kind `30402`, auteur `91036d...310a`, de `d`-identifier van het werkboek en een hint voor `wss://nos.lol/` op. De tags `q`, `p`, `t`, `zap` en `client` zijn keuzes van de applicatie, geen vereisten van NIP-27.
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Vertrouwen, foutgedrag en clientimplementaties
+
+Een veilige reader vindt een volledig `nostr:`-token, valideert bech32, decodeert NIP-19, weigert `nsec`, negeert onbekende TLV-typen en laat misvormde of te lange tekst ongemoeid. `npub` en `nprofile` leiden tot profielquery's; `note` en `nevent` identificeren onveranderlijke events; `naddr` selecteert het nieuwste geldige adresseerbare event voor het betreffende kind, de auteur en de `d`-tag. Relayhints beperken het zoekgebied, maar vormen geen uitbreiding van vertrouwen. Volgens de [eventregels van NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) verifieert de client de id van een opgehaald `nevent` en controleert deze de handtekening van elke `naddr`-kandidaat voordat de vervangingsregels voor adresseerbare events worden toegepast.
+
+Inlinevoorvertoningen zijn een keuze van de client en brengen kosten voor privacy en resources met zich mee. Het ophalen van elke verwijzing onthult de interesses van de lezer en kan een stortvloed aan zoekopdrachten veroorzaken. Clients kunnen daarom een cache gebruiken, het ophalen uitstellen totdat een verwijzing zichtbaar is, het aantal gelijktijdige aanvragen beperken en een klik vereisen voor onbekende media. Volgens [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) moet een voorvertoning duidelijk gescheiden blijven van de ondertekende tekst van de huidige auteur. Een mislukking moet zichtbaar zijn als onopgeloste tekst of als een niet-beschikbare kaart en mag niet stilzwijgend als geverifieerde inhoud worden behandeld.
+
+Vertrouwen verschilt ook per identificatortype. Een `nevent` verwijst naar onveranderlijke bytes, waardoor een client een opgehaald event kan weigeren als de geserialiseerde id afwijkt van de gevraagde id. Een `naddr` verwijst naar een vervangbare coördinaat, waardoor een client elke kandidaat moet verifiëren en de regels voor adresseerbare events moet toepassen voordat wordt bepaald welke versie wordt weergegeven. Een relayhint is in beide gevallen nuttig voor de eerste query, maar vormt geen goedkeuring van de relay of van de teruggegeven inhoud. [De TLV-definitie van NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) levert de gegevens die nodig zijn om deze controles expliciet uit te voeren.
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) definieert een overdraagbare link die van buiten Nostr kan worden geopend, terwijl NIP-27 dezelfde link duurzaam maakt binnen ondertekende tekst. Een client die alleen NIP-21 implementeert, kan een geplakte URI openen, maar geen ingesloten verwijzingen weergeven. Volledige ondersteuning voor NIP-27 voegt scannen, veilig decoderen, ophaalbeleid, lokale weergave en een expliciete keuze voor notificatie- en citaattags toe. De gedeelde URI houdt deze lagen interoperabel zonder clients te dwingen ze op dezelfde manier te presenteren.[Damus](https://github.com/damus-io/damus) modelleert inlineverwijzingen als getypeerde vermeldingen. De [vermeldingscode](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) wijst `npub` en `nprofile` toe aan profielverwijzingen, `note` en `nevent` aan eventverwijzingen en `naddr` aan adresverwijzingen; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) leidt ze naar de juiste bestemming. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [parseert de scheme- en geplakte vormen](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), valideert bech32 en extraheert relayhints, en [zet verwijzingen vervolgens om in modellen voor note-inhoud](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) geeft dezelfde verwijzingen weer in artikelen, recepten, editorvoorvertoningen en afdrukweergaven.
+
+---
+
+Stuur een NIP-17-DM om een project of nieuwsitem te delen via het [Nostr Compass-project](https://github.com/andotherstuff/nostr-compass).

--- a/content/nl/topics/nip-a3.md
+++ b/content/nl/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Betalingsdoelen"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 definieert een overdraagbare manier waarop een Nostr-account betalingsadressen voor meerdere netwerken en diensten kan publiceren. Een vervangbare kind `10133`-event bevat een of meer `payto`-tags.
+
+## Hoe het werkt
+
+Elke tag heeft de vorm `["payto", "<type>", "<address>"]`. Het type wordt in kleine letters geschreven, zoals `bitcoin`, `lightning` of `monero`. Clients kunnen bekende indelingen valideren en een eigen betalings-URI weergeven wanneer die bestaat. Voor onbekende typen wordt teruggevallen op het `payto:`-URI-schema uit RFC 8905.
+
+De event vermeldt bestemmingen, niet een voltooide betaling of een Nostr-zap. Clients bepalen nog steeds welke betalingstypen ze ondersteunen, hoe ze een adres valideren en hoe duidelijk ze de bestemming tonen voordat ze die aan een wallet doorgeven.
+
+## Implementaties
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) biedt een optionele overdracht naar een betaalapp wanneer het een compatibel doel herkent.
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) koppelt toegestane doeltypen aan betalings-URI's.
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) valideert Monero-doelen en bevraagt de relays van de auteur.
+
+---
+
+**Primaire bronnen:**
+- [NIP-A3-specificatie](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: het payto-URI-schema](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Vermeld in:**
+- [Nieuwsbrief #39: NIP-A3-betalingsdoelen bereiken drie clients](/nl/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Zie ook:**
+- [NIP-47: Nostr Wallet Connect](/nl/topics/nip-47/)

--- a/content/pt/newsletters/2026-09-09-newsletter.md
+++ b/content/pt/newsletters/2026-09-09-newsletter.md
@@ -205,7 +205,7 @@ O seguinte [evento do kind `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsth
       "Amethyst"
     ]
   ],
-  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4sкw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
   "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
 }
 ```

--- a/content/pt/newsletters/2026-09-09-newsletter.md
+++ b/content/pt/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,225 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "O Nostr Compass #39 acompanha fluxos de trabalho git assinados, publicação pelo navegador, transmissões ao vivo auto-hospedadas, consentimento de relays comunitários, eventos privados, lançamentos focados e o contrato de links NIP-21/NIP-27."
+---
+
+Bem-vindo de volta ao [Nostr Compass](https://nostrcompass.org), seu guia semanal sobre Nostr.
+
+**Esta semana:** [ngit e GitWorkshop](https://ngit.dev/v3) trazem fluxos de trabalho git assinados para o Nostr e o [Blossom](/pt/topics/blossom/), o [nsite-clay](https://github.com/jooray/nsite-clay) torna a publicação pelo navegador recuperável, e o [Wingman App](https://github.com/OtherStuffAI/wm-app) une navegação, assinatura local, autenticação e arquivos. [Shosho e Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) conectam transmissões auto-hospedadas ao Nostr, o [Communitator](https://github.com/dyne/communitator) torna modelos de relay inspecionáveis antes da assinatura, o [cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) publica horários de agendamento, e o [Plektos](https://github.com/derekross/plektos/pull/16) criptografa eventos privados. Lançamentos etiquetados adicionam trabalho de recuperação e privacidade no [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4), [Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27), [LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) e [SkateSpots](https://zapstore.dev/apps/org.skatespots.app). O trabalho de desenvolvimento abrange renderização de [NIP-27](/pt/topics/nip-27/), preferências de relay assinadas no [Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397), destinos de pagamento [NIP-A3](/pt/topics/nip-a3/) e espelhos Blossom. Mudanças mescladas no [repositório de NIPs](https://github.com/nostr-protocol/nips) esclarecem assinaturas somente ao vivo e dados de aplicativo autenticados. Nosso mergulho profundo explica como os links [NIP-21](/pt/topics/nip-21/) e as referências NIP-27 transportam perfis e eventos Nostr entre aplicativos.
+
+## Principais Notícias
+
+### Fluxos de trabalho git assinados trazem CI, repositórios privados e lançamentos para o Nostr
+
+O [lançamento v3 de 8 de setembro](https://ngit.dev/v3) reúne ngit, GitWorkshop, ngit-grasp e ngit-ci em um único fluxo de trabalho assinado. O [ngit](https://ngit.dev/ngit.git) transporta branches, patches e pull requests como eventos [NIP-34](/pt/topics/nip-34/), enquanto o [GitWorkshop](https://ngit.dev/gitworkshop.git) fornece a interface de revisão. O lançamento adiciona o ngit-ci 0.1, um serviço de integração contínua auto-hospedado cujas instruções e resultados trafegam como eventos Nostr assinados, permitindo que as verificações rodem em hardware controlado pelo mantenedor junto à revisão de código.
+
+O mesmo lançamento dá ao [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) repositórios privados por meio da extensão de repositório privado GRASP-08 e torna explícita a autoridade do mantenedor. Registros de lançamento assinados podem apontar para ativos no [Blossom](/pt/topics/blossom/), mantendo tanto os metadados de lançamento quanto os arquivos endereçados por conteúdo fora de uma forge hospedada. O [novo site de documentação](https://ngit.dev/v3) reúne os componentes de cliente, repositório privado, CI e web.
+
+### nsite-clay torna a publicação pelo navegador recuperável
+
+Uma [correção de prompt do signatário de 31 de agosto](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8), a [recuperação de publicação](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0) e os [controles de edição de 2 de setembro](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7) fazem do [nsite-clay](https://github.com/jooray/nsite-clay) uma ferramenta de publicação no navegador para um site de página única. O usuário edita o modelo de objeto de documento no local, serializa o resultado, envia-o como um blob [Blossom](/pt/topics/blossom/) endereçado por conteúdo e republica o manifesto [NIP-5A](/pt/topics/nip-5a/) do site. Nenhum build local ou servidor é necessário.
+
+O [publicador no navegador](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html) agora torna a publicação com falha recuperável e reduz os prompts repetidos do signatário, enquanto o [guia de edição](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html) documenta o ciclo. O resultado continua sendo um site NIP-5A comum para os gateways existentes.
+
+### Wingman App une navegação, assinatura e arquivos
+
+O trabalho de setembro adiciona [seletores de arquivos](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec), [publicação de perfil](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704), [restauração segura de signatário e sessão](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6) e [builds móveis testados](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac) ao [Wingman App](https://github.com/OtherStuffAI/wm-app). Seu shell Flutter injeta um provedor [NIP-07](/pt/topics/nip-07/) nas páginas abertas dentro do aplicativo, enquanto o Flight Deck e o Drive baseado em Tower fornecem uma superfície de trabalho e um espaço de arquivos ao lado do navegador.
+
+O Wingman assina requisições HTTP autenticadas usando [NIP-98](/pt/topics/nip-98/). A [implementação da requisição](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs) constrói o evento que um servidor verifica antes de responder, dando a uma identidade instalada um caminho de aprovação consistente para ações de relay, assinatura em aplicativos web e arquivos.
+
+### Shosho lança os streams auto-hospedados do Livelier
+
+O [Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) foi lançado em 1º de setembro com suporte ao [Livelier](https://github.com/r0d8lsh0p/livelier), cuja [atualização de atribuição de 31 de agosto](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc) identifica a fonte da bridge e do Owncast nos perfis intermediados. O Livelier observa o diretório público do Owncast, verifica se uma transmissão de vídeo está ao vivo e então publica um evento endereçável `kind:30311` da [NIP-53](/pt/topics/nip-53/). A descoberta trafega pelo Nostr enquanto o vídeo permanece no servidor do streamer.
+
+O chat atravessa a bridge como eventos `kind:1311`. O [design da bridge](https://github.com/r0d8lsh0p/livelier) abre uma conexão do lado da fonte apenas enquanto um leitor Nostr estiver inscrito, rotula as identidades derivadas e envia o chat transitório para um relay que o exclui após três horas. O relay de descoberta aceita escritas de eventos ao vivo apenas da chave da bridge; o relay de chat usa [autenticação NIP-42](/pt/topics/nip-42/) e [sinalizadores de evento protegido da NIP-70](/pt/topics/nip-70/).
+
+### Communitator torna os templates de relay inspecionáveis antes da assinatura
+
+A [série de lançamento de 31 de agosto](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c) dá ao [Communitator](https://github.com/dyne/communitator) templates canônicos para listas de relays de kind `10002`, servidores Blossom de kind `10063` e caixas de entrada de mensagens privadas de kind `10050`. Antes que um assinante se conecte, a aplicação mostra endpoints normalizados, permissões de leitura/escrita, kinds de eventos, relays de publicação fixos e destinos.
+
+O [fluxo delimitado de assinatura e publicação](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501) separa a conexão da aplicação. Cada evento é assinado separadamente, uma execução usa no máximo quatro conexões WebSocket e um destino só conta após um `OK` positivo da [NIP-01](/pt/topics/nip-01/). Os resultados distinguem entrega completa, parcial, com falha e cancelada. Os templates compartilhados permanecem recomendações não confiáveis; a [superfície de consentimento](https://github.com/dyne/communitator#security-and-consent) explica a observabilidade de relays e de rede.
+
+### cal.emre.xyz publica disponibilidade de compromissos via NIP-52
+
+O repositório público foi aberto em um [commit inicial de 2 de setembro](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743), seguido de um [anúncio assinado do handler em 3 de setembro](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac) para o [cal.emre.xyz](https://cal.emre.xyz). Um anfitrião publica a disponibilidade como um evento `kind:31923` da [NIP-52](/pt/topics/nip-52/); um convidado publica um RSVP `kind:31925`.
+
+Ele lê os eventos do anfitrião e os RSVPs de ocupação aceitos a partir dos relays, exclui intervalos de tempo sobrepostos e mantém os eventos Nostr como o registro de agendamento sem copiá-los para um banco de dados separado. Os anfitriões podem assinar com [NIP-07](/pt/topics/nip-07/), [NIP-46](/pt/topics/nip-46/) ou uma chave local; os convidados podem gerar uma chave separada. Seu [repositório](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743) também expõe o `naddr` resultante e os links de calendário, com e-mail desativado por padrão.
+
+### Plektos torna eventos privados um único canal criptografado
+
+A [implementação de eventos privados de 2 de setembro](https://github.com/derekross/plektos/pull/12) faz de cada encontro do [Plektos](https://github.com/derekross/plektos) um canal privado dentro de uma comunidade criptografada do [Concord](/pt/topics/concord-protocol/). A lista de convidados, o quadro de RSVPs, a lista de inscrições, a thread, as contribuições, as imagens de capa, as edições e as exclusões são criptografados juntos; um convite carrega apenas a chave daquele evento e nenhum evento de calendário em texto claro é publicado.
+
+A [auditoria de ciclo de vida de 6 de setembro](https://github.com/derekross/plektos/pull/14) ancora o id da definição do evento para busca direta quando existem mais de 500 wraps, mantendo um fallback paginado. Os pacotes de convite expiram 30 dias após o término de um evento e podem ser desativados, mas alguém que já obteve uma chave de canal pode retê-la. Um [reparo separado de segurança do parser](https://github.com/derekross/plektos/pull/16) faz com que identificadores [NIP-19](/pt/topics/nip-19/) malformados em type-length-value (TLV) falhem em vez de travar o parser.
+
+## Lançamentos Marcados
+
+### Vector 0.4.4 torna a recuperação de comunidades criptografadas mais segura
+
+O [Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) foi lançado em 31 de agosto com correções de recuperação de comunidades, rotação de chaves, moderação e roteamento de respostas. A refundação fecha uma comunidade invadida para o caminho de convite usado pelos atacantes; a substituição de membros sobrepõe o estado local desatualizado; e um único membro inalcançável não congela mais a lista de membros. Rotações vazias são rejeitadas, promoções preservam os membros online e as operações se recusam a executar quando os membros necessários não podem ser alcançados.
+
+O [lançamento](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) também persiste exclusões e banimentos de moderadores, recriptografa o livro de visitas após uma mudança de senha, vincula respostas de notificação à sua conversa após a reinicialização e usa apenas caminhos multiplayer verificados. Estes são controles de recuperação, não revogação de chaves já obtidas.
+
+### Primal Android 3.5.27 verifica a identidade do assinante e da carteira
+
+O [Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) foi lançado em 3 de setembro após a [verificação de identidade do assinante](https://github.com/PrimalHQ/primal-android-app/pull/1108) e a [autenticação de requisições de carteira](https://github.com/PrimalHQ/primal-android-app/pull/1105) serem mescladas em 31 de agosto. A assinatura local rejeita uma requisição cuja identidade não corresponde à conta mantida, e as requisições [NIP-47](/pt/topics/nip-47/) recebidas são autenticadas antes do processamento. O roteamento de zap-polls também envia votos ao autor da enquete quando ela aparece em uma resposta.
+
+### GRAIN 0.8.0-rc2 encerra um caminho de evento reconhecido, mas não armazenado
+
+O [GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) foi lançado em 7 de setembro, depois que uma falha de armazenamento permitia retornar `OK` antes que o gravador assíncrono do banco de dados LMDB percebesse a capacidade de armazenamento esgotada. O relay agora emite avisos aos 80 e 95 por cento, recusa novos eventos aos 97 por cento mantendo espaço para exclusões e relata falhas do gravador após a aceitação. A retenção percorre dos eventos mais antigos para os mais recentes, o encerramento trata mensagens tardias e filtros inválidos não descartam mais os irmãos válidos.
+
+A [versão](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) também confirma anúncios de monitores do kind `10166` e relatórios de relays do kind `30166`, remove relatórios desatualizados, mantém os relays configurados como reserva e informa limites ao vivo e autenticação no [NIP-11](/pt/topics/nip-11/) em vez de zeros estáticos.
+
+### LibreNostr 0.5.0–0.5.2 faz o roteamento Tor falhar de forma fechada
+
+O [LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) foi lançado em 7 de setembro com um modo Orbot que roteia relays, zaps, uploads, mídia, reprodução e pré-visualizações por uma única porta SOCKS, além de uma correção para uma falha na tela de zaps. Se o Orbot ou o proxy não estiver disponível, as conexões são interrompidas em vez de vazar para uma rota direta. A [versão 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) impede que buscas lentas de [NIP-50](/pt/topics/nip-50/) atrasem os resultados locais; a [0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) substitui o layout recursivo de threads e corrige a ordenação de threads.
+
+O [comportamento fail-closed](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) se aplica a todas as superfícies de rede listadas pela versão, e é necessário reiniciar, pois esses clientes são de longa duração. As versões de correção preservam essa escolha enquanto limitam falhas não relacionadas de busca, profundidade de pilha e layout.
+
+### SkateSpots adiciona um caminho de relay no dispositivo
+
+A [versão assinada de 8 de setembro na Zapstore](https://zapstore.dev/apps/org.skatespots.app) adiciona um relay Citrine opcional ao SkateSpots. Spots, crews, mensagens e dados do mapa podem ser carregados localmente; as publicações entram em fila offline; e o telefone mantém uma cópia local. O conteúdo existente de stash e mensagens permanece criptografado de ponta a ponta. As verificações de pagamento exigem valores de invoice e recibos de zap emitidos pelo provedor antes de conceder acesso ou contabilizar contribuições.
+
+O [relay local](https://zapstore.dev/apps/org.skatespots.app) é uma opção de armazenamento e continuidade, não um substituto para todos os relays remotos. Ele permite que um skatista continue trabalhando durante um período desconectado e depois reconcilie a atividade assinada, enquanto as mudanças de pagamento impedem que um recibo autoassinado se torne prova de liquidação.
+
+### Whistle 1.8.15 corrige a recuperação do ciclo de vida de grupos criptografados
+
+O [Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) foi lançado em 3 de setembro, depois que uma correção de ciclo de vida no Android impediu que detentores de estado no nível de rota destruíssem as assinaturas de relays e as atualizações de localização válidas para todo o aplicativo. Suas notas de versão também descrevem o estado de conexão atualizado após bloqueio ou modo de espera e um backlog de 501 eventos recuperado no caso observado.
+
+O [bug](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) vinculava a propriedade de um serviço de longa duração a uma tela de curta duração. Manter viva a instância com escopo de activity e verificar o socket antes de uma leitura única torna menos provável que a navegação comum do Android e a suspensão em segundo plano pareçam um grupo vazio.
+
+### TWENTY ONE Companion 1.12.0 separa DMs criptografadas do chat legado
+
+O [TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) foi lançado em 5 de setembro com DMs em gift wrap do [NIP-17](/pt/topics/nip-17/). A caixa de entrada criptografada é separada do chat de espaços mais antigo, que permanece distinto porque essas mensagens nunca foram criptografadas e não podem ser migradas. PDFs e vídeos são suportados, sujeitos à política do relay, e ocultações pessoais sincronizam sem se tornar banimentos de moderador.
+
+A [separação visível](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) faz parte do modelo de segurança. Chamar o histórico antigo de caixa de entrada segura deturparia sua procedência, enquanto migrá-lo silenciosamente sugeriria uma criptografia que não existia quando ele foi escrito.
+
+### ZapStore 1.1.2 valida ids de eventos e rotação de certificados
+
+O [ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) foi lançado em 4 de setembro com validação de id de evento do NIP-01: o cliente recalcula o id de um evento recebido e rejeita divergências antes de usá-lo. A versão também identifica pacotes instalados fora da ZapStore. No servidor, a [retenção de hash de certificado](https://github.com/zapstore/relay/pull/8) preserva tags `apk_certificate_hash` repetidas para que a rotação da chave de assinatura do Android possa manter uma linhagem aprovada.
+
+A [verificação de id de evento](https://github.com/zapstore/zapstore/releases/tag/1.1.2) impede que um relay ou cache altere tags ou conteúdo mantendo o id antigo. O indicador de origem da instalação fornece procedência separada quando um pacote Android com o mesmo application id veio de outro canal.
+
+### Amber 6.6.1 mantém as respostas do assinante atribuíveis
+
+O [Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) foi lançado em 4 de setembro, depois que o processamento de permissões foi corrigido para tolerar um `kind` opcional ausente, e as solicitações de assinatura rejeitadas passaram a retornar seu id de solicitação original. Os aplicativos chamadores podem associar uma rejeição à operação enviada. A versão também atualiza os padrões de assinante remoto e adiciona um relay indexador.
+
+Juntas, essas [correções](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) preservam a atribuição em ambas as direções: um registro de permissão permanece utilizável quando um campo opcional está ausente, e uma recusa permanece vinculada à solicitação que a causou. As mudanças nos relays padrão afetam a descoberta, mas não substituem a decisão de autorização local do assinante.
+
+## Em Desenvolvimento
+
+### Zap Cooking renderiza referências NIP-27 com dicas de relay
+
+[A fusão de 4 de setembro](https://github.com/zapcooking/frontend/pull/665) faz o [Zap Cooking](https://github.com/zapcooking/frontend) renderizar referências `nostr:npub` e `nostr:nprofile` em artigos, receitas, pré-visualizações do editor e visualizações de impressão. Identificadores inválidos permanecem como texto, a resolução não é bloqueante e o editor pré-visualiza o Markdown que será assinado. Quando existem informações de relay, um `npub` simples se torna um `nprofile` com relays outbox e uma tag `p` correspondente.
+
+Na mesma semana, corrigiu-se [leituras do kind `30023` com escopo de autor](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7), adicionaram-se [relays de busca NIP-50 verificados](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea) com desduplicação e proteções contra consultas obsoletas, e repararam-se [chamadas de carteira NIP-47](https://github.com/zapcooking/frontend/pull/705) após alterações de dependências quebrarem saldos e histórico.
+
+### Conduit reconcilia preferências assinadas de relay e Blossom
+
+O [Conduit](https://github.com/Conduit-BTC/conduit-mono) fundiu a [edição de preferências Blossom](https://github.com/Conduit-BTC/conduit-mono/pull/374) em 2 de setembro e a [reconciliação de preferências assinadas](https://github.com/Conduit-BTC/conduit-mono/pull/397) em 7 de setembro. Market e Merchant retêm a lista de relays kind `10002` e a declaração de inbox kind `10050` válidas mais recentes, preservam uma lista assinada utilizável quando um evento mais novo está mal formado, distinguem uma lista vazia explícita de uma consulta não disponível e não substituem relays declarados que falharam por padrões do código.
+
+O [editor do kind `10063`](https://github.com/Conduit-BTC/conduit-mono/pull/374) permite ao usuário carregar, reordenar, revisar, assinar externamente, publicar e ler de volta uma lista ordenada de servidores de mídia HTTPS sem contatar esses servidores ou inserir um padrão não declarado.
+
+### Alvos de pagamento NIP-A3 chegam a três clientes
+
+De 1 a 3 de setembro, [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041), [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) e [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) implementaram alvos de pagamento NIP-A3 do kind `10133`. O Amethyst oferece uma transferência opcional apenas quando existe um alvo compatível e não a transforma em zap; o Grimoire usa um registro fixo antes de construir URIs de carteira; o Pollerama valida endereços Monero e busca a lista de relays do autor antes de consultar os alvos. Cada cliente ainda precisa de um método de pagamento permitido, uma rota de relay e uma exibição precisa.
+
+### Ditto expande o fallback Blossom e embeds ao vivo
+
+O [Ditto](https://github.com/soapbox-pub/ditto) fundiu [fallback e espelhamento Blossom amplos](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07) em 6 de setembro. Avatares, emblemas, banners, imagens de comunidade, emojis personalizados e ícones de aplicação agora tentam servidores declarados com o mesmo hash de blob; uploads espelhados usam um token de autorização BUD-11 padrão. Uma [alteração de 4 de setembro](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa) adicionou embeds compactos de transmissão ao vivo `kind:30311`.
+
+## Trabalho de Protocolo e Especificação
+
+### Nostr Implementation Possibilities
+
+O [NIP-01](/pt/topics/nip-01/) agora esclarece [o filtro `limit: 0`](https://github.com/nostr-protocol/nips/pull/2460), fundido em 4 de setembro. Um relay MUST retornar nenhum evento armazenado, MUST enviar `EOSE` quando as consultas iniciais terminarem e MUST manter a assinatura ativa para novos eventos correspondentes. Clientes podem abrir uma assinatura somente ao vivo com um campo de filtro, mantendo o histórico local. O esclarecimento registra comportamento compatível entre várias implementações de relay e relays públicos.
+
+O [NIP-78](/pt/topics/nip-78/) ganhou um [requisito de dados de aplicação autenticados](https://github.com/nostr-protocol/nips/pull/2458), fundido em 3 de setembro. Relays SHOULD exigir autenticação [NIP-42](/pt/topics/nip-42/) para os kinds `78` e `30078` e SHOULD servi-los apenas ao autor autenticado do evento. Isso é um SHOULD, não uma garantia de confidencialidade: clientes não podem tratar relays arbitrários como armazenamento privado. A fusão também desencoraja kinds de dados de aplicação personalizados como intercâmbio público genérico.
+
+O [NIP-AC](/pt/topics/nip-ac/) foi aberto em 4 de setembro como uma [proposta de sinalização WebRTC](https://github.com/nostr-protocol/nips/pull/2461) explicitamente aberta. Ele usa kinds efêmeros provisórios para ping, solicitações de conexão, ofertas, respostas e candidatos ICE, endereçados com `p` e agrupados por uma tag `e` de sessão; o kind `30600` dá suporte à descoberta. Relays SHOULD transmitir e MUST NOT armazenar esses eventos de sinalização enquanto os pares se conectam diretamente. Os números permanecem provisórios, clientes SHOULD usar [listas de relays NIP-65](/pt/topics/nip-65/), e aplicações que precisam de confidencialidade SHOULD criptografar o conteúdo de ofertas, respostas e candidatos com [NIP-44](/pt/topics/nip-44/).
+
+## Mergulho no NIP: Links URI e Referências no Texto de Eventos
+
+Um identificador Nostr precisa de um significado transportável antes que outra aplicação possa abri-lo. O [NIP-21](/pt/topics/nip-21/) coloca um identificador [NIP-19](/pt/topics/nip-19/) após o esquema URI `nostr:`, dando a navegadores, sistemas operacionais e aplicações uma forma despachável. O [NIP-27](/pt/topics/nip-27/) define o que esse mesmo URI significa dentro do `content` legível do evento. O NIP-21 atravessa um limite de aplicação; o NIP-27 mantém uma referência de perfil ou evento em prosa assinada. Nenhum dos dois cria um kind de evento ou altera mensagens de relay; as [duas especificações](https://github.com/nostr-protocol/nips/tree/master) definem apenas comportamento de vinculação e renderização.
+
+### Despacho de URI e semântica do NIP-19
+
+[A gramática do NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) é `nostr:` seguida de uma entidade bech32 do NIP-19. O `nsec` é excluído porque codifica uma chave privada. Não há componente de autoridade, caminho ou consulta, portanto um link conforme é `nostr:npub1...`, e não `nostr://npub1...`. Uma plataforma ou cliente pode registrar-se como manipulador; a especificação não escolhe o aplicativo instalado nem define um fallback web.
+
+O prefixo indica ao cliente o que decodificar. O `npub` carrega uma chave pública e o `note` um id de evento. O `nprofile` adiciona dicas de relay opcionais a um perfil; o `nevent` adiciona relays, autor e kind a um id de evento; e o `naddr` carrega o autor, o kind e o identificador `d` de um evento endereçável, com relays opcionais. Essas formas usam [campos type-length-value do NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md). As dicas restringem a descoberta, mas não provam nem a posse do relay nem o controle do autor. Todo evento obtido ainda precisa de uma recomputação do id e de uma verificação de assinatura.
+
+A forma de perfil na [especificação do NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) é:
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+O [NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) também define pontes HTML: uma página que serve um evento Nostr pode colocar seu `naddr` em `<link rel="alternate">`, e um perfil pode colocar um `nprofile` em `<link rel="me">` ou `<link rel="author">`.
+
+### Renderização do NIP-27 e tags opcionais
+
+O [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) aplica-se a conteúdo de evento legível, como notas do kind `1` e artigos do kind `30023`. Um editor pode exibir `@name`, mas publica `nostr:nprofile1...` na string assinada. Um leitor varre a URI, decodifica sua entidade NIP-19, busca o alvo e pode renderizar um nome, cartão, pré-visualização ou link local. Se a decodificação falhar, a URI permanece como texto comum. O conteúdo bruto não deve ser reescrito: alterá-lo muda a serialização do NIP-01, o id e a assinatura.
+
+Referências de conteúdo e tags têm funções relacionadas, mas distintas. O [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) descreve tags `p` e `e` opcionais e a tag `q` do [NIP-18](/pt/topics/nip-18/). Um cliente pode mostrar uma referência sem criar uma notificação ou relação de thread; a descoberta de citações deve escrever tanto a URI quanto uma tag `q`. A [implementação de 4 de setembro do Zap Cooking](https://github.com/zapcooking/frontend/pull/665) segue essa divisão ao manter a URI enquanto adiciona dicas de relay e uma tag `p` correspondente. Adicionar `p` ou `q` não torna a URI privada, e o NIP-27 não tem modo de menção oculta.
+
+O seguinte [evento do kind `1`](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a) foi recuperado de `wss://nos.lol` e verificado antes da inclusão como uma referência concreta do NIP-27. Seu `content` contém um `naddr` para um evento endereçável independente de versão. A decodificação resulta no kind `30402`, autor `91036d...310a`, o identificador `d` do workbook e uma dica `wss://nos.lol/`. As tags `q`, `p`, `t`, `zap` e `client` são escolhas do aplicativo, não requisitos do NIP-27.```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4sкw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### Confiança, comportamento em falhas e implementações de clientes
+
+Um leitor seguro encontra um token `nostr:` completo, valida bech32, decodifica NIP-19, rejeita `nsec`, ignora tipos TLV desconhecidos e deixa textos malformados ou excessivamente longos de lado. `npub` e `nprofile` levam a consultas de perfil; `note` e `nevent` identificam eventos imutáveis; `naddr` seleciona o evento endereçável válido mais recente para seu tipo, autor e tag `d`. Dicas de relay reduzem a busca, mas não ampliam a confiança. Sob as [regras de eventos do NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md), o cliente verifica o id de um `nevent` buscado e confere a assinatura de cada candidato `naddr` antes de aplicar as regras de substituição de eventos endereçáveis.
+
+Pré-visualizações inline são uma escolha do cliente, com custos de privacidade e recursos. Buscar todas as referências revela os interesses do leitor e pode criar uma avalanche de consultas, então os clientes podem usar cache, adiar buscas até o conteúdo ficar visível, limitar a concorrência e exigir um clique para mídia desconhecida. Sob o [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md), uma pré-visualização deve permanecer distinta do texto assinado do autor atual. A falha deve aparecer como texto não resolvido ou um cartão indisponível, não tratada silenciosamente como conteúdo verificado.
+
+A confiança também muda conforme o tipo de identificador. Um `nevent` nomeia bytes imutáveis, então o cliente pode rejeitar um evento buscado cujo id serializado difere do id solicitado. Um `naddr` nomeia uma coordenada substituível, então o cliente deve verificar cada candidato e aplicar as regras de eventos endereçáveis antes de decidir qual versão exibir. Uma dica de relay é útil para a primeira consulta em ambos os casos, mas não constitui endosso do relay nem do conteúdo retornado. A [definição TLV do NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) fornece os dados necessários para tornar essas verificações explícitas.
+
+O [NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) define um link portátil que pode ser aberto fora do Nostr, enquanto o NIP-27 torna esse mesmo link durável dentro de texto assinado. Um cliente que implementa apenas NIP-21 pode abrir uma URI colada, mas não renderiza referências embutidas. O suporte completo a NIP-27 adiciona varredura, decodificação segura, política de busca, renderização local e uma escolha explícita sobre tags de notificação e citação. A URI compartilhada mantém essas camadas interoperáveis sem forçar os clientes a apresentá-las de forma idêntica. [Damus](https://github.com/damus-io/damus) modela referências inline como menções tipadas. Seu [código de menções](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift) mapeia `npub` e `nprofile` para referências de perfil, `note` e `nevent` para referências de evento e `naddr` para referências de endereço; [NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift) as encaminha ao destino apropriado. [Primal Android](https://github.com/PrimalHQ/primal-android-app) [analisa o esquema e formas coladas](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt), valida bech32 e extrai dicas de relay, depois [mapeia referências em modelos de conteúdo de notas](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt). [Zap Cooking](https://github.com/zapcooking/frontend/pull/665) renderiza as mesmas referências em artigos, receitas, pré-visualizações do editor e visualizações de impressão.
+
+---
+
+Envie uma DM NIP-17 para compartilhar um projeto ou notícia através do [projeto Nostr Compass](https://github.com/andotherstuff/nostr-compass).

--- a/content/pt/topics/nip-a3.md
+++ b/content/pt/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: Alvos de Pagamento"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+O NIP-A3 define uma forma portátil de uma conta Nostr publicar endereços de pagamento para múltiplas redes e serviços. Um evento substituível de kind `10133` carrega uma ou mais tags `payto`.
+
+## Como Funciona
+
+Cada tag tem a forma `["payto", "<tipo>", "<endereço>"]`. O tipo é em letras minúsculas, como `bitcoin`, `lightning` ou `monero`. Os clientes podem validar formatos conhecidos e renderizar uma URI de pagamento nativa quando existir uma; tipos desconhecidos recorrem ao esquema de URI `payto:` da RFC 8905.
+
+O evento declara destinos, não um pagamento concluído nem um zap Nostr. Os clientes ainda decidem quais tipos de pagamento suportam, como validar um endereço e com que clareza exibir o destino antes de entregá-lo a uma carteira.
+
+## Implementações
+
+- O [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) oferece uma entrega de pagamento opcional (opt-in) quando reconhece um alvo compatível.
+- O [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) mapeia tipos de alvo permitidos para URIs de pagamento.
+- O [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) valida alvos Monero e consulta os relays do autor.
+
+---
+
+**Fontes primárias:**
+- [Especificação do NIP-A3](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905: The payto URI Scheme](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**Mencionado em:**
+- [Newsletter #39: Alvos de pagamento do NIP-A3 chegam a três clientes](/pt/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**Veja também:**
+- [NIP-47: Nostr Wallet Connect](/pt/topics/nip-47/)

--- a/content/zh/newsletters/2026-09-09-newsletter.md
+++ b/content/zh/newsletters/2026-09-09-newsletter.md
@@ -1,0 +1,227 @@
+---
+title: "Nostr Compass #39"
+date: 2026-09-09
+publishDate: 2026-09-09
+translationOf: /en/newsletters/2026-09-09-newsletter.md
+translationDate: 2026-09-11
+draft: false
+type: newsletters
+description: "Nostr Compass #39 关注签名式 git 工作流、浏览器发布、自托管直播、社区中继同意机制、私密事件、重点版本发布，以及 NIP-21/NIP-27 链接契约。"
+---
+
+欢迎回到 [Nostr Compass](https://nostrcompass.org)，这里是你的每周 Nostr 指南。
+
+**本周内容：**[ngit 和 GitWorkshop](https://ngit.dev/v3)将签名式 git 工作流迁移到 Nostr 和 [Blossom](/zh/topics/blossom/)，[nsite-clay](https://github.com/jooray/nsite-clay)让浏览器发布可从故障中恢复，[Wingman App](https://github.com/OtherStuffAI/wm-app)则将浏览、设备本地签名、身份验证和文件功能整合起来。[Shosho 和 Livelier](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0)把自托管直播接入 Nostr，[Communitator](https://github.com/dyne/communitator)让用户可以在签名前检查中继模板，[cal.emre.xyz](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)发布可预约时段，[Plektos](https://github.com/derekross/plektos/pull/16)则为私密事件提供加密。带标签的版本发布为 [Vector](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)、[Primal Android](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27)、[LibreNostr](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) 和 [SkateSpots](https://zapstore.dev/apps/org.skatespots.app)加入了恢复与隐私方面的改进。开发工作涵盖 [NIP-27](/zh/topics/nip-27/) 渲染、[Conduit](https://github.com/Conduit-BTC/conduit-mono/pull/397)中的签名中继偏好、[NIP-A3](/zh/topics/nip-a3/) 支付目标以及 Blossom 镜像。[NIPs 仓库](https://github.com/nostr-protocol/nips)中已合并的变更进一步明确了仅限直播的订阅和经过身份验证的应用数据。本期深入解析将说明 [NIP-21](/zh/topics/nip-21/) 链接和 NIP-27 引用如何在不同应用之间传递 Nostr 个人资料与事件。
+
+## 重点动态
+
+### 签名式 git 工作流将 CI、私有仓库和版本发布迁移到 Nostr
+
+[9 月 8 日发布的 v3](https://ngit.dev/v3) 将 ngit、GitWorkshop、ngit-grasp 和 ngit-ci 整合进同一个签名式工作流。[ngit](https://ngit.dev/ngit.git)以 [NIP-34](/zh/topics/nip-34/) 事件的形式承载分支、补丁和拉取请求，[GitWorkshop](https://ngit.dev/gitworkshop.git)则提供评审界面。此次发布新增了 ngit-ci 0.1，这是一项自托管持续集成服务，其指令和结果以签名 Nostr 事件的形式传输，因此检查任务可以在维护者控制的硬件上运行，并与代码评审协同进行。
+
+同一版本还通过 GRASP-08 私有仓库扩展为 [ngit-grasp v3](https://ngit.dev/ngit-grasp.git) 提供私有仓库功能，并明确维护者权限。签名发布记录可以指向 [Blossom](/zh/topics/blossom/) 中的资源，使发布元数据和按内容寻址的文件都能脱离托管式代码锻造平台。[新版文档站点](https://ngit.dev/v3)汇集了客户端、私有仓库、CI 和网页组件的相关文档。
+
+### nsite-clay 让浏览器发布可从故障中恢复
+
+[8 月 31 日的签名器提示修复](https://github.com/jooray/nsite-clay/commit/064a0c5350f1e2b107f7d8f1de00ad75ef2e69d8)、[发布恢复功能](https://github.com/jooray/nsite-clay/commit/d1ad514f8068eec2e007059dc62a5b6f1d240ae0)以及[9 月 2 日加入的编辑控件](https://github.com/jooray/nsite-clay/commit/8f9d7d140dd3cd3e1db8726781fcd852041713f7)，让 [nsite-clay](https://github.com/jooray/nsite-clay) 成为适用于单页站点的浏览器发布工具。用户可以直接编辑文档对象模型，将结果序列化，作为按内容寻址的 [Blossom](/zh/topics/blossom/) 数据块上传，然后重新发布站点的 [NIP-5A](/zh/topics/nip-5a/) 清单。整个过程不需要本地构建或服务器。
+
+这款[浏览器发布工具](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/deploy.html)现在可以从发布失败中恢复，并减少重复出现的签名器提示，[编辑指南](https://npub12edc7326qsryw5rw5yw0yh57fmj9r8jf4c8xazz6333w305qgnms9ypvj2.nsite.lol/guide.html)则记录了这一操作流程。最终生成的仍然是可供现有网关使用的普通 NIP-5A 站点。
+
+### Wingman App 整合浏览、签名和文件功能
+
+9 月的开发工作为 [Wingman App](https://github.com/OtherStuffAI/wm-app) 加入了[文件选择器](https://github.com/OtherStuffAI/wm-app/commit/b0c9c03d317573adeafa92b1a56d696ad399e3ec)、[个人资料发布](https://github.com/OtherStuffAI/wm-app/commit/f2343add8493625d62a1eb7fb76002ceab73f704)、[安全的签名器和会话恢复](https://github.com/OtherStuffAI/wm-app/commit/4e278d96eb9258b89dc8b9639eac7bde3ac475c6)，以及[经过测试的移动端构建](https://github.com/OtherStuffAI/wm-app/commit/60456ec0a8b4ed26ecde53812a61f95dc0bd22ac)。它的 Flutter 外壳会向应用内打开的页面注入 [NIP-07](/zh/topics/nip-07/) 提供程序，而 Flight Deck 和由 Tower 支持的 Drive 则在浏览器旁提供工作界面和文件工作区。
+
+Wingman 使用 [NIP-98](/zh/topics/nip-98/) 为经过身份验证的 HTTP 请求签名。[请求实现](https://github.com/OtherStuffAI/wm-app/blob/67ed27d216e528da5bb431322bd10ac15553796f/crates/wmapp-core/src/auth/nip98.rs)会构建一个由服务器在响应前进行验证的事件，让同一个已安装身份能够通过一致的批准流程处理各种中继操作、网页应用签名和文件。
+
+### Shosho 推出 Livelier 自托管直播流支持
+
+[Shosho 1.1.0](https://github.com/r0d8lsh0p/shosho-releases/releases/tag/v1.1.0) 于 9 月 1 日发布，并支持 [Livelier](https://github.com/r0d8lsh0p/livelier)。Livelier 在 [8 月 31 日的来源标注更新](https://github.com/r0d8lsh0p/livelier/commit/7d8abb875770289502b55c3d947987db08e206dc)中，会在桥接资料里标明桥接服务和 Owncast 来源。Livelier 监视 Owncast 的公开目录，检查视频流是否正在直播，然后发布一个可寻址的 `kind:30311` [NIP-53](/zh/topics/nip-53/) 事件。发现过程通过 Nostr 进行，而视频仍保留在直播者的服务器上。
+
+聊天以 `kind:1311` 事件的形式通过桥接服务传输。该[桥接设计](https://github.com/r0d8lsh0p/livelier)仅在有 Nostr 阅读器订阅时建立来源端连接，为派生身份添加标记，并将临时聊天消息发送到一个会在三小时后将其删除的中继。发现中继仅接受来自桥接密钥的直播事件写入；聊天中继使用 [NIP-42 身份验证](/zh/topics/nip-42/)和 [NIP-70 受保护事件标志](/zh/topics/nip-70/)。
+
+### Communitator 让用户能在签名前检查中继模板
+
+[8 月 31 日的首发系列更新](https://github.com/dyne/communitator/commit/520edd33a253ca3249993172fd1003c80bfd9b7c)为 [Communitator](https://github.com/dyne/communitator) 提供了用于 kind `10002` 中继列表、kind `10063` Blossom 服务器和 kind `10050` 私信收件箱的规范模板。在签名器连接之前，应用会显示规范化的端点、读写权限、事件种类、固定发布中继和目标位置。
+
+[受限的签名与发布流程](https://github.com/dyne/communitator/commit/2bd04c8fab292e73fe9a4ada250c64358aee8501)将连接与应用操作分开。每个事件都单独签名，每次运行最多使用四个 WebSocket 连接，并且只有在收到肯定的 [NIP-01](/zh/topics/nip-01/) `OK` 响应后，目标位置才会被计为发布成功。结果会区分完整交付、部分交付、交付失败和交付取消。共享模板仍是不受信任的建议；[同意界面](https://github.com/dyne/communitator#security-and-consent)说明了中继和网络活动的可观察性。
+
+### cal.emre.xyz 发布 NIP-52 预约可用时间
+
+公开仓库通过 [9 月 2 日的初始提交](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)开放，随后又为 [cal.emre.xyz](https://cal.emre.xyz) 发布了一则经过签名的 [9 月 3 日处理程序公告](https://njump.me/6fead386f0f401c2d8641ef842ccc2ade5abb4e45d61bfd7f3872b43db04cdac)。主持人将可用时间发布为 `kind:31923` [NIP-52](/zh/topics/nip-52/) 事件；访客则发布 `kind:31925` RSVP。
+
+它从中继读取主持人的事件以及已接受且标记为忙碌的 RSVP，排除重叠的时间段，并将 Nostr 事件保留为日程记录，而不会将其复制到单独的数据库中。主持人可以使用 [NIP-07](/zh/topics/nip-07/)、[NIP-46](/zh/topics/nip-46/) 或本地密钥签名；访客可以生成单独的密钥。其[仓库](https://github.com/delirehberi/cal.emre.xyz/commit/611f9516852d0a67a9d0ea558c70308d68f42743)还会提供生成的 `naddr` 和日历链接，并默认禁用电子邮件。
+
+### Plektos 将每个私密活动设为单独的加密频道
+
+[9 月 2 日的私密活动实现](https://github.com/derekross/plektos/pull/12)会将每场 [Plektos](https://github.com/derekross/plektos) 聚会设为 [Concord](/zh/topics/concord-protocol/) 加密社区中的一个私密频道。嘉宾名单、RSVP 名册、报名板、讨论串、贡献内容、封面图片、编辑和删除操作都会一并加密；邀请仅携带该活动的密钥，不会发布任何明文日历事件。
+
+[9 月 6 日的生命周期审计](https://github.com/derekross/plektos/pull/14)固定了事件定义的 id，以便在存在超过 500 个封装事件时直接查找，同时保留分页回退机制。邀请包会在活动结束 30 天后过期，也可以被禁用，但已经获得频道密钥的人仍可保留该密钥。另一项独立的[解析器安全修复](https://github.com/derekross/plektos/pull/16)会让格式错误的类型-长度-值（TLV）[NIP-19](/zh/topics/nip-19/) 标识符直接失败，而不是让解析器陷入异常。
+
+## 带标签的版本发布
+
+### Vector 0.4.4 提高加密社区恢复的安全性
+
+[Vector 0.4.4](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4) 于 8 月 31 日发布，包含社区恢复、密钥轮换、管理和回复路由方面的修复。重新创建社区时，会关闭遭受攻击的社区中被攻击者利用的邀请路径；替代成员资格会覆盖过期的本地状态；单个无法联系的成员也不再导致成员名册冻结。系统会拒绝空轮换，晋升操作会保留在线成员，并且在无法联系到必要成员时拒绝执行相关操作。
+
+该[版本](https://github.com/VectorPrivacy/Vector/releases/tag/v0.4.4)还会持久保存管理员执行的删除和封禁操作，在密码更改后重新加密访客簿，在重启后仍将通知回复绑定到对应会话，并且仅使用经过验证的多人路径。这些是恢复控制措施，并不能撤销已经被他人获取的密钥。
+
+### Primal Android 3.5.27 检查签名器和钱包身份
+
+[Primal Android 3.5.27](https://github.com/PrimalHQ/primal-android-app/releases/tag/3.5.27) 于 9 月 3 日发布，此前[签名器身份检查](https://github.com/PrimalHQ/primal-android-app/pull/1108)和[钱包请求身份验证](https://github.com/PrimalHQ/primal-android-app/pull/1105)已于 8 月 31 日合并。如果请求中的身份与当前持有的账户不匹配，本地签名会拒绝该请求；传入的 [NIP-47](/zh/topics/nip-47/) 请求也会在处理前进行身份验证。当 Zap 投票出现在回复中时，其路由现在还会将投票发送给投票发起者。
+
+### GRAIN 0.8.0-rc2 修复了已确认但未存储的路径
+
+[GRAIN 0.8.0-rc2](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2) 于 9 月 7 日发布。此前，由于其异步 LMDB 数据库写入器未能及时发现存储空间已满，中继可能在存储失败前返回 `OK`。中继现在会在存储使用率达到 80% 和 95% 时发出警告，在达到 97% 时拒绝新事件并为删除操作保留空间，同时报告事件接受后发生的写入失败。保留机制按从旧到新的顺序遍历数据，关闭过程可以处理迟到的消息，无效过滤器也不再导致同组中的有效过滤器被丢弃。
+
+该[版本](https://github.com/0ceanSlim/grain/releases/tag/v0.8.0-rc2)还会核验 kind `10166` 监控公告和 kind `30166` 中继报告，清除过期报告，保留已配置中继作为后备，并通过 [NIP-11](/zh/topics/nip-11/) 报告实时限制和身份验证信息，而不是静态的零值。
+
+### LibreNostr 0.5.0–0.5.2 让 Tor 路由在故障时默认关闭
+
+[LibreNostr 0.5.0](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0) 于 9 月 7 日发布，新增 Orbot 模式，通过同一个 SOCKS 端口路由中继连接、zap、上传、媒体、播放和预览，并修复了 zap 面板崩溃问题。如果 Orbot 或代理不可用，连接会停止，而不会泄漏到直接路由。[版本 0.5.1](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.1) 防止缓慢的 [NIP-50](/zh/topics/nip-50/) 搜索延迟本地结果；[0.5.2](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.2) 替换了递归式线程布局，并修复了线程排序。
+
+这种[故障时默认关闭的行为](https://github.com/Lwb89dev/librenostr/releases/tag/v0.5.0)适用于该版本列出的所有网络访问面。由于这些客户端长期存活，因此需要重新启动。后续补丁版本保留了这一选择，同时限制了无关的搜索、堆栈深度和布局故障。
+
+### SkateSpots 新增设备端中继路径
+
+经过签名的 [9 月 8 日 Zapstore 版本](https://zapstore.dev/apps/org.skatespots.app)为 SkateSpots 新增了可选的 Citrine 中继。地点、团队、消息和地图数据可以在本地加载；帖子可在离线时排队；手机也会保留本地副本。现有的私藏和消息内容仍采用端到端加密。付款检查要求提供发票金额以及服务提供方签发的 zap 收据，之后才会授予访问权限或计入贡献。
+
+这个[本地中继](https://zapstore.dev/apps/org.skatespots.app)是用于存储和保持连续性的选项，并非所有远程中继的替代品。它让滑手可以在断网期间继续使用，并在恢复连接后同步已签名的活动；与此同时，付款机制的改动可防止自行生成的收据被用作结算证明。
+
+### Whistle 1.8.15 修复加密群组的生命周期恢复问题
+
+[Whistle 1.8.15](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15) 于 9 月 3 日发布。此前完成的一项 Android 生命周期修复，防止了路由级状态持有者销毁应用级中继订阅和位置更新。其发布说明还提到，设备锁定或进入休眠后连接状态能够刷新，并且在观测案例中恢复了积压的 501 个事件。
+
+这个[缺陷](https://github.com/sjmcnamara/whistle/releases/tag/v1.8.15)将长期运行服务的所有权绑定到了短期存活的界面。让 activity 作用域的实例保持存活，并在单次读取前检查套接字，可降低普通 Android 导航和后台挂起被误判为群组为空的可能性。
+
+### TWENTY ONE Companion 1.12.0 将加密 DM 与旧版聊天分开
+
+[TWENTY ONE Companion 1.12.0](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0) 于 9 月 5 日发布，新增采用 [NIP-17](/zh/topics/nip-17/) 礼物包装的 DM。加密收件箱与较早的空间聊天相互独立；后者仍然单独保留，因为这些消息从未加密，也无法迁移。在中继策略允许的情况下，系统支持 PDF 和视频；个人隐藏设置可以同步，但不会变成版主封禁。
+
+这种[明确可见的分隔](https://github.com/HolgerHatGarKeineNode/twenty-one-companion/releases/tag/v1.12.0)是安全模型的一部分。将旧历史记录称为安全收件箱会歪曲其来源，而静默迁移则会让人误以为这些消息在写入时采用了实际上并不存在的加密。
+
+### ZapStore 1.1.2 验证事件 id 和证书轮换
+
+[ZapStore 1.1.2](https://github.com/zapstore/zapstore/releases/tag/1.1.2) 于 9 月 4 日发布，新增 NIP-01 事件 id 验证：客户端会重新计算传入事件的 id，并在使用前拒绝不匹配的事件。该版本还会识别从 ZapStore 之外安装的软件包。在服务器端，[证书哈希保留](https://github.com/zapstore/relay/pull/8)机制会保留重复的 `apk_certificate_hash` 标签，使 Android 签名密钥轮换能够延续已获批准的密钥谱系。
+
+这项[事件 id 检查](https://github.com/zapstore/zapstore/releases/tag/1.1.2)可防止中继或缓存修改标签或内容后仍沿用旧 id。当具有相同应用 id 的 Android 软件包来自其他渠道时，安装来源指示器会提供独立的来源信息。
+
+### Amber 6.6.1 保持签名器响应的可归属性
+
+[Amber 6.6.1](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1) 于 9 月 4 日发布。权限解析现已修复，可以容忍缺少可选的 `kind`；被拒绝的签名请求也开始返回其原始请求 id。调用应用可以将拒绝响应与已提交的操作对应起来。该版本还更新了远程签名器默认设置，并新增了一个索引器中继。
+
+这些[修复](https://github.com/greenart7c3/Amber/releases/tag/v6.6.1)共同保持了双向可归属性：缺少可选字段时，权限记录仍然可用；拒绝响应也仍与触发它的请求相关联。中继默认设置的改动会影响发现过程，但不会取代签名器的本地授权决定。
+
+## 开发中
+
+### Zap Cooking 使用中继提示渲染 NIP-27 引用
+
+[9月4日合并的变更](https://github.com/zapcooking/frontend/pull/665)使 [Zap Cooking](https://github.com/zapcooking/frontend) 能够在文章、食谱、编辑器预览和打印视图中渲染 `nostr:npub` 与 `nostr:nprofile` 引用。无效标识符会保留为文本，解析过程不会阻塞，编辑器还会预览即将签名的 Markdown。当存在中继信息时，单独的 `npub` 会转换为包含发件箱中继的 `nprofile`，并附带匹配的 `p` 标签。
+
+同一周还修复了[限定作者的 kind `30023` 读取](https://github.com/zapcooking/frontend/commit/6a379c680727bb49074a4ff85f070b404dba97a7)，加入了带有去重和过期查询防护的[已验证 NIP-50 搜索中继](https://github.com/zapcooking/frontend/commit/1802e8d7e95ed482209d09e03c834c2d9adfc1ea)，并在依赖项变更导致余额和历史记录功能失效后修复了 [NIP-47 钱包调用](https://github.com/zapcooking/frontend/pull/705)。
+
+### Conduit 协调已签名的中继与 Blossom 偏好设置
+
+[Conduit](https://github.com/Conduit-BTC/conduit-mono) 于9月2日合并了 [Blossom 偏好设置编辑功能](https://github.com/Conduit-BTC/conduit-mono/pull/374)，并于9月7日合并了[已签名偏好设置协调功能](https://github.com/Conduit-BTC/conduit-mono/pull/397)。Market 和 Merchant 会保留最新的有效 kind `10002` 中继列表及 kind `10050` 收件箱声明；当较新的事件格式错误时，它们会保留仍然可用的已签名列表；它们能够区分明确的空列表与无法获取的查询结果；对于失效的已声明中继，也不会用代码中的默认值替代。
+
+[kind `10063` 编辑器](https://github.com/Conduit-BTC/conduit-mono/pull/374)允许用户加载、重新排序、检查、外部签名、发布并回读一个有序的 HTTPS 媒体服务器列表，同时不会联系这些服务器，也不会插入未声明的默认服务器。
+
+### NIP-A3 支付目标进入三个客户端
+
+9月1日至3日，[Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041)、[Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) 和 [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) 实现了 NIP-A3 kind `10133` 支付目标。Amethyst 仅在存在兼容目标时提供由用户主动选择的转交操作，并且不会将其变成 zap；Grimoire 在构建钱包 URI 之前使用固定注册表；Pollerama 会验证 Monero 地址，并在查询目标之前获取作者的中继列表。每个客户端仍然需要一种获准使用的支付方式、一条中继路由以及准确的展示信息。
+
+### Ditto 扩展 Blossom 回退机制与直播嵌入
+
+[Ditto](https://github.com/soapbox-pub/ditto) 于9月6日合并了[范围更广的 Blossom 回退与镜像功能](https://github.com/soapbox-pub/ditto/commit/1e35a0705c28f706eb40d1f99aedef3105cf6f07)。头像、徽章、横幅、社区图片、自定义表情符号和应用图标现在会尝试从已声明的服务器获取具有相同 blob 哈希的文件；镜像上传使用标准 BUD-11 授权令牌。[9月4日的一项变更](https://github.com/soapbox-pub/ditto/commit/e2a29004a65122470179c83d6ded8336a5c10dfa)加入了紧凑的 `kind:30311` 直播嵌入。
+
+## 协议与规范工作
+
+### Nostr 实现可能性
+
+[NIP-01](/zh/topics/nip-01/) 现在明确说明了 [`limit: 0` 过滤器](https://github.com/nostr-protocol/nips/pull/2460)的行为，该变更于9月4日合并。中继必须不返回任何已存储事件，必须在初始查询完成时发送 `EOSE`，并且必须让订阅保持活动状态，以接收新的匹配事件。客户端可以使用只含一个字段的过滤器开启仅实时订阅，同时保留本地历史记录。这项澄清记录了多个中继实现和公共中继之间相互兼容的行为。
+
+[NIP-78](/zh/topics/nip-78/) 增加了一项[经过身份验证的应用数据要求](https://github.com/nostr-protocol/nips/pull/2458)，该变更于9月3日合并。对于 kind `78` 和 `30078`，中继应当要求进行 [NIP-42](/zh/topics/nip-42/) 身份验证，并且应当只向已通过身份验证的事件作者提供这些事件。这只是“应当”级要求，并非保密保证，客户端不能将任意中继视为私有存储。此次合并还不鼓励把自定义应用数据 kind 用作通用公共交换格式。
+
+[NIP-AC](/zh/topics/nip-ac/) 于9月4日作为一项明确保持开放状态的 [WebRTC 信令提案](https://github.com/nostr-protocol/nips/pull/2461)提出。它使用临时分配的易失性 kind 来处理 ping、连接请求、offer、answer 和 ICE candidate，以 `p` 标签指定接收方，并通过会话 `e` 标签分组；kind `30600` 用于发现。在对等方建立直接连接期间，中继应当广播这些信令事件，并且不得存储它们。这些编号仍为临时编号，客户端应当使用 [NIP-65 中继列表](/zh/topics/nip-65/)，需要保密性的应用应当通过 [NIP-44](/zh/topics/nip-44/) 加密 offer、answer 和 candidate 内容。
+
+## NIP 深入解析：事件文本中的 URI 链接与引用
+
+Nostr 标识符需要具备可传输的含义，其他应用才能打开它。[NIP-21](/zh/topics/nip-21/) 将 [NIP-19](/zh/topics/nip-19/) 标识符置于 `nostr:` URI 方案之后，为浏览器、操作系统和应用提供一种可统一分派的形式。[NIP-27](/zh/topics/nip-27/) 定义了同一个 URI 在可读事件 `content` 中的含义。NIP-21 用于跨越应用边界，NIP-27 则用于在已签名文本中保留对个人资料或事件的引用。两者都不会创建事件 kind，也不会更改中继消息；这[两项规范](https://github.com/nostr-protocol/nips/tree/master)仅定义链接和渲染行为。
+
+### URI 分派与 NIP-19 语义
+
+[NIP-21 的语法](https://github.com/nostr-protocol/nips/blob/master/21.md)是 `nostr:` 后跟一个 NIP-19 bech32 实体。`nsec` 被排除在外，因为它编码的是私钥。其中没有授权信息、路径或查询组件，因此符合规范的链接是 `nostr:npub1...`，而不是 `nostr://npub1...`。平台或客户端可以注册为处理程序；该规范既不选择已安装的应用程序，也不定义网页回退方式。
+
+前缀会告诉客户端应解码什么内容。`npub` 携带公钥，`note` 携带事件 id。`nprofile` 为个人资料添加可选的中继提示；`nevent` 为事件 id 添加中继、作者和 kind；`naddr` 则携带可寻址事件的作者、kind 和 `d` 标识符，并可选择包含中继。这些形式使用 [NIP-19 类型-长度-值字段](https://github.com/nostr-protocol/nips/blob/master/19.md)。提示可以缩小发现范围，但既不能证明中继拥有该事件，也不能证明作者具有控制权。每个获取到的事件仍需重新计算 id 并检查签名。
+
+[NIP-21 规范](https://github.com/nostr-protocol/nips/blob/master/21.md)中的个人资料形式如下：
+
+```
+nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9
+```
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) 还定义了 HTML 桥接方式：提供 Nostr 事件的页面可以将其 `naddr` 放入 `<link rel="alternate">`，个人资料则可以将 `nprofile` 放入 `<link rel="me">` 或 `<link rel="author">`。
+
+### NIP-27 渲染与可选标签
+
+[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) 适用于可读的事件内容，例如 kind `1` 短帖和 kind `30023` 文章。编辑器可以显示 `@name`，但会在签名字符串中发布 `nostr:nprofile1...`。阅读器会扫描该 URI，解码其中的 NIP-19 实体，获取目标，并可以渲染名称、卡片、预览或本地链接。如果解码失败，该 URI 将保留为普通文本。不得重写原始内容，因为修改它会改变 NIP-01 序列化结果、id 和签名。
+
+内容引用与标签的作用相关，但并不相同。[NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) 描述了可选的 `p` 和 `e` 标签，以及 [NIP-18](/zh/topics/nip-18/) 的 `q` 标签。客户端可以显示引用，而不创建通知或帖子串关系；为了便于发现引用，应同时写入 URI 和 `q` 标签。[Zap Cooking 在 9 月 4 日的实现](https://github.com/zapcooking/frontend/pull/665)遵循了这种区分，在保留 URI 的同时添加中继提示和对应的 `p` 标签。添加 `p` 或 `q` 不会使 URI 变为私密内容，并且 NIP-27 没有隐藏提及模式。
+
+以下 [kind `1` 事件](https://njump.me/note1e0my422kylehy2g4ax4d98vsthdvnvy702yq3f6eguedjr0256as200k6a)是从 `wss://nos.lol` 恢复的，并在作为具体的 NIP-27 引用收入本文前经过了验证。其 `content` 包含一个指向与版本无关的可寻址事件的 `naddr`。解码后可得到 kind `30402`、作者 `91036d...310a`、该工作簿的 `d` 标识符，以及一个 `wss://nos.lol/` 提示。`q`、`p`、`t`、`zap` 和 `client` 标签是应用程序的选择，并非 NIP-27 的要求。
+
+```json
+{
+  "id": "cbf64aa95627f3722915e9aad29d905ddac9b09e7a8808a7594732d90deaa6bb",
+  "pubkey": "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+  "created_at": 1788953511,
+  "kind": 1,
+  "tags": [
+    [
+      "p",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/"
+    ],
+    [
+      "t",
+      "archetype"
+    ],
+    [
+      "q",
+      "30402:91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a:Archetype-Workbook-Companion-Meet-your-King-Warrioir-Magician-Lover-today-oejbwe",
+      "wss://nos.lol/"
+    ],
+    [
+      "zap",
+      "91036dec18ee563c07edaed5eff4b5d631755c76f006734b3787292a5e3c310a",
+      "wss://multiplexer.huszonegy.world/",
+      "0.9"
+    ],
+    [
+      "zap",
+      "ed1b999da9a434039d22338c276ffd6e338d609b81e6b1c305a120a982df787d",
+      "wss://relay.nostr.band/",
+      "0.1"
+    ],
+    [
+      "client",
+      "Amethyst"
+    ]
+  ],
+  "content": "You can check, read and use this Workbook already! You can also support and get it for few sats and support us in this project.\n\nI hope it'll help you in your Archetype Journey :)\n\n#archetype\n\nnostr:naddr1qpgyzunrdpjhg7tsv5k4wmmjdd3x7mmt94pk7mtsv9hxjmmw94xk2et594uk7atj949kjmn894tkzunjd9hkju3df4skw6trd9skut2vdamx2u3dw3hkgcte94hk26nzwajszrnhwden5te0dehhxtnvdakz7q3qjypkmmqcaetrcpld4m27la946cch2hrk7qr8xjehsu5j5h3uxy9qxpqqqpmvyqnrm7n",
+  "sig": "aa9592e7c773271b9e9f980c8a7e17fda2ffd5a4483a1789e5dd4c4a83018ac576c5202b21b33b08770dcabe023f93998a41f1a0be4bf00e36cdde611d07915e"
+}
+```
+
+### 信任、失败行为与客户端实现
+
+安全的读取器会识别完整的 `nostr:` 字符串，验证 bech32，解码 NIP-19，拒绝 `nsec`，忽略未知的 TLV 类型，并保持格式错误或过长的文本不变。`npub` 和 `nprofile` 用于查询个人资料；`note` 和 `nevent` 标识不可变事件；`naddr` 根据事件类型、作者和 `d` 标签选择最新的有效可寻址事件。中继提示可以缩小搜索范围，但不会扩展信任范围。根据 [NIP-01 事件规则](https://github.com/nostr-protocol/nips/blob/master/01.md)，客户端会验证所获取 `nevent` 的 id，并在应用可寻址事件替换规则前检查每个 `naddr` 候选事件的签名。
+
+是否显示内联预览由客户端决定，同时需要考虑隐私和资源成本。获取每个引用会暴露读者的兴趣，并可能造成大量查询，因此客户端可以使用缓存、推迟到引用可见时再获取、限制并发量，并要求用户点击后才加载不熟悉的媒体。根据 [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)，预览必须与当前作者签名的文本明确区分。解析失败时，应将引用显示为未解析文本或不可用卡片，而不能静默地将其视为已验证内容。
+
+信任方式也会因标识符类型而异。`nevent` 指向不可变的字节，因此，如果所获取事件的序列化 id 与请求的 id 不同，客户端可以拒绝该事件。`naddr` 指向一个可替换坐标，因此客户端必须验证每个候选事件，并在决定显示哪个版本之前应用可寻址事件规则。无论是哪种情况，中继提示都有助于首次查询，但它并不代表对该中继或其返回内容的认可。[NIP-19 的 TLV 定义](https://github.com/nostr-protocol/nips/blob/master/19.md)提供了明确执行这些检查所需的数据。
+
+[NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md)定义了一种可从 Nostr 外部打开的便携式链接，而 NIP-27 则让同一链接能够持久存在于签名文本中。仅实现 NIP-21 的客户端可以打开粘贴的 URI，但无法渲染嵌入式引用。完整支持 NIP-27 还需要扫描、安全解码、获取策略、本地渲染，以及明确决定如何处理通知标签和引用标签。共享 URI 使这些层能够互操作，而不强制客户端以相同方式呈现它们。[Damus](https://github.com/damus-io/damus)将内联引用建模为带类型的提及。其[提及代码](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/Mentions.swift)将 `npub` 和 `nprofile` 映射为个人资料引用，将 `note` 和 `nevent` 映射为事件引用，并将 `naddr` 映射为地址引用；[NostrLink](https://github.com/damus-io/damus/blob/2ef636aa07f6bd4f24b72fa998b7397dced56d2a/damus/Core/Nostr/NostrLink.swift)会将它们路由到相应的目标。[Primal Android](https://github.com/PrimalHQ/primal-android-app)会[解析协议方案和粘贴形式](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt)，验证 bech32 并提取中继提示，然后[将引用映射到笔记内容模型](https://github.com/PrimalHQ/primal-android-app/blob/36939db97213e7f8eeefaa4adaf125d839fc662e/app/src/main/kotlin/net/primal/android/notes/feed/model/NoteNostrUriUi.kt)。[Zap Cooking](https://github.com/zapcooking/frontend/pull/665)会在文章、食谱、编辑器预览和打印视图中渲染相同的引用。
+
+---
+
+通过 [Nostr Compass 项目](https://github.com/andotherstuff/nostr-compass)发送 NIP-17 私信，分享项目或新闻。

--- a/content/zh/topics/nip-a3.md
+++ b/content/zh/topics/nip-a3.md
@@ -1,0 +1,36 @@
+---
+title: "NIP-A3: 支付目标"
+date: 2026-09-09
+translationOf: /en/topics/nip-a3.md
+translationDate: 2026-09-11
+draft: false
+categories:
+  - Protocol
+  - Payments
+---
+
+NIP-A3 定义了一种可移植的方式，让 Nostr 账户能够发布适用于多个网络和服务的支付地址。一个可替换的 kind `10133` 事件包含一个或多个 `payto` 标签。
+
+## 工作原理
+
+每个标签的格式为 `["payto", "<type>", "<address>"]`。类型使用小写形式，例如 `bitcoin`、`lightning` 或 `monero`。客户端可以验证已知格式，并在存在原生支付 URI 时进行呈现；对于不熟悉的类型，则回退到 RFC 8905 中定义的 `payto:` URI 方案。
+
+该事件声明的是支付目的地，而不是一笔已完成的付款或 Nostr zap。客户端仍需决定支持哪些支付类型、如何验证地址，以及在将目的地交给钱包之前以多清晰的方式向用户展示。
+
+## 实现
+
+- [Amethyst](https://github.com/vitorpamplona/amethyst/pull/4041) 在识别到兼容的目标时，提供可选择启用的支付转交功能。
+- [Grimoire](https://github.com/purrgrammer/grimoire/commit/54052506f7a0da06dfc4cf7e969331ee61be7851) 将允许的目标类型映射到支付 URI。
+- [Pollerama](https://github.com/formstr-hq/nostr-polls/commit/5a015f1d17abecd036f3e10c88d493d23928fa98) 验证 Monero 目标并查询作者的中继。
+
+---
+
+**主要来源：**
+- [NIP-A3 规范](https://github.com/nostr-protocol/nips/blob/master/A3.md)
+- [RFC 8905：payto URI 方案](https://www.rfc-editor.org/rfc/rfc8905.html)
+
+**提及于：**
+- [第 39 期新闻简报：NIP-A3 支付目标已获三个客户端支持](/zh/newsletters/2026-09-09-newsletter/#nip-a3-payment-targets-reach-three-clients)
+
+**另请参阅：**
+- [NIP-47：Nostr Wallet Connect](/zh/topics/nip-47/)


### PR DESCRIPTION
Translations for Newsletter #39 (2026-09-09).

Languages: es, pt, de, fr, it, ja, ko, nl, zh

Generated and verified by `scripts/translate.sh`: every language passes the encoding, link-leak, and native-script checks, and all referenced topic pages are present.